### PR TITLE
Create cancelable pullpayment contract

### DIFF
--- a/contracts/payment/CancellablePullPayment.sol
+++ b/contracts/payment/CancellablePullPayment.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.4.11;
+
+
+import "./PullPayment.sol";
+
+
+/*
+ * @title CancellablePullPayment
+ * 
+ * @dev Inherits from PullPayment and allows the payment sender to cancel
+ * @dev a payment before it's withdrawn by the reciever.
+ * @dev Inherit from this contract and use asyncSend instead of send.
+ */
+
+contract CancellablePullPayment is PullPayment {
+
+  mapping(address => mapping(address => uint )) public paymentsByPayer;
+
+  /**
+  * @dev Adds to asyncSender from PullPayment adding tracking of both the payer, payee, and amount.
+  * @param dest The destination address of the funds.
+  * @param amount The amount to transfer.
+  */
+
+  function asyncSend(address dest, uint amount) internal {
+    paymentsByPayer[msg.sender][dest] = amount;
+    super.asyncSend(dest, amount);
+  }
+
+  /**
+  * @dev Called by the payer to withdraw all payments made to given payee
+  * @param payee The address the payer is removing pending payments from.
+  */
+
+  function cancelPayments(address payee) internal {
+    address payer = msg.sender;
+    uint refund = paymentsByPayer[payer][payee];
+
+    if (refund == 0) {
+      throw;
+    }
+
+    if (this.balance < refund) {
+      throw;
+    }
+
+    totalPayments = totalPayments.sub(refund);
+    payments[payee] = payments[payee].sub(refund);
+    paymentsByPayer[payer][payee] = 0;
+
+    if (!payer.send(refund)) {
+      throw;
+    }
+  }
+}

--- a/test/CancellablePullPayment.js
+++ b/test/CancellablePullPayment.js
@@ -1,0 +1,63 @@
+var CancellablePullPaymentMock = artifacts.require("./helpers/CancellablePullPaymentMock.sol");
+
+contract('CancellablePullPayment', function(accounts) {
+
+  it("can cancel a payment before the payee has withdrawn it", async function() {
+    let AMOUNT = 17*1e18;
+    let payee = accounts[1];
+
+    let cancellablePullPayment = await CancellablePullPaymentMock.new({value: AMOUNT});
+    let call1 = await cancellablePullPayment.callSend(payee, AMOUNT);
+
+    let payment1 = await cancellablePullPayment.payments(payee);
+    assert.equal(payment1, AMOUNT);
+
+    let totalPayments = await cancellablePullPayment.totalPayments();
+    assert.equal(totalPayments, AMOUNT);
+
+    let cancel = await cancellablePullPayment.callCancelPayments(payee);
+    let payment2 = await cancellablePullPayment.payments(payee);
+    assert.equal(payment2, 0);
+
+
+    totalPayments = await cancellablePullPayment.totalPayments();
+    assert.equal(totalPayments, 0);
+  });
+
+  it("should only cancels pending payments made by the caller of cancelPayments", async function() {
+    let AMOUNT = 17*1e18;
+    let payee = accounts[1];
+    let initialBalance = web3.eth.getBalance(accounts[0]);
+
+    let cancellablePullPayment = await CancellablePullPaymentMock.new({value: AMOUNT});
+    let call1 = await cancellablePullPayment.callSend(payee, AMOUNT);
+    let call2 = await cancellablePullPayment.callSend(payee, AMOUNT, {from: accounts[9]});
+
+    let payment1 = await cancellablePullPayment.payments(payee);
+    let expectedAmount = AMOUNT * 2;
+    assert.equal(payment1, expectedAmount);
+
+    let paymentsByPayer = await cancellablePullPayment.paymentsByPayer(accounts[0], payee);
+    assert.equal(paymentsByPayer, AMOUNT);
+
+    let totalPayments = await cancellablePullPayment.totalPayments();
+    assert.equal(totalPayments, expectedAmount);
+
+    let balanceAfterPayment = web3.eth.getBalance(accounts[0]);
+
+    let cancel = await cancellablePullPayment.callCancelPayments(payee);
+    let payment2 = await cancellablePullPayment.payments(payee);
+    assert.equal(payment2, AMOUNT);
+
+    let paymentsByPayer2 = await cancellablePullPayment.paymentsByPayer(accounts[0], payee);
+    assert.equal(paymentsByPayer2, 0);
+
+    totalPayments = await cancellablePullPayment.totalPayments();
+    assert.equal(totalPayments, AMOUNT);
+
+
+    let balanceAfterCancel = web3.eth.getBalance(accounts[0]);
+    assert(initialBalance > balanceAfterCancel);
+    assert(balanceAfterCancel > balanceAfterPayment);
+  });
+})

--- a/test/helpers/CancellablePullPaymentMock.sol
+++ b/test/helpers/CancellablePullPaymentMock.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.11;
+
+
+import '../../contracts/payment/CancellablePullPayment.sol';
+
+
+// mock class using CancellablePullPayment
+contract CancellablePullPaymentMock is CancellablePullPayment {
+
+  function CancellablePullPaymentMock() payable { }
+
+  // test helper function to call asyncSend
+  function callSend(address dest, uint amount) {
+    asyncSend(dest, amount);
+  }
+
+  // test helper function to call cancelPayments
+  function callCancelPayments(address payee) {
+    cancelPayments(payee);
+  }
+}


### PR DESCRIPTION
This contract fixes #196 
The basic idea is to create a cancellable pullpayment contract that allows a ```payer``` to call ```cancelPayments(payee)``` and have the amount the sent to the ```payee``` refunded to them.
Creates, tests and documents the ```CancellablePullPayment``` contract.
@maraoz