### PR TITLE
Adding canBuyTokens / willBuyTokens / didBuyTokens methods

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -68,7 +68,7 @@ contract Crowdsale {
   // low level token purchase function
   function buyTokens(address beneficiary) payable {
     require(beneficiary != 0x0);
-    require(shouldBuyTokens(beneficiary));
+    require(canBuyTokens(beneficiary));
     willBuyTokens(beneficiary);
 
     uint256 weiAmount = msg.value;
@@ -87,7 +87,7 @@ contract Crowdsale {
   }
 
   // pre-flight method - authorizing buying tokens
-  function shouldBuyTokens(address beneficiary) internal returns (bool) {
+  function canBuyTokens(address beneficiary) internal returns (bool) {
     return validPurchase();
   }
 

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -68,7 +68,8 @@ contract Crowdsale {
   // low level token purchase function
   function buyTokens(address beneficiary) payable {
     require(beneficiary != 0x0);
-    require(willBuyTokens(beneficiary));
+    require(shouldBuyTokens(beneficiary));
+    willBuyTokens(beneficiary);
 
     uint256 weiAmount = msg.value;
 
@@ -86,11 +87,15 @@ contract Crowdsale {
   }
 
   // pre-flight method - authorizing buying tokens
-  function willBuyTokens(address beneficiary) internal returns (bool) {
+  function shouldBuyTokens(address beneficiary) internal returns (bool) {
     return validPurchase();
   }
 
-  // post-flight method - notifying buying tokens
+  // pre-flight method - notifying that tokens will be bought
+  function willBuyTokens(address beneficiary) internal {
+  }
+
+  // post-flight method - notifying that tokens were bought
   function didBuyTokens(address beneficiary, uint256 weiAmount, uint256 amount) internal {
     TokenPurchase(msg.sender, beneficiary, weiAmount, amount);
   }

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -68,7 +68,7 @@ contract Crowdsale {
   // low level token purchase function
   function buyTokens(address beneficiary) payable {
     require(beneficiary != 0x0);
-    require(validPurchase());
+    require(willBuyTokens(beneficiary));
 
     uint256 weiAmount = msg.value;
 
@@ -79,9 +79,20 @@ contract Crowdsale {
     weiRaised = weiRaised.add(weiAmount);
 
     token.mint(beneficiary, tokens);
-    TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
 
     forwardFunds();
+
+    didBuyTokens(beneficiary, weiAmount, tokens);
+  }
+
+  // pre-flight method - authorizing buying tokens
+  function willBuyTokens(address beneficiary) internal returns (bool) {
+    return validPurchase();
+  }
+
+  // post-flight method - notifying buying tokens
+  function didBuyTokens(address beneficiary, uint256 weiAmount, uint256 amount) internal {
+    TokenPurchase(msg.sender, beneficiary, weiAmount, amount);
   }
 
   // send ether to the fund collection wallet


### PR DESCRIPTION
Hello there!

This is a backward compatible proposal for the Crowdsale#buyTokens method.
That way, subclasses of Crowdsale could just override willBuyTokens or didBuyTokens if they need some customisation, and avoid rewriting buyTokens.
Best,

Ludo