### PR TITLE
Implement partial refunds in CappedCrowdsale.

### DIFF
--- a/contracts/crowdsale/CappedCrowdsale.sol
+++ b/contracts/crowdsale/CappedCrowdsale.sol
@@ -27,8 +27,12 @@ contract CappedCrowdsale is Crowdsale {
   // overriding Crowdsale#hasEnded to add cap logic
   // @return true if crowdsale event has ended
   function hasEnded() public constant returns (bool) {
-    bool capReached = weiRaised >= cap;
-    return super.hasEnded() || capReached;
+    return super.hasEnded() || capReached();
+  }
+
+  // @return true if cap has been reached
+  function capReached() internal constant returns (bool) {
+    return weiRaised >= cap;
   }
 
 }

--- a/contracts/crowdsale/CappedCrowdsale.sol
+++ b/contracts/crowdsale/CappedCrowdsale.sol
@@ -34,4 +34,17 @@ contract CappedCrowdsale is Crowdsale {
     return weiRaised >= cap;
   }
 
+  // overriding Crowdsale#buyTokens to add partial refund logic
+  function buyTokens(address beneficiary) public payable {
+    uint256 weiToCap = cap.sub(weiRaised);
+    uint256 weiAmount = weiToCap < msg.value ? weiToCap : msg.value;
+
+    buyTokens(beneficiary, weiAmount);
+
+    uint256 refund = msg.value.sub(weiAmount);
+    if (refund > 0) {
+      msg.sender.transfer(refund);
+    }
+  }
+
 }

--- a/contracts/crowdsale/CappedCrowdsale.sol
+++ b/contracts/crowdsale/CappedCrowdsale.sol
@@ -19,8 +19,8 @@ contract CappedCrowdsale is Crowdsale {
 
   // overriding Crowdsale#validPurchase to add extra cap logic
   // @return true if investors can buy at the moment
-  function validPurchase() internal constant returns (bool) {
-    return super.validPurchase() && !capReached();
+  function validPurchase(uint256 weiAmount) internal constant returns (bool) {
+    return super.validPurchase(weiAmount) && !capReached();
   }
 
   // overriding Crowdsale#hasEnded to add cap logic

--- a/contracts/crowdsale/CappedCrowdsale.sol
+++ b/contracts/crowdsale/CappedCrowdsale.sol
@@ -20,8 +20,7 @@ contract CappedCrowdsale is Crowdsale {
   // overriding Crowdsale#validPurchase to add extra cap logic
   // @return true if investors can buy at the moment
   function validPurchase() internal constant returns (bool) {
-    bool withinCap = weiRaised.add(msg.value) <= cap;
-    return super.validPurchase() && withinCap;
+    return super.validPurchase() && !capReached();
   }
 
   // overriding Crowdsale#hasEnded to add cap logic

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -67,10 +67,13 @@ contract Crowdsale {
 
   // low level token purchase function
   function buyTokens(address beneficiary) public payable {
-    require(beneficiary != 0x0);
-    require(validPurchase());
+    buyTokens(beneficiary, msg.value);
+  }
 
-    uint256 weiAmount = msg.value;
+  // implementation of low level token purchase function
+  function buyTokens(address beneficiary, uint256 weiAmount) internal {
+    require(beneficiary != 0x0);
+    require(validPurchase(weiAmount));
 
     // calculate token amount to be created
     uint256 tokens = weiAmount.mul(rate);
@@ -91,9 +94,9 @@ contract Crowdsale {
   }
 
   // @return true if the transaction can buy tokens
-  function validPurchase() internal constant returns (bool) {
+  function validPurchase(uint256 weiAmount) internal constant returns (bool) {
     bool withinPeriod = now >= startTime && now <= endTime;
-    bool nonZeroPurchase = msg.value != 0;
+    bool nonZeroPurchase = weiAmount != 0;
     return withinPeriod && nonZeroPurchase;
   }
 

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -84,13 +84,13 @@ contract Crowdsale {
     token.mint(beneficiary, tokens);
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
 
-    forwardFunds();
+    forwardFunds(weiAmount);
   }
 
   // send ether to the fund collection wallet
   // override to create custom fund forwarding mechanisms
-  function forwardFunds() internal {
-    wallet.transfer(msg.value);
+  function forwardFunds(uint256 weiAmount) internal {
+    wallet.transfer(weiAmount);
   }
 
   // @return true if the transaction can buy tokens

--- a/contracts/crowdsale/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/RefundableCrowdsale.sol
@@ -30,8 +30,8 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
   // We're overriding the fund forwarding from Crowdsale.
   // In addition to sending the funds, we want to call
   // the RefundVault deposit function
-  function forwardFunds() internal {
-    vault.deposit.value(msg.value)(msg.sender);
+  function forwardFunds(uint256 weiAmount) internal {
+    vault.deposit.value(weiAmount)(msg.sender);
   }
 
   // if crowdsale is unsuccessful, investors can claim refunds here


### PR DESCRIPTION
This PR modifies the behaviour of CappedCrowdsale when a transaction whose value is larger than the amount needed to reach the cap. Now CappedCrowdsale accepts just enough to reach the cap, and refunds the rest.