### PR TITLE
Categorized ERC721 token

### DIFF
--- a/contracts/token/CategorizedERC721/CategorizedERC721Token.sol
+++ b/contracts/token/CategorizedERC721/CategorizedERC721Token.sol
@@ -1,0 +1,58 @@
+pragma solidity ^0.4.18;
+
+import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'zeppelin-solidity/contracts/token/ERC721/ERC721Token.sol';
+
+contract CategorizedERC721Token is ERC721Token, Ownable {
+
+  // event fired when a new category is created
+  event CategoryCreated(uint categoryId, uint fromTokenId, uint toTokenId);
+
+  // array with the supply of each category
+  uint[] categoriesSupply;
+
+  // mapping between the tokenId and categoryId
+  mapping (uint => uint) private tokenIdCategoryId;
+
+  // method used to create a new category and mint the tokens
+  function createCategory(uint _supply) public onlyOwner{
+    uint categoryId = categoriesSupply.push(_supply);
+
+    uint startTokenId = totalSupply();
+    uint lastTokenId = startTokenId + _supply - 1;
+    for(uint tokenId = startTokenId; tokenId <= lastTokenId; tokenId++) {
+      _mint(msg.sender, tokenId);
+      tokenIdCategoryId[tokenId] = categoryId;
+    }
+
+    CategoryCreated(categoryId, startTokenId, lastTokenId);
+  }
+  // method to extend the amount of tokens for a given category
+  function increaseCategorySupply(uint _categoryId, uint _extraSupply) public onlyOwner{
+    require(categoriesSupply[_categoryId] > 0);
+
+    uint currentSupply = categoriesSupply[_categoryId];
+
+    uint newSupply = currentSupply + _extraSupply;
+    categoriesSupply[_categoryId] = newSupply;
+
+    uint startTokenId = totalSupply();
+    uint lastTokenId = startTokenId + _extraSupply - 1;
+    for(uint tokenId = startTokenId; tokenId <= lastTokenId; tokenId++) {
+      _mint(msg.sender, tokenId);
+      tokenIdCategoryId[tokenId] = _categoryId;
+    }
+  }
+
+  // get the categoryId for a given token
+  function getCategoryId(uint _tokenId) public view returns (uint) {
+    require(_tokenId < totalSupply());
+    return tokenIdCategoryId[_tokenId];
+  }
+
+  // get the total supply for a given category
+  function getCategorySupply(uint _categoryId) public view returns (uint){
+    require(_categoryId < categoriesSupply.length);
+    return categoriesSupply[_categoryId];
+  }
+}


### PR DESCRIPTION
This PR propose a new feature to the OpenZeppelin project by proposing an extension of the ERC721 Token in order to be able to categorize the tokens managed by the ERC721 token.

# 🚀 Description

We propose this extension of the ERC721 in order to allow the categorization of the tokens managed by the ERC 721 standard. We can therefore support both Fungible and Non-Fungible tokens with a single token.

This new extension was developed in the scope of the ETHDenver Hackathon by the Taiga Market team which is building a decentralized marketplace for fungible tokens, such has game assets or digital assets where all tokens belonging to a category have the same properties.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).

We will propose the need tests/changes in the following days.