### PR TITLE
Making visibility explicit for storage variables

### DIFF
--- a/contracts/token/ERC20/BasicToken.sol
+++ b/contracts/token/ERC20/BasicToken.sol
@@ -12,9 +12,9 @@ import "../../math/SafeMath.sol";
 contract BasicToken is ERC20Basic {
   using SafeMath for uint256;
 
-  mapping(address => uint256) public balances;
+  mapping(address => uint256) internal balances;
 
-  uint256 public totalSupply_;
+  uint256 internal totalSupply_;
 
   /**
   * @dev total number of tokens in existence

--- a/contracts/token/ERC20/BasicToken.sol
+++ b/contracts/token/ERC20/BasicToken.sol
@@ -12,9 +12,9 @@ import "../../math/SafeMath.sol";
 contract BasicToken is ERC20Basic {
   using SafeMath for uint256;
 
-  mapping(address => uint256) balances;
+  mapping(address => uint256) public balances;
 
-  uint256 totalSupply_;
+  uint256 public totalSupply_;
 
   /**
   * @dev total number of tokens in existence


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Making `balances` and `totalSupply_` visibility explicitly public in BasicToken

They are currently implicitly public.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

I assume that `totalSupply_` could have originally been made private, since a `totalSupply()` getter was manually created. But it is already public and should stay that way.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).