### PR TITLE
TaxedToken implementation that charges a fee for token transfers. 

### DIFF
--- a/contracts/mocks/TaxedTokenMock.sol
+++ b/contracts/mocks/TaxedTokenMock.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.18;
+
+import "../token/ERC20/TaxedToken.sol";
+
+
+contract TaxedTokenMock is TaxedToken {
+
+  function TaxedTokenMock(
+    address initialAccount,
+    uint256 initialBalance,
+    address _feeAccount,
+    uint _maxTransferFee,
+    uint8 _transferFeePercentage
+  ) public
+  {
+    balances[initialAccount] = initialBalance;
+    totalSupply_ = initialBalance;
+
+    feeAccount = _feeAccount;
+    maxTransferFee = _maxTransferFee;
+    transferFeePercentage = _transferFeePercentage;
+  }
+}

--- a/contracts/token/ERC20/TaxedToken.sol
+++ b/contracts/token/ERC20/TaxedToken.sol
@@ -20,20 +20,13 @@ contract TaxedToken is BasicToken {
    * @param _value The number of tokens to transfer.
    */
   function transfer(address _to, uint256 _value) public returns (bool) {
-    require(_to != address(0));
-    require(_value <= balances[msg.sender]);
     require(_value % (uint256(10) ** decimals) == 0);
-
-    balances[msg.sender] = balances[msg.sender].sub(_value);
 
     uint256 fee = Math.min256(_value.mul(transferFeePercentage).div(100), maxTransferFee);
     uint256 taxedValue = _value.sub(fee);
 
-    balances[_to] = balances[_to].add(taxedValue);
-    Transfer(msg.sender, _to, taxedValue);
-
-    balances[feeAccount] = balances[feeAccount].add(fee);
-    Transfer(msg.sender, feeAccount, fee);
+    require(super.transfer(feeAccount, fee));
+    require(super.transfer(_to, taxedValue));
 
     return true;
   }

--- a/contracts/token/ERC20/TaxedToken.sol
+++ b/contracts/token/ERC20/TaxedToken.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.18;
+
+import "./BasicToken.sol";
+import "../../math/Math.sol";
+import "../../math/SafeMath.sol";
+
+
+contract TaxedToken is BasicToken {
+  using SafeMath for uint256;
+
+  uint8 public decimals = 2;
+
+  address internal feeAccount;
+  uint256 internal maxTransferFee;
+  uint8 internal transferFeePercentage;
+
+  /**
+   * @dev Transfer tokens to a specified account after diverting a fee to a central account.
+   * @param _to The receiving address.
+   * @param _value The number of tokens to transfer.
+   */
+  function transfer(address _to, uint256 _value) public returns (bool) {
+    require(_to != address(0));
+    require(_value <= balances[msg.sender]);
+    require(_value % (uint256(10) ** decimals) == 0);
+
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+
+    uint256 fee = Math.min256(_value.mul(transferFeePercentage).div(100), maxTransferFee);
+    uint256 taxedValue = _value.sub(fee);
+
+    balances[_to] = balances[_to].add(taxedValue);
+    Transfer(msg.sender, _to, taxedValue);
+
+    balances[feeAccount] = balances[feeAccount].add(fee);
+    Transfer(msg.sender, feeAccount, fee);
+
+    return true;
+  }
+}

--- a/test/token/TaxedToken.test.js
+++ b/test/token/TaxedToken.test.js
@@ -15,6 +15,9 @@ contract('TaxedToken', function ([owner, recipient, feeAccount]) {
 
         it('reverts', async function () {
           await assertRevert(this.token.transfer(to, amount, { from: owner }));
+
+          const ownerBalance = await this.token.balanceOf(owner);
+          assert.equal(ownerBalance, 1000);
         });
       });
 
@@ -40,13 +43,13 @@ contract('TaxedToken', function ([owner, recipient, feeAccount]) {
           assert.equal(logs.length, 2);
           assert.equal(logs[0].event, 'Transfer');
           assert.equal(logs[0].args.from, owner);
-          assert.equal(logs[0].args.to, to);
-          assert(logs[0].args.value.eq(99));
+          assert.equal(logs[0].args.to, feeAccount);
+          assert(logs[0].args.value.eq(1));
 
           assert.equal(logs[1].event, 'Transfer');
           assert.equal(logs[1].args.from, owner);
-          assert.equal(logs[1].args.to, feeAccount);
-          assert(logs[1].args.value.eq(1));
+          assert.equal(logs[1].args.to, to);
+          assert(logs[1].args.value.eq(99));
         });
 
         it('reverts if not evenly divisible', async function () {

--- a/test/token/TaxedToken.test.js
+++ b/test/token/TaxedToken.test.js
@@ -1,0 +1,71 @@
+import assertRevert from '../helpers/assertRevert';
+const TaxedTokenMock = artifacts.require('TaxedTokenMock');
+
+contract('TaxedToken', function ([owner, recipient, feeAccount]) {
+  beforeEach(async function () {
+    this.token = await TaxedTokenMock.new(owner, 1000, feeAccount, 5, 1);
+  });
+
+  describe('transfer', function () {
+    describe('when the recipient is not the zero address', function () {
+      const to = recipient;
+
+      describe('when the sender does not have enough balance', function () {
+        const amount = 1001;
+
+        it('reverts', async function () {
+          await assertRevert(this.token.transfer(to, amount, { from: owner }));
+        });
+      });
+
+      describe('when the sender has enough balance', function () {
+        const amount = 100;
+
+        it('transfers the requested amount', async function () {
+          await this.token.transfer(to, amount, { from: owner });
+
+          const ownerBalance = await this.token.balanceOf(owner);
+          assert.equal(ownerBalance, 900);
+
+          const recipientBalance = await this.token.balanceOf(to);
+          assert.equal(recipientBalance, 99);
+
+          const feeAccountBalance = await this.token.balanceOf(feeAccount);
+          assert.equal(feeAccountBalance, 1);
+        });
+
+        it('emits the transfer events', async function () {
+          const { logs } = await this.token.transfer(to, amount, { from: owner });
+
+          assert.equal(logs.length, 2);
+          assert.equal(logs[0].event, 'Transfer');
+          assert.equal(logs[0].args.from, owner);
+          assert.equal(logs[0].args.to, to);
+          assert(logs[0].args.value.eq(99));
+
+          assert.equal(logs[1].event, 'Transfer');
+          assert.equal(logs[1].args.from, owner);
+          assert.equal(logs[1].args.to, feeAccount);
+          assert(logs[1].args.value.eq(1));
+        });
+
+        it('reverts if not evenly divisible', async function () {
+          await assertRevert(this.token.transfer(to, 99, { from: owner }));
+        });
+
+        it('transfers the max fee', async function () {
+          this.token.transfer(to, 600, { from: owner });
+
+          const ownerBalance = await this.token.balanceOf(owner);
+          assert.equal(ownerBalance, 400);
+
+          const recipientBalance = await this.token.balanceOf(to);
+          assert.equal(recipientBalance, 595);
+
+          const feeAccountBalance = await this.token.balanceOf(feeAccount);
+          assert.equal(feeAccountBalance, 5);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #787 

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

An interesting erc20 token use-case I keep seeing is a 'taxed' transfer (i.e. a small fee (for example 1%) is diverted to a feeAccount in `transfer`). This PR implements that functionality and includes corresponding unit-tests.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).