### PR TITLE
parties can extend generic proposals to be voted upon and eventually executed or rejected

### DIFF
--- a/contracts/mocks/ProposableMock.sol
+++ b/contracts/mocks/ProposableMock.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.4.18;
+
+import "../voting/Proposable.sol";
+
+
+contract ProposableMock is Proposable {
+
+  function getClout(address) view internal returns (uint clout) {
+    clout = 1;
+  }
+
+  function tallyVotes(uint tallyFor, uint tallyAgainst) view internal returns (Actions action) {
+    action = Actions.Pend;
+
+    if (tallyFor > 1) {
+      action = Actions.Accept;
+    } else if (tallyAgainst > 1) {
+      action = Actions.Reject;
+    }
+  }
+
+  function closeProposal(bytes32 hash) internal {
+    Proposal storage proposal = proposals[hash];
+    require(proposal.status == Status.Open);
+
+    proposal.status = Status.Closed;
+    ProposalClosed(hash);
+  }
+
+  function executeProposal(bytes32 hash) internal {
+    Proposal storage proposal = proposals[hash];
+    require(proposal.status == Status.Accepted);
+
+    proposal.status = Status.Executed;
+    ProposalExecuted(hash);
+  }
+}

--- a/contracts/voting/Proposable.sol
+++ b/contracts/voting/Proposable.sol
@@ -1,0 +1,171 @@
+pragma solidity ^0.4.18;
+
+import "../math/SafeMath.sol";
+
+
+/**
+ * @title Proposable
+ * @dev parties can extend generic `Proposal`s to be voted upon and eventually executed or closed
+ */
+contract Proposable {
+  using SafeMath for uint;
+
+  enum Actions { Accept, Pend, Reject }  // possible outcomes of the voting process
+  enum Status { Null, Accepted, Closed, Executed, Open }  // possible states of a `Proposal`
+
+  struct Proposal {
+    /**
+     * a `Proposal` is uniquely identified by a `keccak256()` hash of the following information...
+     */
+
+    uint sendValue;  // for example: send `100`
+    string sendDescription;  // 'tokens'
+    address to;  // to `0xdead...`
+
+    uint forValue;  // for `1`
+    string forDescription;  // 'ETH'
+    address from;  // from `0xdead...`
+
+    string ipfs;
+    address proposedBy;
+
+    address[] directed;
+
+    /**
+     * meta-data (not included in hash)
+     */
+
+    Status status;
+    uint tallyFor;
+    uint tallyAgainst;
+
+    mapping(address => bool) directedTowards;
+    mapping (address => bool) voters;
+  }
+
+  mapping(bytes32 => Proposal) public proposals;  // all unique `Proposal`s
+
+  event ProposalExtended(bytes32 indexed proposal, address indexed by);
+  event Voted(bytes32 indexed proposal, address indexed voter);
+  event ProposalAccepted(bytes32 indexed proposal);
+  event ProposalRejected(bytes32 indexed proposal);
+  event ProposalClosed(bytes32 indexed proposal);  // emitted by abstract method `closeProposal()`
+  event ProposalExecuted(bytes32 indexed proposal);  // emitted by abstract method `executeProposal()`
+
+  /**
+   * @dev get the voting influence/power of a party
+   * @param voter address of the voting party
+   * @dev this may revert if `voter` is not `WhiteList`ed or has no clout
+   */
+  function getClout(address voter) view internal returns (uint clout);
+
+  /**
+   * @dev indicate an `Action` to take based on the current state of a `Proposal`'s voting process
+   * @param tallyFor current vote count in favor of this `Proposal`
+   * @param tallyAgainst current vote count in opposition of this `Proposal`
+   */
+  function tallyVotes(uint tallyFor, uint tallyAgainst) view internal returns (Actions action);
+
+  /**
+   * @dev close a `Proposal` (it is either `Rejected` via vote or rescinded by `Proposal.proposedBy`)
+   * @param hash unique identifier of the `Proposal` being `Closed`
+   */
+  function closeProposal(bytes32 hash) internal;
+
+  /**
+   * @dev execute a proposal (it has been `Accepted` via vote)
+   * @param hash unique identifier of the `Proposal` being executed
+   */
+  function executeProposal(bytes32 hash) internal;
+
+  /**
+   * inheriting contract can optionally restrict `extendProposal()` and `vote()` by overriding these modifiers
+   */
+
+  modifier extendProposalFilter {
+    _;
+  }
+
+  modifier voteFilter {
+    _;
+  }
+
+  /**
+  * @dev extend a `Proposal` to be voted upon and eventually `Executed` or `Closed`
+  * @param sendValue the value this `Proposal` is proposing to send (i.e. 100) (units defined by inheriting contract)
+  * @param sendDescription human-readable description of `sendValue` (i.e. 'tokens')
+  * @param to address receiving `sendValue`
+  * @param forValue the value being received in exchange for `sendValue` (i.e. 1) (units defined by inheriting contract)
+  * @param forDescription human-readable description of `forValue` (i.e. 'ETH')
+  * @param from address providing `forValue`
+  * @param ipfs hash of off-chain data relevant to this proposal
+  * @param directed addresses this proposal is directed towards (empty indicates an undirected `Proposal`)
+  */
+  function extendProposal(
+    uint sendValue,
+    string sendDescription,
+    address to,
+    uint forValue,
+    string forDescription,
+    address from,
+    string ipfs,
+    address[] directed
+  )
+    public
+    extendProposalFilter
+  {
+    bytes32 hash = keccak256(sendValue, sendDescription, to, forValue, forDescription, from, ipfs, msg.sender, directed);
+    require(proposals[hash].status == Status.Null);
+
+    proposals[hash] = Proposal(sendValue, sendDescription, to, forValue, forDescription, from, ipfs, msg.sender, directed, Status.Open, 0, 0);
+    for (uint i = 0; i < directed.length; i++) {
+      proposals[hash].directedTowards[directed[i]] = true;
+    }
+
+    ProposalExtended(hash, msg.sender);
+  }
+
+  /**
+   * @dev a party can rescind (close) a `Proposal` they've extended (until it has been `Accepted` via the voting process)
+   * @param hash unique identifier of the `Proposal` being rescinded
+   */
+  function rescindProposal(bytes32 hash) public {
+    require(msg.sender == proposals[hash].proposedBy);
+    closeProposal(hash);
+  }
+
+  /**
+   * @dev a party can vote on `Open` `Proposal`s
+   * @param hash unique identifier of the `Proposal` being voted on
+   * @param inSupport `true` indicates yea, `false` indicates nay
+   */
+  function vote(bytes32 hash, bool inSupport) voteFilter public {
+    Proposal storage proposal = proposals[hash];
+    require(proposal.status == Status.Open);
+
+    if (proposal.directed.length > 0) {
+      require(proposal.directedTowards[msg.sender]);
+    }
+
+    require(!proposal.voters[msg.sender]);
+    proposal.voters[msg.sender] = true;
+
+    if (inSupport) {
+      proposal.tallyFor += getClout(msg.sender);
+    } else {
+      proposal.tallyAgainst += getClout(msg.sender);
+    }
+
+    Voted(hash, msg.sender);
+
+    Actions action = tallyVotes(proposal.tallyFor, proposal.tallyAgainst);
+    if (action == Actions.Accept) {
+      proposal.status = Status.Accepted;
+      ProposalAccepted(hash);
+      executeProposal(hash);
+    } else if (action == Actions.Reject) {
+      ProposalRejected(hash);
+      closeProposal(hash);
+    }
+  }
+}

--- a/test/voting/Proposable.test.js
+++ b/test/voting/Proposable.test.js
@@ -1,0 +1,117 @@
+import assertRevert from '../helpers/assertRevert';
+
+const ProposableMock = artifacts.require('ProposableMock');
+
+contract('ProposableMock', (accounts) => {
+  const from = accounts[0];
+  const args = [100, 'tokens', accounts[1], 1, 'ETH', accounts[1], '0xdeadbeef'];
+
+  beforeEach(async function () {
+    this.proposable = await ProposableMock.new();
+  });
+
+  describe('extendProposal', () => {
+    it('extend a proposal', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [], { from });
+      assert.equal(logs.length, 1);
+      assert.equal(logs[0].event, 'ProposalExtended');
+      assert.equal(logs[0].args.by, from);
+    });
+
+    it('reverts because a proposal with this identifier already exists', async function () {
+      await this.proposable.extendProposal(...args, [], { from });
+      await assertRevert(this.proposable.extendProposal(...args, [], { from }));
+    });
+
+    it('proposals with unique identifiers can be extended', async function () {
+      await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.extendProposal(...args, [], { from: accounts[1] });
+    });
+
+    it('extends a proposal directed towards a single party', async function () {
+      await this.proposable.extendProposal(...args, [accounts[0]], { from });
+    });
+
+    it('extends a proposal directed towards multiple parties', async function () {
+      await this.proposable.extendProposal(...args, [accounts[0], accounts[2]], { from });
+    });
+  });
+
+  describe('rescindProposal', () => {
+    it('rescinds an open proposal', async function () {
+      const r = await this.proposable.extendProposal(...args, [], { from });
+      const { logs } = await this.proposable.rescindProposal(r.logs[0].args.proposal, { from });
+      assert.equal(logs.length, 1);
+      assert.equal(logs[0].event, 'ProposalClosed');
+      assert.equal(logs[0].args.proposal, r.logs[0].args.proposal);
+    });
+
+    it('reverts because a party tries to rescind a proposal it did not extend', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [], { from });
+      await assertRevert(this.proposable.rescindProposal(logs[0].args.proposal, { from: accounts[1] }));
+    });
+
+    it('reverts because a party tries to rescind a proposal that is not open', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.vote(logs[0].args.proposal, true, { from });
+      await this.proposable.vote(logs[0].args.proposal, true, { from: accounts[1] });
+      await assertRevert(this.proposable.rescindProposal(logs[0].args.proposal, { from }));
+    });
+  });
+
+  describe('vote', () => {
+    it('voteUp', async function () {
+      const r = await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.vote(r.logs[0].args.proposal, true, { from });
+      const { logs } = await this.proposable.vote(r.logs[0].args.proposal, true, { from: accounts[1] });
+
+      assert.equal(logs.length, 3);
+      assert.equal(logs[0].event, 'Voted');
+      assert.equal(logs[0].args.proposal, r.logs[0].args.proposal);
+      assert.equal(logs[0].args.voter, accounts[1]);
+      assert.equal(logs[1].event, 'ProposalAccepted');
+      assert.equal(logs[1].args.proposal, r.logs[0].args.proposal);
+      assert.equal(logs[2].event, 'ProposalExecuted');
+      assert.equal(logs[2].args.proposal, r.logs[0].args.proposal);
+    });
+
+    it('voteDown', async function () {
+      const r = await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.vote(r.logs[0].args.proposal, false, { from });
+      const { logs } = await this.proposable.vote(r.logs[0].args.proposal, false, { from: accounts[1] });
+
+      assert.equal(logs.length, 3);
+      assert.equal(logs[0].event, 'Voted');
+      assert.equal(logs[0].args.proposal, r.logs[0].args.proposal);
+      assert.equal(logs[0].args.voter, accounts[1]);
+      assert.equal(logs[1].event, 'ProposalRejected');
+      assert.equal(logs[1].args.proposal, r.logs[0].args.proposal);
+      assert.equal(logs[2].event, 'ProposalClosed');
+      assert.equal(logs[2].args.proposal, r.logs[0].args.proposal);
+    });
+
+    it('reverts because a party tries to vote on a proposal that is not open', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.vote(logs[0].args.proposal, true, { from: accounts[1] });
+      await this.proposable.vote(logs[0].args.proposal, true, { from: accounts[2] });
+      await assertRevert(this.proposable.vote(logs[0].args.proposal, true, { from }));
+    });
+
+    it('a party can vote on a proposal directed towards itself', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [accounts[4]], { from });
+      const r = await this.proposable.vote(logs[0].args.proposal, true, { from: accounts[4] });
+      assert.equal(r.logs[0].event, 'Voted');
+    });
+
+    it('reverts because a party tries to vote on a proposal not directed towards itself', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [accounts[4]], { from });
+      await assertRevert(this.proposable.vote(logs[0].args.proposal, true, { from }));
+    });
+
+    it('reverts because a party tries to vote on a proposal multiple times', async function () {
+      const { logs } = await this.proposable.extendProposal(...args, [], { from });
+      await this.proposable.vote(logs[0].args.proposal, true, { from });
+      await assertRevert(this.proposable.vote(logs[0].args.proposal, true, { from }));
+    });
+  });
+});


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->
# 🚀 Description

This PR enables (as generic as possible) `Proposal`s to be extended by parties and voted upon by stakeholders, eventually being executed or closed. There are various use-cases that can be built on top of this. The goal is to keep this module as simple and flexible as possible, with abstract methods and overridable modifiers where appropriate to allow inheriting contracts to configure behavior as necessary. It should be very simple to create various DAOs by inheriting from `Proposable`, as well as some other use-cases.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

In my Dapp i've implemented a simple DAO, functionality to exchange ETH for ERC20 tokens, and functionality to contribute funds to certain ventures. I realized all three of these contracts were starting to repeat the functionality contained in this PR. I was able to share this functionality in `Proposable` and simplifiy my above implementations by inheriting from this. I think there are various other use-cases that can benefit from this PR.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).