### PR TITLE
fix: force RefundableCrowdsale to also be a PostDeliveryCrowdsale

### DIFF
--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.21;
 
 import "../../math/SafeMath.sol";
 import "./FinalizableCrowdsale.sol";
+import "./PostDeliveryCrowdsale.sol";
 import "./utils/RefundVault.sol";
 
 
@@ -11,8 +12,9 @@ import "./utils/RefundVault.sol";
  * @dev Extension of Crowdsale contract that adds a funding goal, and
  * the possibility of users getting a refund if goal is not met.
  * Uses a RefundVault as the crowdsale's vault.
+ * Only distributes tokens after funding goal is met.
  */
-contract RefundableCrowdsale is FinalizableCrowdsale {
+contract RefundableCrowdsale is FinalizableCrowdsale, PostDeliveryCrowdsale {
   using SafeMath for uint256;
 
   // minimum amount of funds to be raised in weis
@@ -29,6 +31,17 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
     require(_goal > 0);
     vault = new RefundVault(wallet);
     goal = _goal;
+  }
+
+  /**
+   * @dev Investors can claim their tokens if a crowdsale is successful
+   */
+  function withdrawTokens() public {
+    // require that the crowdsale is finalized and that the goal was reached
+    require(isFinalized);
+    require(goalReached());
+    // then allow users to withdraw tokens
+    super.withdrawTokens();
   }
 
   /**

--- a/test/crowdsale/PostDeliveryCrowdsale.behavior.js
+++ b/test/crowdsale/PostDeliveryCrowdsale.behavior.js
@@ -1,0 +1,38 @@
+import { increaseTimeTo } from '../helpers/increaseTime';
+import EVMRevert from '../helpers/EVMRevert';
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(web3.BigNumber))
+  .should();
+
+export default function (investor, purchaser, value, endCrowdsale) {
+  describe('as a PostDeliveryCrowdsale', function () {
+    context('before end', function () {
+      it('should not immediately assign tokens to beneficiary', async function () {
+        await increaseTimeTo(this.openingTime);
+        await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
+        const balance = await this.token.balanceOf(investor);
+        balance.should.be.bignumber.equal(0);
+      });
+
+      it('should not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
+        await increaseTimeTo(this.beforeEndTime);
+        await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
+        await this.crowdsale.withdrawTokens({ from: investor }).should.be.rejectedWith(EVMRevert);
+      });
+    });
+
+    context('after end', function () {
+      beforeEach(async function () {
+        await endCrowdsale.call(this, investor, purchaser, value);
+      });
+
+      it('should return the amount of tokens bought', async function () {
+        await this.crowdsale.withdrawTokens({ from: investor });
+        const balance = await this.token.balanceOf(investor);
+        balance.should.be.bignumber.equal(value);
+      });
+    });
+  });
+};


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #877 

# 🚀 Description

When participating in a refundable crowdsale, because tokens were delivered immediately, malicious investors could previously sell tokens to unsuspecting users and then collect their own ether-based refund after the goal is not met.

This change forces RefundableCrowdsale to also be a PostDeliveryCrowdsale where users are only allowed to withdraw tokens if the goal is reached, the crowdsale is over, and it is finalized.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
