### PR TITLE
feat: initial implementation of ERC1046

### DIFF
--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.21;
 import "../token/ERC20/StandardToken.sol";
 import "../proposals/ERC1046/TokenMetadata.sol";
 
+
 contract ERC20WithMetadataMock is StandardToken, ERC20WithMetadata {
   function ERC20WithMetadataMock(string _tokenURI)
     ERC20WithMetadata(_tokenURI)

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.21;
+
+import "../token/ERC20/StandardToken.sol";
+import "../proposals/ERC1046/TokenMetadata.sol";
+
+contract ERC20WithMetadataMock is StandardToken, ERC20WithMetadata {
+  function ERC20WithMetadataMock(string _tokenURI)
+    ERC20WithMetadata(_tokenURI)
+    public
+  {
+  }
+}

--- a/contracts/proposals/ERC1046/TokenMetadata.sol
+++ b/contracts/proposals/ERC1046/TokenMetadata.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.21;
+
+import "../../token/ERC20/ERC20.sol";
+
+/**
+ * @title ERC-1047 Token Metadata
+ * @dev See https://eips.ethereum.org/EIPS/eip-1046
+ * @dev tokenURI must respond with a URI that implements https://eips.ethereum.org/EIPS/eip-1047
+ * @dev TODO - update https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/ERC721.sol#L17 when 1046 is finalized
+ */
+contract ERC20TokenMetadata is ERC20 {
+  function tokenURI() public view returns (string);
+}
+
+contract ERC20WithMetadata is ERC20TokenMetadata {
+  string private tokenURI_ = "";
+
+  function ERC20WithMetadata(string _tokenURI)
+    public
+  {
+    tokenURI_ = _tokenURI;
+  }
+
+  function tokenURI() public view returns (string) {
+    // in the effort of minimum-effort compatibility,
+    //   tokenURI MUST throw if not exists https://eips.ethereum.org/EIPS/eip-721
+    bytes memory _tokenURI = bytes(tokenURI_);
+    require(_tokenURI.length > 0);
+
+    return tokenURI_;
+  }
+}

--- a/contracts/proposals/ERC1046/TokenMetadata.sol
+++ b/contracts/proposals/ERC1046/TokenMetadata.sol
@@ -24,11 +24,6 @@ contract ERC20WithMetadata is ERC20TokenMetadata {
   }
 
   function tokenURI() external view returns (string) {
-    // in the effort of minimum-effort compatibility,
-    //   tokenURI MUST throw if not exists https://eips.ethereum.org/EIPS/eip-721
-    bytes memory _tokenURI = bytes(tokenURI_);
-    require(_tokenURI.length > 0);
-
     return tokenURI_;
   }
 }

--- a/contracts/proposals/ERC1046/TokenMetadata.sol
+++ b/contracts/proposals/ERC1046/TokenMetadata.sol
@@ -10,7 +10,7 @@ import "../../token/ERC20/ERC20.sol";
  * @dev TODO - update https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/ERC721.sol#L17 when 1046 is finalized
  */
 contract ERC20TokenMetadata is ERC20 {
-  function tokenURI() public view returns (string);
+  function tokenURI() external view returns (string);
 }
 
 
@@ -23,7 +23,7 @@ contract ERC20WithMetadata is ERC20TokenMetadata {
     tokenURI_ = _tokenURI;
   }
 
-  function tokenURI() public view returns (string) {
+  function tokenURI() external view returns (string) {
     // in the effort of minimum-effort compatibility,
     //   tokenURI MUST throw if not exists https://eips.ethereum.org/EIPS/eip-721
     bytes memory _tokenURI = bytes(tokenURI_);

--- a/contracts/proposals/ERC1046/TokenMetadata.sol
+++ b/contracts/proposals/ERC1046/TokenMetadata.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.21;
 
 import "../../token/ERC20/ERC20.sol";
 
+
 /**
  * @title ERC-1047 Token Metadata
  * @dev See https://eips.ethereum.org/EIPS/eip-1046
@@ -11,6 +12,7 @@ import "../../token/ERC20/ERC20.sol";
 contract ERC20TokenMetadata is ERC20 {
   function tokenURI() public view returns (string);
 }
+
 
 contract ERC20WithMetadata is ERC20TokenMetadata {
   string private tokenURI_ = "";

--- a/test/proposals/ERC1046/TokenMetadata.test.js
+++ b/test/proposals/ERC1046/TokenMetadata.test.js
@@ -1,4 +1,3 @@
-import assertRevert from '../../helpers/assertRevert';
 const ERC20WithMetadata = artifacts.require('ERC20WithMetadataMock');
 
 require('chai')
@@ -6,28 +5,14 @@ require('chai')
   .should();
 
 const metadataURI = 'https://example.com';
-const invalidMetadataURI = '';
 
 describe('ERC20WithMetadata', function () {
-  context('invalid metadata', function () {
-    before(async function () {
-      this.token = await ERC20WithMetadata.new(invalidMetadataURI);
-    });
-
-    it('throws', async function () {
-      await assertRevert(
-        this.token.tokenURI()
-      );
-    });
+  before(async function () {
+    this.token = await ERC20WithMetadata.new(metadataURI);
   });
-  context('valid metadata', function () {
-    before(async function () {
-      this.token = await ERC20WithMetadata.new(metadataURI);
-    });
 
-    it('responds with the metadata', async function () {
-      const got = await this.token.tokenURI();
-      got.should.eq(metadataURI);
-    });
+  it('responds with the metadata', async function () {
+    const got = await this.token.tokenURI();
+    got.should.eq(metadataURI);
   });
 });

--- a/test/proposals/ERC1046/TokenMetadata.test.js
+++ b/test/proposals/ERC1046/TokenMetadata.test.js
@@ -1,0 +1,33 @@
+import assertRevert from '../../helpers/assertRevert';
+const ERC20WithMetadata = artifacts.require('ERC20WithMetadataMock');
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+
+const metadataURI = 'https://example.com';
+const invalidMetadataURI = '';
+
+describe('ERC20WithMetadata', function () {
+  context('invalid metadata', function () {
+    before(async function () {
+      this.token = await ERC20WithMetadata.new(invalidMetadataURI);
+    });
+
+    it('throws', async function () {
+      await assertRevert(
+        this.token.tokenURI()
+      );
+    });
+  });
+  context('valid metadata', function () {
+    before(async function () {
+      this.token = await ERC20WithMetadata.new(metadataURI);
+    });
+
+    it('responds with the metadata', async function () {
+      const got = await this.token.tokenURI();
+      got.should.eq(metadataURI);
+    });
+  });
+});


### PR DESCRIPTION
# 🚀 Description

This is the initial implementation of ERC1046, which adds (optional) `tokenURI` to ERC20 tokens to allow them to exist on-par with ERC721 tokens.

https://eips.ethereum.org/EIPS/eip-1046

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
