### PR TITLE
Feature/cancellable pull payment contract #196

### DIFF
--- a/contracts/mocks/CancellablePullPaymentMock.sol
+++ b/contracts/mocks/CancellablePullPaymentMock.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.23;
+
+
+import "../payment/CancellablePullPayment.sol";
+
+
+// mock class using CancellablePullPayment
+contract CancellablePullPaymentMock is CancellablePullPayment {
+
+  constructor() public payable { }
+
+  // test helper function to call asyncSend
+  function callSend(address dest, uint256 amount) public {
+    asyncSend(dest, amount);
+  }
+
+  // test helper function to call cancelPayment
+  function callCancel(address dest) public {
+    cancelPayment(dest);
+  }
+}

--- a/contracts/payment/CancellablePullPayment.sol
+++ b/contracts/payment/CancellablePullPayment.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.23;
+
+
+import "./PullPayment.sol";
+
+
+/**
+ * @title CancellablePullPayment
+ * @dev PullPayment contract supporting cancelling an issued payment.
+ */
+contract CancellablePullPayment is PullPayment {
+
+  /**
+  * @dev Called by the payer to cancel the stored amount for an address.
+  * @param _payee The destination address of the funds.
+  */
+  function cancelPayment(address _payee) internal {
+    uint256 payment = payments[_payee];
+
+    require(payment != 0);
+
+    payments[_payee] = 0;
+    totalPayments = totalPayments.sub(payment);
+  }
+}

--- a/test/payment/CancellablePullPayment.test.js
+++ b/test/payment/CancellablePullPayment.test.js
@@ -1,5 +1,7 @@
 var CancellablePullPaymentMock = artifacts.require('CancellablePullPaymentMock');
 
+const EVMThrow = require('../helpers/EVMThrow.js');
+
 contract('CancellablePullPayment', function (accounts) {
   let mock;
   let amount = 17 * 1e18;
@@ -62,8 +64,6 @@ contract('CancellablePullPayment', function (accounts) {
   });
 
   it('should not allow to cancel a non-existent payment', async () => {
-    await expectThrow(
-      mock.callCancel(payee1)
-    );
+    await mock.callCancel(payee1).should.be.rejectedWith(EVMThrow);
   });
 });

--- a/test/payment/CancellablePullPayment.test.js
+++ b/test/payment/CancellablePullPayment.test.js
@@ -1,0 +1,69 @@
+var CancellablePullPaymentMock = artifacts.require('CancellablePullPaymentMock');
+
+contract('CancellablePullPayment', function (accounts) {
+  let mock;
+  let amount = 17 * 1e18;
+
+  const [
+    payee1,
+    payee2,
+  ] = accounts;
+
+  beforeEach(async function () {
+    mock = await CancellablePullPaymentMock.new({ value: amount });
+  });
+
+  it('can\'t call cancelPayment externally', async function () {
+    assert.isUndefined(mock.cancelPayment);
+  });
+
+  it('can cancel a payment correctly when there are payments for different addresses', async function () {
+    await mock.callSend(payee1, 100);
+    await mock.callSend(payee2, 200);
+
+    const totalPayments = await mock.totalPayments();
+    assert.equal(totalPayments, 300);
+
+    const paymentsToPayee1 = await mock.payments(payee1);
+    assert.equal(paymentsToPayee1, 100);
+
+    const paymentsToPayee2 = await mock.payments(payee2);
+    assert.equal(paymentsToPayee2, 200);
+
+    await mock.callCancel(payee1);
+
+    const totalPaymentsAfterCancel = await mock.totalPayments();
+    assert.equal(totalPaymentsAfterCancel, 200);
+
+    const paymentsToPayee1AfterCancel = await mock.payments(payee1);
+    assert.equal(paymentsToPayee1AfterCancel, 0);
+
+    const paymentsToPayee2AfterCancel = await mock.payments(payee2);
+    assert.equal(paymentsToPayee2AfterCancel, 200);
+  });
+
+  it('can cancel a payment correctly when there are multiple payments for the same address', async function () {
+    await mock.callSend(payee1, 100);
+    await mock.callSend(payee1, 200);
+
+    const totalPayments = await mock.totalPayments();
+    assert.equal(totalPayments, 300);
+
+    const paymentsToPayee1 = await mock.payments(payee1);
+    assert.equal(paymentsToPayee1, 300);
+
+    await mock.callCancel(payee1);
+
+    const totalPaymentsAfterCancel = await mock.totalPayments();
+    assert.equal(totalPaymentsAfterCancel, 0);
+
+    const paymentsToPayee1AfterCancel = await mock.payments(payee1);
+    assert.equal(paymentsToPayee1AfterCancel, 0);
+  });
+
+  it('should not allow to cancel a non-existent payment', async () => {
+    await expectThrow(
+      mock.callCancel(payee1)
+    );
+  });
+});


### PR DESCRIPTION
Fixes #196 

# 🚀 Description

Creating a CancellablePullPayment contract with the ability to cancel all the async payments for a specific payee address.

- [X] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [X] ✅ I've added tests where applicable to test my new functionality.
- [X] 📖 I've made sure that my contracts are well-documented.
- [X] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
