### PR TITLE
Refactoring Superuser contract to allow Owners to transfer ownership …

### DIFF
--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -34,20 +34,28 @@ contract Ownable {
   }
 
   /**
-   * @dev Allows the current owner to transfer control of the contract to a newOwner.
-   * @param newOwner The address to transfer ownership to.
-   */
-  function transferOwnership(address newOwner) public onlyOwner {
-    require(newOwner != address(0));
-    emit OwnershipTransferred(owner, newOwner);
-    owner = newOwner;
-  }
-
-  /**
    * @dev Allows the current owner to relinquish control of the contract.
    */
   function renounceOwnership() public onlyOwner {
     emit OwnershipRenounced(owner);
     owner = address(0);
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param _newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address _newOwner) public onlyOwner {
+    _transferOwnership(_newOwner);
+  }
+
+  /**
+   * @dev Transfers control of the contract to a newOwner.
+   * @param _newOwner The address to transfer ownership to.
+   */
+  function _transferOwnership(address _newOwner) internal {
+    require(_newOwner != address(0));
+    emit OwnershipTransferred(owner, _newOwner);
+    owner = _newOwner;
   }
 }

--- a/contracts/ownership/Superuser.sol
+++ b/contracts/ownership/Superuser.sol
@@ -26,6 +26,11 @@ contract Superuser is Ownable, RBAC {
     _;
   }
 
+  modifier onlyOwnerOrSuperuser() {
+    require(msg.sender == owner || isSuperuser(msg.sender));
+    _;
+  }
+
   /**
    * @dev getter to determine if address has superuser role
    */
@@ -41,22 +46,17 @@ contract Superuser is Ownable, RBAC {
    * @dev Allows the current superuser to transfer his role to a newSuperuser.
    * @param _newSuperuser The address to transfer ownership to.
    */
-  function transferSuperuser(address _newSuperuser) 
-    onlySuperuser
-    public
-  {
+  function transferSuperuser(address _newSuperuser) public onlySuperuser {
     require(_newSuperuser != address(0));
     removeRole(msg.sender, ROLE_SUPERUSER);
     addRole(_newSuperuser, ROLE_SUPERUSER);
   }
 
   /**
-   * @dev Allows the current superuser to transfer control of the contract to a newOwner.
+   * @dev Allows the current superuser or owner to transfer control of the contract to a newOwner.
    * @param _newOwner The address to transfer ownership to.
    */
-  function transferOwnership(address _newOwner) public onlySuperuser {
-    require(_newOwner != address(0));
-    owner = _newOwner;
-    emit OwnershipTransferred(owner, _newOwner);
+  function transferOwnership(address _newOwner) public onlyOwnerOrSuperuser {
+    _transferOwnership(_newOwner);
   }
 }

--- a/test/ownership/Superuser.test.js
+++ b/test/ownership/Superuser.test.js
@@ -12,6 +12,7 @@ contract('Superuser', function (accounts) {
     firstOwner,
     newSuperuser,
     newOwner,
+    finalOwner,
     anyone,
   ] = accounts;
 
@@ -35,7 +36,7 @@ contract('Superuser', function (accounts) {
       address1IsSuperuser.should.be.equal(true);
     });
 
-    it('should change owner after transferring', async function () {
+    it('should change owner after the superuser transfers the ownership', async function () {
       await expectEvent.inTransaction(
         this.superuser.transferOwnership(newOwner, { from: newSuperuser }),
         'OwnershipTransferred'
@@ -43,6 +44,16 @@ contract('Superuser', function (accounts) {
 
       const currentOwner = await this.superuser.owner();
       currentOwner.should.be.equal(newOwner);
+    });
+
+    it('should change owner after the owner transfers the ownership', async function () {
+      await expectEvent.inTransaction(
+        this.superuser.transferOwnership(finalOwner, { from: newOwner }),
+        'OwnershipTransferred'
+      );
+
+      const currentOwner = await this.superuser.owner();
+      currentOwner.should.be.equal(finalOwner);
     });
   });
 
@@ -53,7 +64,7 @@ contract('Superuser', function (accounts) {
       );
     });
 
-    it('should prevent non-superusers from setting a new owner', async function () {
+    it('should prevent users that are not superuser nor owner from setting a new owner', async function () {
       await expectThrow(
         this.superuser.transferOwnership(newOwner, { from: anyone })
       );

--- a/test/ownership/Superuser.test.js
+++ b/test/ownership/Superuser.test.js
@@ -12,11 +12,10 @@ contract('Superuser', function (accounts) {
     firstOwner,
     newSuperuser,
     newOwner,
-    finalOwner,
     anyone,
   ] = accounts;
 
-  before(async function () {
+  beforeEach(async function () {
     this.superuser = await Superuser.new();
   });
 
@@ -32,11 +31,13 @@ contract('Superuser', function (accounts) {
       const ownerIsSuperuser = await this.superuser.isSuperuser(firstOwner);
       ownerIsSuperuser.should.be.equal(false);
 
-      const address1IsSuperuser = await this.superuser.isSuperuser(newSuperuser);
-      address1IsSuperuser.should.be.equal(true);
+      const newSuperuserIsSuperuser = await this.superuser.isSuperuser(newSuperuser);
+      newSuperuserIsSuperuser.should.be.equal(true);
     });
 
     it('should change owner after the superuser transfers the ownership', async function () {
+      await this.superuser.transferSuperuser(newSuperuser, { from: firstOwner });
+
       await expectEvent.inTransaction(
         this.superuser.transferOwnership(newOwner, { from: newSuperuser }),
         'OwnershipTransferred'
@@ -48,12 +49,12 @@ contract('Superuser', function (accounts) {
 
     it('should change owner after the owner transfers the ownership', async function () {
       await expectEvent.inTransaction(
-        this.superuser.transferOwnership(finalOwner, { from: newOwner }),
+        this.superuser.transferOwnership(newOwner, { from: firstOwner }),
         'OwnershipTransferred'
       );
 
       const currentOwner = await this.superuser.owner();
-      currentOwner.should.be.equal(finalOwner);
+      currentOwner.should.be.equal(newOwner);
     });
   });
 


### PR DESCRIPTION
Fixes #50

Refactor to the Superuser contract to allow owners that are not superusers to transfer the ownership of the contract.

- [X] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [X] ✅ I've added tests where applicable to test my new functionality.
- [X] 📖 I've made sure that my contracts are well-documented.
- [X] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
