### PR TITLE
Fix/whitelisted crowdsale

### DIFF
--- a/contracts/access/Whitelist.sol
+++ b/contracts/access/Whitelist.sol
@@ -18,6 +18,7 @@ contract Whitelist is Ownable, RBAC {
 
   /**
    * @dev Throws if called by any account that's not whitelisted.
+   * @dev kept as `onlyWhitelisted` for backwards compatibility
    */
   modifier onlyWhitelisted() {
     checkRole(msg.sender, ROLE_WHITELISTED);
@@ -25,70 +26,78 @@ contract Whitelist is Ownable, RBAC {
   }
 
   /**
+   * @dev Throws if beneficiary is not whitelisted.
+   */
+  modifier isWhitelisted(address _beneficiary) {
+    checkRole(_beneficiary, ROLE_WHITELISTED);
+    _;
+  }
+
+  /**
    * @dev add an address to the whitelist
-   * @param addr address
+   * @param _addr address
    * @return true if the address was added to the whitelist, false if the address was already in the whitelist
    */
-  function addAddressToWhitelist(address addr)
+  function addAddressToWhitelist(address _addr)
     onlyOwner
     public
   {
-    addRole(addr, ROLE_WHITELISTED);
-    emit WhitelistedAddressAdded(addr);
+    addRole(_addr, ROLE_WHITELISTED);
+    emit WhitelistedAddressAdded(_addr);
   }
 
   /**
    * @dev getter to determine if address is in whitelist
    */
-  function whitelist(address addr)
+  function whitelist(address _addr)
     public
     view
     returns (bool)
   {
-    return hasRole(addr, ROLE_WHITELISTED);
+    return hasRole(_addr, ROLE_WHITELISTED);
   }
 
   /**
    * @dev add addresses to the whitelist
-   * @param addrs addresses
+   * @param _addrs addresses
    * @return true if at least one address was added to the whitelist,
    * false if all addresses were already in the whitelist
    */
-  function addAddressesToWhitelist(address[] addrs)
+  function addAddressesToWhitelist(address[] _addrs)
     onlyOwner
     public
   {
-    for (uint256 i = 0; i < addrs.length; i++) {
-      addAddressToWhitelist(addrs[i]);
+    for (uint256 i = 0; i < _addrs.length; i++) {
+      addAddressToWhitelist(_addrs[i]);
     }
   }
 
   /**
    * @dev remove an address from the whitelist
-   * @param addr address
+   * @param _addr address
    * @return true if the address was removed from the whitelist,
    * false if the address wasn't in the whitelist in the first place
    */
-  function removeAddressFromWhitelist(address addr)
+  function removeAddressFromWhitelist(address _addr)
     onlyOwner
     public
   {
-    removeRole(addr, ROLE_WHITELISTED);
-    emit WhitelistedAddressRemoved(addr);
+    removeRole(_addr, ROLE_WHITELISTED);
+    emit WhitelistedAddressRemoved(_addr);
   }
 
   /**
    * @dev remove addresses from the whitelist
-   * @param addrs addresses
+   * @param _addrs addresses
    * @return true if at least one address was removed from the whitelist,
    * false if all addresses weren't in the whitelist in the first place
    */
-  function removeAddressesFromWhitelist(address[] addrs)
+  function removeAddressesFromWhitelist(address[] _addrs)
     onlyOwner
     public
   {
-    for (uint256 i = 0; i < addrs.length; i++) {
-      removeAddressFromWhitelist(addrs[i]);
+    for (uint256 i = 0; i < _addrs.length; i++) {
+      removeAddressFromWhitelist(_addrs[i]);
     }
   }
 

--- a/contracts/access/Whitelist.sol
+++ b/contracts/access/Whitelist.sol
@@ -14,86 +14,77 @@ contract Whitelist is Ownable, RBAC {
   string public constant ROLE_WHITELISTED = "whitelist";
 
   /**
-   * @dev Throws if called by any account that's not whitelisted.
-   * @dev kept as `onlyWhitelisted` for backwards compatibility
-   * @dev use isWhitelisted(address) and pass in msg.sender for more readable code
+   * @dev Throws if operator is not whitelisted.
+   * @param _operator address
    */
-  modifier onlyWhitelisted() {
-    checkRole(msg.sender, ROLE_WHITELISTED);
-    _;
-  }
-
-  /**
-   * @dev Throws if beneficiary is not whitelisted.
-   */
-  modifier isWhitelisted(address _beneficiary) {
-    checkRole(_beneficiary, ROLE_WHITELISTED);
+  modifier onlyIfWhitelisted(address _operator) {
+    checkRole(_operator, ROLE_WHITELISTED);
     _;
   }
 
   /**
    * @dev add an address to the whitelist
-   * @param _addr address
+   * @param _operator address
    * @return true if the address was added to the whitelist, false if the address was already in the whitelist
    */
-  function addAddressToWhitelist(address _addr)
+  function addAddressToWhitelist(address _operator)
     onlyOwner
     public
   {
-    addRole(_addr, ROLE_WHITELISTED);
+    addRole(_operator, ROLE_WHITELISTED);
   }
 
   /**
    * @dev getter to determine if address is in whitelist
    */
-  function whitelist(address _addr)
+  function whitelist(address _operator)
     public
     view
     returns (bool)
   {
-    return hasRole(_addr, ROLE_WHITELISTED);
+    return hasRole(_operator, ROLE_WHITELISTED);
   }
 
   /**
    * @dev add addresses to the whitelist
-   * @param _addrs addresses
+   * @param _operators addresses
    * @return true if at least one address was added to the whitelist,
    * false if all addresses were already in the whitelist
    */
-  function addAddressesToWhitelist(address[] _addrs)
+  function addAddressesToWhitelist(address[] _operators)
     onlyOwner
     public
   {
-    for (uint256 i = 0; i < _addrs.length; i++) {
-      addAddressToWhitelist(_addrs[i]);
+    for (uint256 i = 0; i < _operators.length; i++) {
+      addAddressToWhitelist(_operators[i]);
     }
   }
 
   /**
    * @dev remove an address from the whitelist
-   * @param _addr address
+   * @param _operator address
    * @return true if the address was removed from the whitelist,
    * false if the address wasn't in the whitelist in the first place
    */
-  function removeAddressFromWhitelist(address _addr)
+  function removeAddressFromWhitelist(address _operator)
     onlyOwner
     public
   {
-    removeRole(_addr, ROLE_WHITELISTED);
+    removeRole(_operator, ROLE_WHITELISTED);
   }
 
   /**
    * @dev remove addresses from the whitelist
-   * @param _addrs addresses
+   * @param _operators addresses
    * @return true if at least one address was removed from the whitelist,
    * false if all addresses weren't in the whitelist in the first place
    */
-  function removeAddressesFromWhitelist(address[] _addrs)
+  function removeAddressesFromWhitelist(address[] _operators)
     onlyOwner
     public
   {
-    for (uint256 i = 0; i < _addrs.length; i++) {
-      removeAddressFromWhitelist(_addrs[i]);
+    for (uint256 i = 0; i < _operators.length; i++) {
+      removeAddressFromWhitelist(_operators[i]);
     }
   }
 

--- a/contracts/access/Whitelist.sol
+++ b/contracts/access/Whitelist.sol
@@ -11,9 +11,6 @@ import "../ownership/rbac/RBAC.sol";
  * This simplifies the implementation of "user permissions".
  */
 contract Whitelist is Ownable, RBAC {
-  event WhitelistedAddressAdded(address addr);
-  event WhitelistedAddressRemoved(address addr);
-
   string public constant ROLE_WHITELISTED = "whitelist";
 
   /**
@@ -43,7 +40,6 @@ contract Whitelist is Ownable, RBAC {
     public
   {
     addRole(_addr, ROLE_WHITELISTED);
-    emit WhitelistedAddressAdded(_addr);
   }
 
   /**
@@ -83,7 +79,6 @@ contract Whitelist is Ownable, RBAC {
     public
   {
     removeRole(_addr, ROLE_WHITELISTED);
-    emit WhitelistedAddressRemoved(_addr);
   }
 
   /**

--- a/contracts/access/Whitelist.sol
+++ b/contracts/access/Whitelist.sol
@@ -16,6 +16,7 @@ contract Whitelist is Ownable, RBAC {
   /**
    * @dev Throws if called by any account that's not whitelisted.
    * @dev kept as `onlyWhitelisted` for backwards compatibility
+   * @dev use isWhitelisted(address) and pass in msg.sender for more readable code
    */
   modifier onlyWhitelisted() {
     checkRole(msg.sender, ROLE_WHITELISTED);

--- a/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
@@ -1,51 +1,16 @@
 pragma solidity ^0.4.24;
 
 import "../Crowdsale.sol";
+import "../../ownership/Whitelist.sol";
 import "../../ownership/Ownable.sol";
 
 
 /**
  * @title WhitelistedCrowdsale
  * @dev Crowdsale in which only whitelisted users can contribute.
+ * @dev (using explicit Ownable inheritance even though Whitelist already inherits)
  */
-contract WhitelistedCrowdsale is Crowdsale, Ownable {
-
-  mapping(address => bool) public whitelist;
-
-  /**
-   * @dev Reverts if beneficiary is not whitelisted. Can be used when extending this contract.
-   */
-  modifier isWhitelisted(address _beneficiary) {
-    require(whitelist[_beneficiary]);
-    _;
-  }
-
-  /**
-   * @dev Adds single address to whitelist.
-   * @param _beneficiary Address to be added to the whitelist
-   */
-  function addToWhitelist(address _beneficiary) external onlyOwner {
-    whitelist[_beneficiary] = true;
-  }
-
-  /**
-   * @dev Adds list of addresses to whitelist. Not overloaded due to limitations with truffle testing.
-   * @param _beneficiaries Addresses to be added to the whitelist
-   */
-  function addManyToWhitelist(address[] _beneficiaries) external onlyOwner {
-    for (uint256 i = 0; i < _beneficiaries.length; i++) {
-      whitelist[_beneficiaries[i]] = true;
-    }
-  }
-
-  /**
-   * @dev Removes single address from whitelist.
-   * @param _beneficiary Address to be removed to the whitelist
-   */
-  function removeFromWhitelist(address _beneficiary) external onlyOwner {
-    whitelist[_beneficiary] = false;
-  }
-
+contract WhitelistedCrowdsale is Ownable, Whitelist, Crowdsale {
   /**
    * @dev Extend parent behavior requiring beneficiary to be in whitelist.
    * @param _beneficiary Token beneficiary
@@ -55,8 +20,8 @@ contract WhitelistedCrowdsale is Crowdsale, Ownable {
     address _beneficiary,
     uint256 _weiAmount
   )
-    internal
     isWhitelisted(_beneficiary)
+    internal
   {
     super._preValidatePurchase(_beneficiary, _weiAmount);
   }

--- a/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
 import "../Crowdsale.sol";
-import "../../ownership/Whitelist.sol";
+import "../../access/Whitelist.sol";
 
 
 /**

--- a/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
@@ -2,15 +2,13 @@ pragma solidity ^0.4.24;
 
 import "../Crowdsale.sol";
 import "../../ownership/Whitelist.sol";
-import "../../ownership/Ownable.sol";
 
 
 /**
  * @title WhitelistedCrowdsale
  * @dev Crowdsale in which only whitelisted users can contribute.
- * @dev (using explicit Ownable inheritance even though Whitelist already inherits)
  */
-contract WhitelistedCrowdsale is Ownable, Whitelist, Crowdsale {
+contract WhitelistedCrowdsale is Whitelist, Crowdsale {
   /**
    * @dev Extend parent behavior requiring beneficiary to be in whitelist.
    * @param _beneficiary Token beneficiary
@@ -20,7 +18,7 @@ contract WhitelistedCrowdsale is Ownable, Whitelist, Crowdsale {
     address _beneficiary,
     uint256 _weiAmount
   )
-    isWhitelisted(_beneficiary)
+    onlyIfWhitelisted(_beneficiary)
     internal
   {
     super._preValidatePurchase(_beneficiary, _weiAmount);

--- a/contracts/mocks/WhitelistMock.sol
+++ b/contracts/mocks/WhitelistMock.sol
@@ -6,6 +6,7 @@ contract WhitelistMock is Whitelist {
 
   function onlyWhitelistedCanDoThis()
     onlyWhitelisted
+    isWhitelisted(msg.sender)
     view
     external
   {

--- a/contracts/mocks/WhitelistMock.sol
+++ b/contracts/mocks/WhitelistMock.sol
@@ -5,8 +5,7 @@ import "../access/Whitelist.sol";
 contract WhitelistMock is Whitelist {
 
   function onlyWhitelistedCanDoThis()
-    onlyWhitelisted
-    isWhitelisted(msg.sender)
+    onlyIfWhitelisted(msg.sender)
     view
     external
   {

--- a/contracts/mocks/WhitelistedCrowdsaleImpl.sol
+++ b/contracts/mocks/WhitelistedCrowdsaleImpl.sol
@@ -2,18 +2,18 @@ pragma solidity ^0.4.24;
 
 import "../token/ERC20/ERC20.sol";
 import "../crowdsale/validation/WhitelistedCrowdsale.sol";
+import "../crowdsale/Crowdsale.sol";
 
 
-contract WhitelistedCrowdsaleImpl is WhitelistedCrowdsale {
+contract WhitelistedCrowdsaleImpl is Crowdsale, WhitelistedCrowdsale {
 
   constructor (
     uint256 _rate,
     address _wallet,
     ERC20 _token
   )
-    public
     Crowdsale(_rate, _wallet, _token)
+    public
   {
   }
-
 }

--- a/contracts/ownership/rbac/RBAC.sol
+++ b/contracts/ownership/rbac/RBAC.sol
@@ -19,83 +19,83 @@ contract RBAC {
 
   mapping (string => Roles.Role) private roles;
 
-  event RoleAdded(address addr, string roleName);
-  event RoleRemoved(address addr, string roleName);
+  event RoleAdded(address indexed _operator, string _role);
+  event RoleRemoved(address indexed _operator, string _role);
 
   /**
    * @dev reverts if addr does not have role
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _operator address
+   * @param _role the name of the role
    * // reverts
    */
-  function checkRole(address addr, string roleName)
+  function checkRole(address _operator, string _role)
     view
     public
   {
-    roles[roleName].check(addr);
+    roles[_role].check(_operator);
   }
 
   /**
    * @dev determine if addr has role
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _operator address
+   * @param _role the name of the role
    * @return bool
    */
-  function hasRole(address addr, string roleName)
+  function hasRole(address _operator, string _role)
     view
     public
     returns (bool)
   {
-    return roles[roleName].has(addr);
+    return roles[_role].has(_operator);
   }
 
   /**
    * @dev add a role to an address
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _operator address
+   * @param _role the name of the role
    */
-  function addRole(address addr, string roleName)
+  function addRole(address _operator, string _role)
     internal
   {
-    roles[roleName].add(addr);
-    emit RoleAdded(addr, roleName);
+    roles[_role].add(_operator);
+    emit RoleAdded(_operator, _role);
   }
 
   /**
    * @dev remove a role from an address
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _operator address
+   * @param _role the name of the role
    */
-  function removeRole(address addr, string roleName)
+  function removeRole(address _operator, string _role)
     internal
   {
-    roles[roleName].remove(addr);
-    emit RoleRemoved(addr, roleName);
+    roles[_role].remove(_operator);
+    emit RoleRemoved(_operator, _role);
   }
 
   /**
    * @dev modifier to scope access to a single role (uses msg.sender as addr)
-   * @param roleName the name of the role
+   * @param _role the name of the role
    * // reverts
    */
-  modifier onlyRole(string roleName)
+  modifier onlyRole(string _role)
   {
-    checkRole(msg.sender, roleName);
+    checkRole(msg.sender, _role);
     _;
   }
 
   /**
    * @dev modifier to scope access to a set of roles (uses msg.sender as addr)
-   * @param roleNames the names of the roles to scope access to
+   * @param _roles the names of the roles to scope access to
    * // reverts
    *
    * @TODO - when solidity supports dynamic arrays as arguments to modifiers, provide this
    *  see: https://github.com/ethereum/solidity/issues/2467
    */
-  // modifier onlyRoles(string[] roleNames) {
+  // modifier onlyRoles(string[] _roles) {
   //     bool hasAnyRole = false;
-  //     for (uint8 i = 0; i < roleNames.length; i++) {
-  //         if (hasRole(msg.sender, roleNames[i])) {
+  //     for (uint8 i = 0; i < _roles.length; i++) {
+  //         if (hasRole(msg.sender, _roles[i])) {
   //             hasAnyRole = true;
   //             break;
   //         }

--- a/contracts/ownership/rbac/RBAC.sol
+++ b/contracts/ownership/rbac/RBAC.sol
@@ -19,8 +19,8 @@ contract RBAC {
 
   mapping (string => Roles.Role) private roles;
 
-  event RoleAdded(address indexed _operator, string _role);
-  event RoleRemoved(address indexed _operator, string _role);
+  event RoleAdded(address indexed operator, string role);
+  event RoleRemoved(address indexed operator, string role);
 
   /**
    * @dev reverts if addr does not have role

--- a/test/crowdsale/WhitelistedCrowdsale.test.js
+++ b/test/crowdsale/WhitelistedCrowdsale.test.js
@@ -24,13 +24,13 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
 
     describe('accepting payments', function () {
       it('should accept payments to whitelisted (from whichever buyers)', async function () {
-        await this.crowdsale.send(value, { from: authorized }).should.be.fulfilled;
+        await this.crowdsale.sendTransaction({ value, from: authorized }).should.be.fulfilled;
         await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
         await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized }).should.be.fulfilled;
       });
 
       it('should reject payments to not whitelisted (from whichever buyers)', async function () {
-        await this.crowdsale.send(value).should.be.rejected;
+        await this.crowdsale.sendTransaction({ value, from: unauthorized }).should.be.rejected;
         await this.crowdsale.buyTokens(unauthorized, { value: value, from: unauthorized }).should.be.rejected;
         await this.crowdsale.buyTokens(unauthorized, { value: value, from: authorized }).should.be.rejected;
       });

--- a/test/crowdsale/WhitelistedCrowdsale.test.js
+++ b/test/crowdsale/WhitelistedCrowdsale.test.js
@@ -19,11 +19,12 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
       this.token = await SimpleToken.new();
       this.crowdsale = await WhitelistedCrowdsale.new(rate, wallet, this.token.address);
       await this.token.transfer(this.crowdsale.address, tokenSupply);
-      await this.crowdsale.addToWhitelist(authorized);
+      await this.crowdsale.addAddressToWhitelist(authorized);
     });
 
     describe('accepting payments', function () {
       it('should accept payments to whitelisted (from whichever buyers)', async function () {
+        await this.crowdsale.send(value, { from: authorized }).should.be.fulfilled;
         await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
         await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized }).should.be.fulfilled;
       });
@@ -35,7 +36,7 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
       });
 
       it('should reject payments to addresses removed from whitelist', async function () {
-        await this.crowdsale.removeFromWhitelist(authorized);
+        await this.crowdsale.removeAddressFromWhitelist(authorized);
         await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.rejected;
       });
     });
@@ -55,7 +56,7 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
       this.token = await SimpleToken.new();
       this.crowdsale = await WhitelistedCrowdsale.new(rate, wallet, this.token.address);
       await this.token.transfer(this.crowdsale.address, tokenSupply);
-      await this.crowdsale.addManyToWhitelist([authorized, anotherAuthorized]);
+      await this.crowdsale.addAddressesToWhitelist([authorized, anotherAuthorized]);
     });
 
     describe('accepting payments', function () {
@@ -73,7 +74,7 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
       });
 
       it('should reject payments to addresses removed from whitelist', async function () {
-        await this.crowdsale.removeFromWhitelist(anotherAuthorized);
+        await this.crowdsale.removeAddressFromWhitelist(anotherAuthorized);
         await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
         await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: authorized }).should.be.rejected;
       });

--- a/test/helpers/expectEvent.js
+++ b/test/helpers/expectEvent.js
@@ -1,14 +1,18 @@
-const assert = require('chai').assert;
+const should = require('chai').should();
 
-const inLogs = async (logs, eventName) => {
+const inLogs = async (logs, eventName, eventArgs = {}) => {
   const event = logs.find(e => e.event === eventName);
-  assert.exists(event);
+  should.exist(event);
+  for (const [k, v] of Object.entries(eventArgs)) {
+    should.exist(event.args[k]);
+    event.args[k].should.eq(v);
+  }
   return event;
 };
 
-const inTransaction = async (tx, eventName) => {
+const inTransaction = async (tx, eventName, eventArgs = {}) => {
   const { logs } = await tx;
-  return inLogs(logs, eventName);
+  return inLogs(logs, eventName, eventArgs);
 };
 
 module.exports = {

--- a/test/ownership/Whitelist.test.js
+++ b/test/ownership/Whitelist.test.js
@@ -8,8 +8,6 @@ require('chai')
   .should();
 
 contract('Whitelist', function (accounts) {
-  let mock;
-
   const [
     owner,
     whitelistedAddress1,
@@ -20,73 +18,78 @@ contract('Whitelist', function (accounts) {
   const whitelistedAddresses = [whitelistedAddress1, whitelistedAddress2];
 
   before(async function () {
-    mock = await WhitelistMock.new();
+    this.mock = await WhitelistMock.new();
+    this.role = await this.mock.ROLE_WHITELISTED();
   });
 
-  context('in normal conditions', () => {
+  context('in normal conditions', function () {
     it('should add address to the whitelist', async function () {
       await expectEvent.inTransaction(
-        mock.addAddressToWhitelist(whitelistedAddress1, { from: owner }),
-        'RoleAdded'
+        this.mock.addAddressToWhitelist(whitelistedAddress1, { from: owner }),
+        'RoleAdded',
+        { _role: this.role },
       );
-      const isWhitelisted = await mock.whitelist(whitelistedAddress1);
+      const isWhitelisted = await this.mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(true);
     });
 
     it('should add addresses to the whitelist', async function () {
       await expectEvent.inTransaction(
-        mock.addAddressesToWhitelist(whitelistedAddresses, { from: owner }),
-        'RoleAdded'
+        this.mock.addAddressesToWhitelist(whitelistedAddresses, { from: owner }),
+        'RoleAdded',
+        { _role: this.role },
       );
       for (let addr of whitelistedAddresses) {
-        const isWhitelisted = await mock.whitelist(addr);
+        const isWhitelisted = await this.mock.whitelist(addr);
         isWhitelisted.should.be.equal(true);
       }
     });
 
     it('should remove address from the whitelist', async function () {
       await expectEvent.inTransaction(
-        mock.removeAddressFromWhitelist(whitelistedAddress1, { from: owner }),
-        'RoleRemoved'
+        this.mock.removeAddressFromWhitelist(whitelistedAddress1, { from: owner }),
+        'RoleRemoved',
+        { _role: this.role },
       );
-      let isWhitelisted = await mock.whitelist(whitelistedAddress1);
+      let isWhitelisted = await this.mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(false);
     });
 
     it('should remove addresses from the the whitelist', async function () {
       await expectEvent.inTransaction(
-        mock.removeAddressesFromWhitelist(whitelistedAddresses, { from: owner }),
-        'RoleRemoved'
+        this.mock.removeAddressesFromWhitelist(whitelistedAddresses, { from: owner }),
+        'RoleRemoved',
+        { _role: this.role },
       );
       for (let addr of whitelistedAddresses) {
-        const isWhitelisted = await mock.whitelist(addr);
+        const isWhitelisted = await this.mock.whitelist(addr);
         isWhitelisted.should.be.equal(false);
       }
     });
 
-    it('should allow whitelisted address to call #onlyWhitelistedCanDoThis', async () => {
-      await mock.addAddressToWhitelist(whitelistedAddress1, { from: owner });
-      await mock.onlyWhitelistedCanDoThis({ from: whitelistedAddress1 })
+    it('should allow whitelisted address to call #onlyWhitelistedCanDoThis', async function () {
+      await this.mock.addAddressToWhitelist(whitelistedAddress1, { from: owner });
+      await this.mock.onlyWhitelistedCanDoThis({ from: whitelistedAddress1 })
         .should.be.fulfilled;
     });
   });
 
-  context('in adversarial conditions', () => {
-    it('should not allow "anyone" to add to the whitelist', async () => {
+  context('in adversarial conditions', function () {
+    it('should not allow "anyone" to add to the whitelist', async function () {
       await expectThrow(
-        mock.addAddressToWhitelist(whitelistedAddress1, { from: anyone })
+        this.mock.addAddressToWhitelist(whitelistedAddress1, { from: anyone })
       );
     });
 
-    it('should not allow "anyone" to remove from the whitelist', async () => {
+    it('should not allow "anyone" to remove from the whitelist', async function () {
       await expectThrow(
-        mock.removeAddressFromWhitelist(whitelistedAddress1, { from: anyone })
+        this.mock.removeAddressFromWhitelist(whitelistedAddress1, { from: anyone })
       );
     });
 
-    it('should not allow "anyone" to call #onlyWhitelistedCanDoThis', async () => {
+    it('should not allow "anyone" to call #onlyWhitelistedCanDoThis', async function () {
       await expectThrow(
-        mock.onlyWhitelistedCanDoThis({ from: anyone })
+        this.mock.onlyWhitelistedCanDoThis({ from: anyone })
       );
     });
   });

--- a/test/ownership/Whitelist.test.js
+++ b/test/ownership/Whitelist.test.js
@@ -27,7 +27,7 @@ contract('Whitelist', function (accounts) {
       await expectEvent.inTransaction(
         this.mock.addAddressToWhitelist(whitelistedAddress1, { from: owner }),
         'RoleAdded',
-        { _role: this.role },
+        { role: this.role },
       );
       const isWhitelisted = await this.mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(true);
@@ -37,7 +37,7 @@ contract('Whitelist', function (accounts) {
       await expectEvent.inTransaction(
         this.mock.addAddressesToWhitelist(whitelistedAddresses, { from: owner }),
         'RoleAdded',
-        { _role: this.role },
+        { role: this.role },
       );
       for (let addr of whitelistedAddresses) {
         const isWhitelisted = await this.mock.whitelist(addr);
@@ -49,7 +49,7 @@ contract('Whitelist', function (accounts) {
       await expectEvent.inTransaction(
         this.mock.removeAddressFromWhitelist(whitelistedAddress1, { from: owner }),
         'RoleRemoved',
-        { _role: this.role },
+        { role: this.role },
       );
       let isWhitelisted = await this.mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(false);
@@ -59,7 +59,7 @@ contract('Whitelist', function (accounts) {
       await expectEvent.inTransaction(
         this.mock.removeAddressesFromWhitelist(whitelistedAddresses, { from: owner }),
         'RoleRemoved',
-        { _role: this.role },
+        { role: this.role },
       );
       for (let addr of whitelistedAddresses) {
         const isWhitelisted = await this.mock.whitelist(addr);

--- a/test/ownership/Whitelist.test.js
+++ b/test/ownership/Whitelist.test.js
@@ -27,7 +27,7 @@ contract('Whitelist', function (accounts) {
     it('should add address to the whitelist', async function () {
       await expectEvent.inTransaction(
         mock.addAddressToWhitelist(whitelistedAddress1, { from: owner }),
-        'WhitelistedAddressAdded'
+        'RoleAdded'
       );
       const isWhitelisted = await mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(true);
@@ -36,7 +36,7 @@ contract('Whitelist', function (accounts) {
     it('should add addresses to the whitelist', async function () {
       await expectEvent.inTransaction(
         mock.addAddressesToWhitelist(whitelistedAddresses, { from: owner }),
-        'WhitelistedAddressAdded'
+        'RoleAdded'
       );
       for (let addr of whitelistedAddresses) {
         const isWhitelisted = await mock.whitelist(addr);
@@ -47,7 +47,7 @@ contract('Whitelist', function (accounts) {
     it('should remove address from the whitelist', async function () {
       await expectEvent.inTransaction(
         mock.removeAddressFromWhitelist(whitelistedAddress1, { from: owner }),
-        'WhitelistedAddressRemoved'
+        'RoleRemoved'
       );
       let isWhitelisted = await mock.whitelist(whitelistedAddress1);
       isWhitelisted.should.be.equal(false);
@@ -56,7 +56,7 @@ contract('Whitelist', function (accounts) {
     it('should remove addresses from the the whitelist', async function () {
       await expectEvent.inTransaction(
         mock.removeAddressesFromWhitelist(whitelistedAddresses, { from: owner }),
-        'WhitelistedAddressRemoved'
+        'RoleRemoved'
       );
       for (let addr of whitelistedAddresses) {
         const isWhitelisted = await mock.whitelist(addr);


### PR DESCRIPTION
# 🚀 Description

found the issue! truffle-contract's send() function is bad software and doesn't accept an options hash like every other method in the library, so the sender of that transaction is always the default account, which is not authorized and therefore fails the whitelist check.

I also took this opportunity to refactor WhitelistedCrowdsale, Whitelist.sol, and RBAC.sol to get them up to date with various best practices since they were made.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
