### PR TITLE
Remove Solidity 0.4.24 abi.encodePacked warning for keccak256

### DIFF
--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -69,8 +69,10 @@ library ECRecovery {
     // 32 is the length in bytes of hash,
     // enforced by the type signature above
     return keccak256(
-      "\x19Ethereum Signed Message:\n32",
-      hash
+      abi.encodePacked(
+        "\x19Ethereum Signed Message:\n32",
+        hash
+      )
     );
   }
 }

--- a/contracts/MerkleProof.sol
+++ b/contracts/MerkleProof.sol
@@ -30,10 +30,10 @@ library MerkleProof {
 
       if (computedHash < proofElement) {
         // Hash(current computed hash + current element of the proof)
-        computedHash = keccak256(computedHash, proofElement);
+        computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
       } else {
         // Hash(current element of the proof + current computed hash)
-        computedHash = keccak256(proofElement, computedHash);
+        computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
       }
     }
 

--- a/contracts/access/SignatureBouncer.sol
+++ b/contracts/access/SignatureBouncer.sol
@@ -99,7 +99,7 @@ contract SignatureBouncer is Ownable, RBAC {
     returns (bool)
   {
     return isValidDataHash(
-      keccak256(address(this), _address),
+      keccak256(abi.encodePacked(address(this), _address)),
       _sig
     );
   }
@@ -118,7 +118,7 @@ contract SignatureBouncer is Ownable, RBAC {
       data[i] = msg.data[i];
     }
     return isValidDataHash(
-      keccak256(address(this), _address, data),
+      keccak256(abi.encodePacked(address(this), _address, data)),
       _sig
     );
   }
@@ -139,7 +139,7 @@ contract SignatureBouncer is Ownable, RBAC {
       data[i] = msg.data[i];
     }
     return isValidDataHash(
-      keccak256(address(this), _address, data),
+      keccak256(abi.encodePacked(address(this), _address, data)),
       _sig
     );
   }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Removes Solidity 0.4.24 keccak256 warning `Warning: This function only accepts a single "bytes" argument. Please use "abi.encodePacked(...)" or a similar function to encode the data.`

<!-- 2. Describe the changes introduced in this pull request -->

Seen as an added warning for 0.4.24 here:
https://github.com/ethereum/solidity/releases

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
    (The linter fixes files other than the ones I've touched. It has no issues with the files I changed)