### PR TITLE
Update the use of keccak256 and call().

### DIFF
--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -24,11 +24,10 @@ contract ReentrancyMock is ReentrancyGuard {
   }
 
   function countThisRecursive(uint256 n) public nonReentrant {
-    bytes4 func = bytes4(keccak256("countThisRecursive(uint256)"));
     if (n > 0) {
       count();
       // solium-disable-next-line security/no-low-level-calls
-      bool result = address(this).call(func, n - 1);
+      bool result = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
       require(result == true);
     }
   }


### PR DESCRIPTION
# 🚀 Description

Update how `.call()` and `keccak256()` will be required to be used starting from Solidity 0.5.0.