### PR TITLE
Remove redundant modifiers from ERC721 safeTransferFrom (#1029)

### DIFF
--- a/contracts/token/ERC721/ERC721BasicToken.sol
+++ b/contracts/token/ERC721/ERC721BasicToken.sol
@@ -52,24 +52,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
   // Mapping from owner to operator approvals
   mapping (address => mapping (address => bool)) internal operatorApprovals;
 
-  /**
-   * @dev Guarantees msg.sender is owner of the given token
-   * @param _tokenId uint256 ID of the token to validate its ownership belongs to msg.sender
-   */
-  modifier onlyOwnerOf(uint256 _tokenId) {
-    require(ownerOf(_tokenId) == msg.sender);
-    _;
-  }
-
-  /**
-   * @dev Checks msg.sender can transfer a token, by being owner, approved, or operator
-   * @param _tokenId uint256 ID of the token to validate
-   */
-  modifier canTransfer(uint256 _tokenId) {
-    require(isApprovedOrOwner(msg.sender, _tokenId));
-    _;
-  }
-
   constructor()
     public
   {
@@ -178,8 +160,8 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     uint256 _tokenId
   )
     public
-    canTransfer(_tokenId)
   {
+    require(isApprovedOrOwner(msg.sender, _tokenId));
     require(_from != address(0));
     require(_to != address(0));
 
@@ -208,7 +190,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     uint256 _tokenId
   )
     public
-    canTransfer(_tokenId)
   {
     // solium-disable-next-line arg-overflow
     safeTransferFrom(_from, _to, _tokenId, "");
@@ -233,7 +214,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     bytes _data
   )
     public
-    canTransfer(_tokenId)
   {
     transferFrom(_from, _to, _tokenId);
     // solium-disable-next-line arg-overflow


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #1029 

# 🚀 Description

Removes modifiers from `ERC721BasicToken.sol`.  `onlyOwnerOf` was not actually being used, and `canTransfer` has been removed for efficiency reasons.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
