### PR TITLE
Optimize ERC721 (depends on #1030)

### DIFF
--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -5,6 +5,8 @@ import "../../token/ERC20/ERC20.sol";
 import "../../token/ERC20/ERC20Basic.sol";
 import "../../token/ERC20/SafeERC20.sol";
 import "../../math/SafeMath.sol";
+
+
 /**
  * @title AllowanceCrowdsale
  * @dev Extension of Crowdsale where tokens are held by a wallet, which approves an allowance to the crowdsale.

--- a/contracts/mocks/ERC721BasicTokenMock.sol
+++ b/contracts/mocks/ERC721BasicTokenMock.sol
@@ -9,10 +9,24 @@ import "../token/ERC721/ERC721BasicToken.sol";
  */
 contract ERC721BasicTokenMock is ERC721BasicToken {
   function mint(address _to, uint256 _tokenId) public {
-    super._mint(_to, _tokenId);
+    require(_to != address(0));
+    require(!exists(_tokenId));
+
+    tokenOwner[_tokenId] = _to;
+    ownedTokensCount[_to] = ownedTokensCount[_to].add(1);
+    emit Transfer(address(0), _to, _tokenId);
   }
 
   function burn(uint256 _tokenId) public {
-    super._burn(ownerOf(_tokenId), _tokenId);
+    address _owner = ownerOf(_tokenId);
+    require(_owner != address(0));
+
+    if (tokenApprovals[_tokenId] != address(0)) {
+      tokenApprovals[_tokenId] = address(0);
+    }
+
+    tokenOwner[_tokenId] = address(0);
+    ownedTokensCount[_owner] = ownedTokensCount[_owner].sub(1);
+    emit Transfer(_owner, address(0), _tokenId);
   }
 }

--- a/contracts/mocks/ERC721TokenMock.sol
+++ b/contracts/mocks/ERC721TokenMock.sol
@@ -14,11 +14,55 @@ contract ERC721TokenMock is ERC721Token {
   { }
 
   function mint(address _to, uint256 _tokenId) public {
-    super._mint(_to, _tokenId);
+    require(_to != address(0));
+    require(!exists(_tokenId));
+
+    tokenOwner[_tokenId] = _to;
+    ownedTokensCount[_to] = ownedTokensCount[_to].add(1);
+
+    ownedTokensIndex[_tokenId] = ownedTokens[_to].length;
+    ownedTokens[_to].push(_tokenId);
+
+    allTokensIndex[_tokenId] = allTokens.length;
+    allTokens.push(_tokenId);
+
+    emit Transfer(address(0), _to, _tokenId);
   }
 
   function burn(uint256 _tokenId) public {
-    super._burn(ownerOf(_tokenId), _tokenId);
+    address _owner = ownerOf(_tokenId);
+    require(_owner != address(0));
+
+    if (tokenApprovals[_tokenId] != address(0)) {
+      tokenApprovals[_tokenId] = address(0);
+    }
+
+    tokenOwner[_tokenId] = address(0);
+    ownedTokensCount[_owner] = ownedTokensCount[_owner].sub(1);
+
+    uint256 removeOwnedTokenIndex = ownedTokensIndex[_tokenId];
+    uint256 lastOwnedTokenIndex = ownedTokens[_owner].length.sub(1);
+    uint256 lastOwnedToken = ownedTokens[_owner][lastOwnedTokenIndex];
+
+    ownedTokens[_owner][removeOwnedTokenIndex] = lastOwnedToken;
+    ownedTokens[_owner].length--;
+    ownedTokensIndex[_tokenId] = 0;
+    ownedTokensIndex[lastOwnedToken] = removeOwnedTokenIndex;
+
+    if (bytes(tokenURIs[_tokenId]).length != 0) {
+      delete tokenURIs[_tokenId];
+    }
+
+    uint256 removeAllTokenIndex = allTokensIndex[_tokenId];
+    uint256 lastAllTokenIndex = allTokens.length.sub(1);
+    uint256 lastAllToken = allTokens[lastAllTokenIndex];
+
+    allTokens[removeAllTokenIndex] = lastAllToken;
+    allTokens.length--;
+    allTokensIndex[_tokenId] = 0;
+    allTokensIndex[lastAllToken] = removeAllTokenIndex;
+
+    emit Transfer(_owner, address(0), _tokenId);
   }
 
   function setTokenURI(uint256 _tokenId, string _uri) public {

--- a/contracts/mocks/RBACCappedTokenMock.sol
+++ b/contracts/mocks/RBACCappedTokenMock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.24;
 import "../token/ERC20/RBACMintableToken.sol";
 import "../token/ERC20/CappedToken.sol";
 
+
 contract RBACCappedTokenMock is CappedToken, RBACMintableToken {
   constructor(
     uint256 _cap

--- a/contracts/mocks/WhitelistMock.sol
+++ b/contracts/mocks/WhitelistMock.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.24;
 
 import "../access/Whitelist.sol";
 
+
 contract WhitelistMock is Whitelist {
 
   function onlyWhitelistedCanDoThis()

--- a/contracts/token/ERC721/ERC721BasicToken.sol
+++ b/contracts/token/ERC721/ERC721BasicToken.sol
@@ -52,24 +52,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
   // Mapping from owner to operator approvals
   mapping (address => mapping (address => bool)) internal operatorApprovals;
 
-  /**
-   * @dev Guarantees msg.sender is owner of the given token
-   * @param _tokenId uint256 ID of the token to validate its ownership belongs to msg.sender
-   */
-  modifier onlyOwnerOf(uint256 _tokenId) {
-    require(ownerOf(_tokenId) == msg.sender);
-    _;
-  }
-
-  /**
-   * @dev Checks msg.sender can transfer a token, by being owner, approved, or operator
-   * @param _tokenId uint256 ID of the token to validate
-   */
-  modifier canTransfer(uint256 _tokenId) {
-    require(isApprovedOrOwner(msg.sender, _tokenId));
-    _;
-  }
-
   constructor()
     public
   {
@@ -178,8 +160,8 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     uint256 _tokenId
   )
     public
-    canTransfer(_tokenId)
   {
+    require(isApprovedOrOwner(msg.sender, _tokenId));
     require(_from != address(0));
     require(_to != address(0));
 
@@ -208,7 +190,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     uint256 _tokenId
   )
     public
-    canTransfer(_tokenId)
   {
     // solium-disable-next-line arg-overflow
     safeTransferFrom(_from, _to, _tokenId, "");
@@ -233,7 +214,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     bytes _data
   )
     public
-    canTransfer(_tokenId)
   {
     transferFrom(_from, _to, _tokenId);
     // solium-disable-next-line arg-overflow

--- a/contracts/token/ERC721/ERC721BasicToken.sol
+++ b/contracts/token/ERC721/ERC721BasicToken.sol
@@ -161,13 +161,25 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
   )
     public
   {
-    require(isApprovedOrOwner(msg.sender, _tokenId));
-    require(_from != address(0));
+    address owner = ownerOf(_tokenId);
+    require(_from == owner);
     require(_to != address(0));
 
-    clearApproval(_from, _tokenId);
-    removeTokenFrom(_from, _tokenId);
-    addTokenTo(_to, _tokenId);
+    address spender = msg.sender;
+    require(
+      spender == owner ||
+      isApprovedForAll(owner, spender) ||
+      getApproved(_tokenId) == spender
+    );
+
+    if (tokenApprovals[_tokenId] != address(0)) {
+      tokenApprovals[_tokenId] = address(0);
+      emit Approval(owner, address(0), _tokenId);
+    }
+
+    tokenOwner[_tokenId] = _to;
+    ownedTokensCount[_from] = ownedTokensCount[_from].sub(1);
+    ownedTokensCount[_to] = ownedTokensCount[_to].add(1);
 
     emit Transfer(_from, _to, _tokenId);
   }

--- a/contracts/token/ERC721/ERC721BasicToken.sol
+++ b/contracts/token/ERC721/ERC721BasicToken.sol
@@ -167,6 +167,9 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
 
     address spender = msg.sender;
     require(
+    // Disable solium check because of
+    // https://github.com/duaraghav8/Solium/issues/175
+    // solium-disable-next-line operator-whitespace
       spender == owner ||
       isApprovedForAll(owner, spender) ||
       getApproved(_tokenId) == spender
@@ -174,7 +177,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
 
     if (tokenApprovals[_tokenId] != address(0)) {
       tokenApprovals[_tokenId] = address(0);
-      emit Approval(owner, address(0), _tokenId);
     }
 
     tokenOwner[_tokenId] = _to;
@@ -230,90 +232,6 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     transferFrom(_from, _to, _tokenId);
     // solium-disable-next-line arg-overflow
     require(checkAndCallSafeTransfer(_from, _to, _tokenId, _data));
-  }
-
-  /**
-   * @dev Returns whether the given spender can transfer a given token ID
-   * @param _spender address of the spender to query
-   * @param _tokenId uint256 ID of the token to be transferred
-   * @return bool whether the msg.sender is approved for the given token ID,
-   *  is an operator of the owner, or is the owner of the token
-   */
-  function isApprovedOrOwner(
-    address _spender,
-    uint256 _tokenId
-  )
-    internal
-    view
-    returns (bool)
-  {
-    address owner = ownerOf(_tokenId);
-    // Disable solium check because of
-    // https://github.com/duaraghav8/Solium/issues/175
-    // solium-disable-next-line operator-whitespace
-    return (
-      _spender == owner ||
-      getApproved(_tokenId) == _spender ||
-      isApprovedForAll(owner, _spender)
-    );
-  }
-
-  /**
-   * @dev Internal function to mint a new token
-   * Reverts if the given token ID already exists
-   * @param _to The address that will own the minted token
-   * @param _tokenId uint256 ID of the token to be minted by the msg.sender
-   */
-  function _mint(address _to, uint256 _tokenId) internal {
-    require(_to != address(0));
-    addTokenTo(_to, _tokenId);
-    emit Transfer(address(0), _to, _tokenId);
-  }
-
-  /**
-   * @dev Internal function to burn a specific token
-   * Reverts if the token does not exist
-   * @param _tokenId uint256 ID of the token being burned by the msg.sender
-   */
-  function _burn(address _owner, uint256 _tokenId) internal {
-    clearApproval(_owner, _tokenId);
-    removeTokenFrom(_owner, _tokenId);
-    emit Transfer(_owner, address(0), _tokenId);
-  }
-
-  /**
-   * @dev Internal function to clear current approval of a given token ID
-   * Reverts if the given address is not indeed the owner of the token
-   * @param _owner owner of the token
-   * @param _tokenId uint256 ID of the token to be transferred
-   */
-  function clearApproval(address _owner, uint256 _tokenId) internal {
-    require(ownerOf(_tokenId) == _owner);
-    if (tokenApprovals[_tokenId] != address(0)) {
-      tokenApprovals[_tokenId] = address(0);
-    }
-  }
-
-  /**
-   * @dev Internal function to add a token ID to the list of a given address
-   * @param _to address representing the new owner of the given token ID
-   * @param _tokenId uint256 ID of the token to be added to the tokens list of the given address
-   */
-  function addTokenTo(address _to, uint256 _tokenId) internal {
-    require(tokenOwner[_tokenId] == address(0));
-    tokenOwner[_tokenId] = _to;
-    ownedTokensCount[_to] = ownedTokensCount[_to].add(1);
-  }
-
-  /**
-   * @dev Internal function to remove a token ID from the list of a given address
-   * @param _from address representing the previous owner of the given token ID
-   * @param _tokenId uint256 ID of the token to be removed from the tokens list of the given address
-   */
-  function removeTokenFrom(address _from, uint256 _tokenId) internal {
-    require(ownerOf(_tokenId) == _from);
-    ownedTokensCount[_from] = ownedTokensCount[_from].sub(1);
-    tokenOwner[_tokenId] = address(0);
   }
 
   /**

--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -123,23 +123,16 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
   {
     super.transferFrom(_from, _to, _tokenId);
 
-    uint256 tokenIndex = ownedTokensIndex[_tokenId];
+    uint256 removeTokenIndex = ownedTokensIndex[_tokenId];
     uint256 lastTokenIndex = ownedTokens[_from].length.sub(1);
     uint256 lastToken = ownedTokens[_from][lastTokenIndex];
 
-    ownedTokens[_from][tokenIndex] = lastToken;
-    ownedTokens[_from][lastTokenIndex] = 0;
-    // Note that this will handle single-element arrays. In that case, both tokenIndex and lastTokenIndex are going to
-    // be zero. Then we can make sure that we will remove _tokenId from the ownedTokens list since we are first swapping
-    // the lastToken to the first position, and then dropping the element placed in the last position of the list
-
+    ownedTokens[_from][removeTokenIndex] = lastToken;
     ownedTokens[_from].length--;
-    ownedTokensIndex[_tokenId] = 0;
-    ownedTokensIndex[lastToken] = tokenIndex;
+    ownedTokensIndex[lastToken] = removeTokenIndex;
     
-    uint256 length = ownedTokens[_to].length;
     ownedTokens[_to].push(_tokenId);
-    ownedTokensIndex[_tokenId] = length;
+    ownedTokensIndex[_tokenId] = ownedTokens[_to].length - 1;
   }
   /**
    * @dev Gets the total amount of tokens stored by the contract
@@ -170,80 +163,4 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
     require(exists(_tokenId));
     tokenURIs[_tokenId] = _uri;
   }
-
-  /**
-   * @dev Internal function to add a token ID to the list of a given address
-   * @param _to address representing the new owner of the given token ID
-   * @param _tokenId uint256 ID of the token to be added to the tokens list of the given address
-   */
-  function addTokenTo(address _to, uint256 _tokenId) internal {
-    super.addTokenTo(_to, _tokenId);
-    uint256 length = ownedTokens[_to].length;
-    ownedTokens[_to].push(_tokenId);
-    ownedTokensIndex[_tokenId] = length;
-  }
-
-  /**
-   * @dev Internal function to remove a token ID from the list of a given address
-   * @param _from address representing the previous owner of the given token ID
-   * @param _tokenId uint256 ID of the token to be removed from the tokens list of the given address
-   */
-  function removeTokenFrom(address _from, uint256 _tokenId) internal {
-    super.removeTokenFrom(_from, _tokenId);
-
-    uint256 tokenIndex = ownedTokensIndex[_tokenId];
-    uint256 lastTokenIndex = ownedTokens[_from].length.sub(1);
-    uint256 lastToken = ownedTokens[_from][lastTokenIndex];
-
-    ownedTokens[_from][tokenIndex] = lastToken;
-    ownedTokens[_from][lastTokenIndex] = 0;
-    // Note that this will handle single-element arrays. In that case, both tokenIndex and lastTokenIndex are going to
-    // be zero. Then we can make sure that we will remove _tokenId from the ownedTokens list since we are first swapping
-    // the lastToken to the first position, and then dropping the element placed in the last position of the list
-
-    ownedTokens[_from].length--;
-    ownedTokensIndex[_tokenId] = 0;
-    ownedTokensIndex[lastToken] = tokenIndex;
-  }
-
-  /**
-   * @dev Internal function to mint a new token
-   * Reverts if the given token ID already exists
-   * @param _to address the beneficiary that will own the minted token
-   * @param _tokenId uint256 ID of the token to be minted by the msg.sender
-   */
-  function _mint(address _to, uint256 _tokenId) internal {
-    super._mint(_to, _tokenId);
-
-    allTokensIndex[_tokenId] = allTokens.length;
-    allTokens.push(_tokenId);
-  }
-
-  /**
-   * @dev Internal function to burn a specific token
-   * Reverts if the token does not exist
-   * @param _owner owner of the token to burn
-   * @param _tokenId uint256 ID of the token being burned by the msg.sender
-   */
-  function _burn(address _owner, uint256 _tokenId) internal {
-    super._burn(_owner, _tokenId);
-
-    // Clear metadata (if any)
-    if (bytes(tokenURIs[_tokenId]).length != 0) {
-      delete tokenURIs[_tokenId];
-    }
-
-    // Reorg all tokens array
-    uint256 tokenIndex = allTokensIndex[_tokenId];
-    uint256 lastTokenIndex = allTokens.length.sub(1);
-    uint256 lastToken = allTokens[lastTokenIndex];
-
-    allTokens[tokenIndex] = lastToken;
-    allTokens[lastTokenIndex] = 0;
-
-    allTokens.length--;
-    allTokensIndex[_tokenId] = 0;
-    allTokensIndex[lastToken] = tokenIndex;
-  }
-
 }

--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -107,6 +107,41 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
   }
 
   /**
+   * @dev Transfers the ownership of a given token ID to another address
+   * Usage of this method is discouraged, use `safeTransferFrom` whenever possible
+   * Requires the msg sender to be the owner, approved, or operator
+   * @param _from current owner of the token
+   * @param _to address to receive the ownership of the given token ID
+   * @param _tokenId uint256 ID of the token to be transferred
+  */
+  function transferFrom(
+    address _from,
+    address _to,
+    uint256 _tokenId
+  )
+    public
+  {
+    super.transferFrom(_from, _to, _tokenId);
+
+    uint256 tokenIndex = ownedTokensIndex[_tokenId];
+    uint256 lastTokenIndex = ownedTokens[_from].length.sub(1);
+    uint256 lastToken = ownedTokens[_from][lastTokenIndex];
+
+    ownedTokens[_from][tokenIndex] = lastToken;
+    ownedTokens[_from][lastTokenIndex] = 0;
+    // Note that this will handle single-element arrays. In that case, both tokenIndex and lastTokenIndex are going to
+    // be zero. Then we can make sure that we will remove _tokenId from the ownedTokens list since we are first swapping
+    // the lastToken to the first position, and then dropping the element placed in the last position of the list
+
+    ownedTokens[_from].length--;
+    ownedTokensIndex[_tokenId] = 0;
+    ownedTokensIndex[lastToken] = tokenIndex;
+    
+    uint256 length = ownedTokens[_to].length;
+    ownedTokens[_to].push(_tokenId);
+    ownedTokensIndex[_tokenId] = length;
+  }
+  /**
    * @dev Gets the total amount of tokens stored by the contract
    * @return uint256 representing the total amount of tokens
    */


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

This PR depends on #1030 (happy to drop that commit if it's an issue).

# 🚀 Description

There are a _ton_ of redundant checks and state reads in the current ERC721 implementations. I'm assuming that a lot of this is because everything is broken up into multiple function calls. Even though they read from a lot of the same state, the optimizer has trouble combining the SLOADs because they are occurring in different scopes. 

By flattening all of the function calls in `transferFrom`, quick tests show that we save a whopping **~8000 gas** per transfer (this is in addition to the ~2000 gas saved by dropping the modifiers in #1030). 

IMO, flattening the functions also makes actual token contracts more readable, as we are able to drop a lot of unused functions. The downside is that there is now a lot of redundant code in the mock contracts, but I think the tradeoff is massively worth it.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
