### PR TITLE
Graded token vesting with varying rates

### DIFF
--- a/contracts/token/ERC20/VariableRateTokenVesting.sol
+++ b/contracts/token/ERC20/VariableRateTokenVesting.sol
@@ -1,0 +1,71 @@
+pragma solidity ^0.4.21;
+
+import "./ERC20Basic.sol";
+import "./SafeERC20.sol";
+import "./TokenVesting.sol";
+import "../../math/SafeMath.sol";
+
+
+contract VariableRateTokenVesting is TokenVesting {
+
+  using SafeMath for uint256;
+  using SafeERC20 for ERC20Basic;
+
+  // Every element between 0 and 100, and should increase monotonically.
+  // [10, 20, 30, ..., 100] means releasing 10% for each period.
+  uint256[] public cumulativeRates;
+
+  // Seconds between each period.
+  uint256 public interval;
+
+
+  /**
+   * @dev Creates a vesting contract that vests its balance of any ERC20 token to the
+   * _beneficiary, with varying vesting rates depending on period.
+   * @param _beneficiary address of the beneficiary to whom vested tokens are transferred
+   * @param _cliff duration in seconds of the cliff in which tokens will begin to vest
+   * @param _revocable whether the vesting is revocable or not
+   * @param _cumulativeRates vesting rates in percentages, every element between 0 and 100
+   * and should increase monotonically
+   * @param _interval duration in seconds for each vesting period
+   */
+  constructor(
+    address _beneficiary,
+    uint256 _start,
+    uint256 _cliff,
+    bool _revocable,
+    uint256[] _cumulativeRates,
+    uint256 _interval
+  ) public
+    // We don't need `duration`, also always allow revoking.
+    TokenVesting(_beneficiary, _start, _cliff, /*duration: uint max*/~uint256(0), _revocable)
+  {
+    // Validate rates.
+    for (uint256 i = 0; i < _cumulativeRates.length; ++i) {
+      require(_cumulativeRates[i] <= 100);
+      if (i > 0) {
+        require(_cumulativeRates[i] >= _cumulativeRates[i - 1]);
+      }
+    }
+
+    cumulativeRates = _cumulativeRates;
+    interval = _interval;
+  }
+
+  /// @dev Override to use cumulative rates to calculated amount for vesting.
+  function vestedAmount(ERC20Basic token) public view returns (uint256) {
+    if (now < cliff) {
+      return 0;
+    }
+
+    uint256 currentBalance = token.balanceOf(this);
+    uint256 totalBalance = currentBalance.add(released[token]);
+
+    uint256 timeSinceStart = now.sub(start);
+    uint256 currentPeriod = timeSinceStart.div(interval);
+    if (currentPeriod >= cumulativeRates.length) {
+      return totalBalance;
+    }
+    return totalBalance.mul(cumulativeRates[currentPeriod]).div(100);
+  }
+}

--- a/contracts/token/ERC20/VariableRateTokenVesting.sol
+++ b/contracts/token/ERC20/VariableRateTokenVesting.sol
@@ -37,7 +37,7 @@ contract VariableRateTokenVesting is TokenVesting {
     uint256[] _cumulativeRates,
     uint256 _interval
   ) public
-    // We don't need `duration`, also always allow revoking.
+    // We don't need `duration`.
     TokenVesting(_beneficiary, _start, _cliff, /*duration: uint max*/~uint256(0), _revocable)
   {
     // Validate rates.

--- a/test/token/ERC20/VariableRateTokenVesting.test.js
+++ b/test/token/ERC20/VariableRateTokenVesting.test.js
@@ -1,0 +1,133 @@
+import EVMRevert from '../../helpers/EVMRevert';
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+
+const day = 3600 * 24;
+const month = day * 30;
+
+const MintableToken = artifacts.require('MintableToken');
+const Vesting = artifacts.require('./VariableRateTokenVesting.sol');
+
+// Utility helper functions.
+async function addHoursOnEVM (hours) {
+  const seconds = hours * 3600;
+  await web3.currentProvider.send({
+    jsonrpc: '2.0', method: 'evm_increaseTime', params: [seconds], id: 0,
+  });
+  await web3.currentProvider.send({
+    jsonrpc: '2.0', method: 'evm_mine', params: [], id: 0,
+  });
+}
+
+async function snapshotEVM () {
+  await web3.currentProvider.send({
+    jsonrpc: '2.0', method: 'evm_snapshot', params: [], id: 0,
+  });
+}
+
+async function revertEVM () {
+  await web3.currentProvider.send({
+    jsonrpc: '2.0', method: 'evm_revert', params: [], id: 0,
+  });
+}
+
+contract('VariableRateTokenVesting', async (accounts) => {
+  let token;
+  let vesting;
+  const beneficiary = accounts[9];
+
+  beforeEach(async () => {
+    await snapshotEVM();
+    token = await MintableToken.new();
+    await token.mint(accounts[0], 100000);
+  });
+
+  afterEach(async () => {
+    await revertEVM();
+  });
+
+  it('should validate contructor args', async () => {
+    // Invalid.
+    await Vesting.new(beneficiary, 0, 0, true, [0, 10, 100, 200], 1)
+      .should.be.rejectedWith(EVMRevert);
+    await Vesting.new(beneficiary, 0, 0, true, [20, 10, 100], 1)
+      .should.be.rejectedWith(EVMRevert);
+    // Valid.
+    await Vesting.new(beneficiary, 0, 0, true, [0, 100], 1);
+    await Vesting.new(beneficiary, 0, 0, true, [0, 10, 20, 30, 30, 30, 100], 1);
+  });
+
+  it('should calculate vested amount correctly - case 1', async () => {
+    const currTs = web3.eth.getBlock(web3.eth.blockNumber).timestamp;
+    vesting = await Vesting.new(beneficiary, currTs, day, true, [50, 100], month);
+    await token.transfer(vesting.address, 8888);
+    // Before start, expect zero.
+    let amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 0);
+    // First period.
+    await addHoursOnEVM(25); // One day later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 4444);
+    await addHoursOnEVM(24 * 15); // In total 16 days later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 4444);
+    // Second period and after.
+    await addHoursOnEVM(24 * 20); // In total 36 days later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 8888);
+    await addHoursOnEVM(24 * 50); // In total 86 days later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 8888);
+  });
+
+  it('should calculate vested amount correctly - case 2', async () => {
+    const currTs = web3.eth.getBlock(web3.eth.blockNumber).timestamp;
+    vesting = await Vesting.new(beneficiary, currTs, day, true, [10, 20, 40, 60, 60, 100], month);
+    await token.transfer(vesting.address, 10000);
+    // Before start, expect zero.
+    let amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 0);
+    // First period.
+    await addHoursOnEVM(25); // One day later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 1000);
+    // Second period.
+    await addHoursOnEVM(24 * 31); // In total 32 days later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 2000);
+    // Third period.
+    await addHoursOnEVM(24 * 31); // In total 63 days (2mo) later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 4000);
+    // Forth period.
+    await addHoursOnEVM(24 * 31); // In total 94 days (3mo) later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 6000);
+    // Fifth period.
+    await addHoursOnEVM(24 * 31); // In total 125 days (4mo) later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 6000); // Same vesting amount as last period.
+    // Last period.
+    await addHoursOnEVM(24 * 31); // In total 156 days (5mo) later.
+    amount = await vesting.vestedAmount(token.address);
+    assert.equal(amount.toNumber(), 10000);
+  });
+
+  it('should release amount accordingly', async () => {
+    const currTs = web3.eth.getBlock(web3.eth.blockNumber).timestamp;
+    vesting = await Vesting.new(beneficiary, currTs, day, true, [50, 100], month);
+    await token.transfer(vesting.address, 8888);
+    // First period.
+    await addHoursOnEVM(25); // One day later.
+    await vesting.release(token.address);
+    let amount = await token.balanceOf(beneficiary);
+    assert.equal(amount.toNumber(), 4444);
+    // Second period and after.
+    await addHoursOnEVM(24 * 31); // 1mo day later.
+    await vesting.release(token.address);
+    amount = await token.balanceOf(beneficiary);
+    assert.equal(amount.toNumber(), 8888);
+  });
+});


### PR DESCRIPTION
vesting schedule in our project is quite different from the linear fashion in `TokenVesting.sol`, so we think this PR could be helpful for other people.

we want to support graded vesting so that the beneficiary will receive different portions of tokens based on *the vesting period*, for example, 10% for the first month, 30% for the second month and remaining 60% for the third month.

this is achieved by providing `cumulativeRates` array as a constructor argument, where each element corresponds to the percentage of tokens for vesting at that period; `interval` is used to define the duration of a period. in this case, `duration` from the parent class is not used anymore.

passed linting and testing.