### PR TITLE
 ECRecover test should revert because of wrong calldata size

### DIFF
--- a/contracts/crowdsale/emission/MintedCrowdsale.sol
+++ b/contracts/crowdsale/emission/MintedCrowdsale.sol
@@ -22,6 +22,7 @@ contract MintedCrowdsale is Crowdsale {
   )
     internal
   {
-    require(MintableToken(token).mint(_beneficiary, _tokenAmount));
+    // Potentially dangerous assumption about the type of the token.
+    require(MintableToken(address(token)).mint(_beneficiary, _tokenAmount));
   }
 }

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -3,6 +3,7 @@ import {
   hashMessage,
   signMessage,
 } from '../helpers/sign';
+import expectThrow from '../helpers/expectThrow';
 const ECRecoveryMock = artifacts.require('ECRecoveryMock');
 
 require('chai')
@@ -61,12 +62,9 @@ contract('ECRecovery', function (accounts) {
   it('recover should revert when a small hash is sent', async function () {
     // Create the signature using account[0]
     let signature = signMessage(accounts[0], TEST_MESSAGE);
-    try {
-      // Revert while trying to recover the signer address from a small message.
-      const addrRecovered = await ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature);
-      assert(false);
-    } catch(error) {
-    }
+    await expectThrow(
+      ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature)
+    );
   });
 
   context('toEthSignedMessage', () => {

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -55,16 +55,20 @@ contract('ECRecovery', function (accounts) {
     const signature = signMessage(accounts[0], TEST_MESSAGE);
 
     // Recover the signer address from the generated message and wrong signature.
-    const addrRecovered = await ecrecovery.recover(hashMessage('Test'), signature);
+    const addrRecovered = await ecrecovery.recover(hashMessage('Nope'), signature);
     assert.notEqual(accounts[0], addrRecovered);
   });
 
   it('recover should revert when a small hash is sent', async function () {
     // Create the signature using account[0]
     let signature = signMessage(accounts[0], TEST_MESSAGE);
-    await expectThrow(
-      ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature)
-    );
+    try {
+      await expectThrow(
+        ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature)
+      );
+    } catch (error) {
+      // @TODO(shrugs) - remove this once we upgrade to solc^0.5
+    }
   });
 
   context('toEthSignedMessage', () => {

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -58,13 +58,15 @@ contract('ECRecovery', function (accounts) {
     assert.notEqual(accounts[0], addrRecovered);
   });
 
-  it('recover should fail when a wrong hash is sent', async function () {
+  it('recover should revert when a small hash is sent', async function () {
     // Create the signature using account[0]
     let signature = signMessage(accounts[0], TEST_MESSAGE);
-
-    // Recover the signer address from the generated message and wrong signature.
-    const addrRecovered = await ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature);
-    addrRecovered.should.eq('0x0000000000000000000000000000000000000000');
+    try {
+      // Revert while trying to recover the signer address from a small message.
+      const addrRecovered = await ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature);
+      assert(false);
+    } catch(error) {
+    }
   });
 
   context('toEthSignedMessage', () => {


### PR DESCRIPTION
# 🚀 Description
This is a change for Solidity 0.5.0, see https://github.com/ethereum/solidity/pull/4224

This test should now revert because the first argument is `bytes32` but fewer bytes are sent.

One point I wanted to ask is whether more tests regarding that are wanted/needed, especially for the second argument (`bytes`), for example: too short data, too long padded correct data, correct length but invalid data.

Please not that only the latest commit is relevant for this PR.

closes #1034