### PR TITLE
decrease approval condition fix (greater than and equal to)

### DIFF
--- a/contracts/token/ERC20/StandardToken.sol
+++ b/contracts/token/ERC20/StandardToken.sol
@@ -112,7 +112,7 @@ contract StandardToken is ERC20, BasicToken {
     returns (bool)
   {
     uint256 oldValue = allowed[msg.sender][_spender];
-    if (_subtractedValue > oldValue) {
+    if (_subtractedValue >= oldValue) {
       allowed[msg.sender][_spender] = 0;
     } else {
       allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);

--- a/test/token/ERC20/StandardToken.test.js
+++ b/test/token/ERC20/StandardToken.test.js
@@ -308,13 +308,11 @@ contract('StandardToken', function ([_, owner, recipient, anotherAccount]) {
 
           describe('when the decrease amount is equal to allowed amount', function () {
             it('set the allowance to zero', async function () {
-              await this.token.decreaseApproval(spender, amount+1, { from: owner });
+              await this.token.decreaseApproval(spender, amount + 1, { from: owner });
               const allowance = await this.token.allowance(owner, spender);
               assert.equal(allowance, 0);
             });
-        });
-
-
+          });
         });
       });
 

--- a/test/token/ERC20/StandardToken.test.js
+++ b/test/token/ERC20/StandardToken.test.js
@@ -295,23 +295,29 @@ contract('StandardToken', function ([_, owner, recipient, anotherAccount]) {
         });
 
         describe('when the spender had an approved amount', function () {
+          const approvedAmount = amount;
+
           beforeEach(async function () {
-            await this.token.approve(spender, amount + 1, { from: owner });
+            await this.token.approve(spender, approvedAmount, { from: owner });
           });
 
           it('decreases the spender allowance subtracting the requested amount', async function () {
-            await this.token.decreaseApproval(spender, amount, { from: owner });
+            await this.token.decreaseApproval(spender, approvedAmount - 5, { from: owner });
 
             const allowance = await this.token.allowance(owner, spender);
-            assert.equal(allowance, 1);
+            assert.equal(allowance, 5);
           });
 
-          describe('when the decrease amount is equal to allowed amount', function () {
-            it('set the allowance to zero', async function () {
-              await this.token.decreaseApproval(spender, amount + 1, { from: owner });
-              const allowance = await this.token.allowance(owner, spender);
-              assert.equal(allowance, 0);
-            });
+          it('sets the allowance to zero when all allowance is removed', async function () {
+            await this.token.decreaseApproval(spender, approvedAmount, { from: owner });
+            const allowance = await this.token.allowance(owner, spender);
+            assert.equal(allowance, 0);
+          });
+
+          it('sets the allowance to zero when more than the full allowance is removed', async function () {
+            await this.token.decreaseApproval(spender, approvedAmount + 5, { from: owner });
+            const allowance = await this.token.allowance(owner, spender);
+            assert.equal(allowance, 0);
           });
         });
       });

--- a/test/token/ERC20/StandardToken.test.js
+++ b/test/token/ERC20/StandardToken.test.js
@@ -305,6 +305,16 @@ contract('StandardToken', function ([_, owner, recipient, anotherAccount]) {
             const allowance = await this.token.allowance(owner, spender);
             assert.equal(allowance, 1);
           });
+
+          describe('when the decrease amount is equal to allowed amount', function () {
+            it('set the allowance to zero', async function () {
+              await this.token.decreaseApproval(spender, amount+1, { from: owner });
+              const allowance = await this.token.allowance(owner, spender);
+              assert.equal(allowance, 0);
+            });
+        });
+
+
         });
       });
 


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
The `decreaseApproval` function in StandardToken.sol has a condition that if the subtracted amount is greater than the allowed amount, simply make the allowance 0, otherwise, it invokes a subtraction function for reducing the approval amount:
```
 if (_subtractedValue > oldValue) {
      allowed[msg.sender][_spender] = 0;
    } else {
      allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
    }
```
If the subtracted amount is exactly equal to the allowed tokens, this will execute both the first condition, and will then default to the else where the subtract function is called which unnecessarily increases the gas amount of such a transaction. If we modify the condition to be `(_subtractedValue >= oldValue)`, the allowance will be reset to 0. This will only increase 3 units of gas per transaction but  it will save **88 units of gas** when `subtractedValue` is equal to the `oldValue`. 

**Before update in statement the transaction cost is 16278 to decrease the exactly same allowed amount**
![before](https://user-images.githubusercontent.com/14287497/42408604-d228e2a6-81e7-11e8-8b34-398d97dd38d4.png)

**After the update the transaction cost is 16190**
![after](https://user-images.githubusercontent.com/14287497/42408607-e54bb80e-81e7-11e8-8ba1-33ba406d740e.png)


   
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
