### PR TITLE
Added explicit data locations for function parameters to comply with Solidity v050 changes.

### DIFF
--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -15,7 +15,7 @@ library ECRecovery {
    * @param _hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
    * @param _signature bytes signature, the signature is generated using web3.eth.sign()
    */
-  function recover(bytes32 _hash, bytes _signature)
+  function recover(bytes32 _hash, bytes memory _signature)
     internal
     pure
     returns (address)

--- a/contracts/MerkleProof.sol
+++ b/contracts/MerkleProof.sol
@@ -15,7 +15,7 @@ library MerkleProof {
    * @param _leaf Leaf of Merkle tree
    */
   function verifyProof(
-    bytes32[] _proof,
+    bytes32[] memory _proof,
     bytes32 _root,
     bytes32 _leaf
   )

--- a/contracts/access/SignatureBouncer.sol
+++ b/contracts/access/SignatureBouncer.sol
@@ -40,7 +40,7 @@ contract SignatureBouncer is Ownable, RBAC {
   /**
    * @dev requires that a valid signature of a bouncer was provided
    */
-  modifier onlyValidSignature(bytes _signature)
+  modifier onlyValidSignature(bytes memory _signature)
   {
     require(isValidSignature(msg.sender, _signature));
     _;
@@ -49,7 +49,7 @@ contract SignatureBouncer is Ownable, RBAC {
   /**
    * @dev requires that a valid signature with a specifed method of a bouncer was provided
    */
-  modifier onlyValidSignatureAndMethod(bytes _signature)
+  modifier onlyValidSignatureAndMethod(bytes memory _signature)
   {
     require(isValidSignatureAndMethod(msg.sender, _signature));
     _;
@@ -58,7 +58,7 @@ contract SignatureBouncer is Ownable, RBAC {
   /**
    * @dev requires that a valid signature with a specifed method and params of a bouncer was provided
    */
-  modifier onlyValidSignatureAndData(bytes _signature)
+  modifier onlyValidSignatureAndData(bytes memory _signature)
   {
     require(isValidSignatureAndData(msg.sender, _signature));
     _;
@@ -89,7 +89,7 @@ contract SignatureBouncer is Ownable, RBAC {
    * @dev is the signature of `this + sender` from a bouncer?
    * @return bool
    */
-  function isValidSignature(address _address, bytes _signature)
+  function isValidSignature(address _address, bytes memory _signature)
     internal
     view
     returns (bool)
@@ -104,7 +104,7 @@ contract SignatureBouncer is Ownable, RBAC {
    * @dev is the signature of `this + sender + methodId` from a bouncer?
    * @return bool
    */
-  function isValidSignatureAndMethod(address _address, bytes _signature)
+  function isValidSignatureAndMethod(address _address, bytes memory _signature)
     internal
     view
     returns (bool)
@@ -124,7 +124,7 @@ contract SignatureBouncer is Ownable, RBAC {
     * @notice the _signature parameter of the method being validated must be the "last" parameter
     * @return bool
     */
-  function isValidSignatureAndData(address _address, bytes _signature)
+  function isValidSignatureAndData(address _address, bytes memory _signature)
     internal
     view
     returns (bool)
@@ -145,7 +145,7 @@ contract SignatureBouncer is Ownable, RBAC {
    * and then recover the signature and check it against the bouncer role
    * @return bool
    */
-  function isValidDataHash(bytes32 _hash, bytes _signature)
+  function isValidDataHash(bytes32 _hash, bytes memory _signature)
     internal
     view
     returns (bool)

--- a/contracts/access/Whitelist.sol
+++ b/contracts/access/Whitelist.sol
@@ -51,7 +51,7 @@ contract Whitelist is Ownable, RBAC {
    * @return true if at least one address was added to the whitelist,
    * false if all addresses were already in the whitelist
    */
-  function addAddressesToWhitelist(address[] _operators)
+  function addAddressesToWhitelist(address[] memory _operators)
     public
     onlyOwner
   {
@@ -79,7 +79,7 @@ contract Whitelist is Ownable, RBAC {
    * @return true if at least one address was removed from the whitelist,
    * false if all addresses weren't in the whitelist in the first place
    */
-  function removeAddressesFromWhitelist(address[] _operators)
+  function removeAddressesFromWhitelist(address[] memory _operators)
     public
     onlyOwner
   {

--- a/contracts/access/rbac/RBAC.sol
+++ b/contracts/access/rbac/RBAC.sol
@@ -26,7 +26,7 @@ contract RBAC {
    * @param _role the name of the role
    * // reverts
    */
-  function checkRole(address _operator, string _role)
+  function checkRole(address _operator, string memory _role)
     public
     view
   {
@@ -39,7 +39,7 @@ contract RBAC {
    * @param _role the name of the role
    * @return bool
    */
-  function hasRole(address _operator, string _role)
+  function hasRole(address _operator, string memory _role)
     public
     view
     returns (bool)
@@ -52,7 +52,7 @@ contract RBAC {
    * @param _operator address
    * @param _role the name of the role
    */
-  function addRole(address _operator, string _role)
+  function addRole(address _operator, string memory _role)
     internal
   {
     roles[_role].add(_operator);
@@ -64,7 +64,7 @@ contract RBAC {
    * @param _operator address
    * @param _role the name of the role
    */
-  function removeRole(address _operator, string _role)
+  function removeRole(address _operator, string memory _role)
     internal
   {
     roles[_role].remove(_operator);
@@ -76,7 +76,7 @@ contract RBAC {
    * @param _role the name of the role
    * // reverts
    */
-  modifier onlyRole(string _role)
+  modifier onlyRole(string memory _role)
   {
     checkRole(msg.sender, _role);
     _;
@@ -90,7 +90,7 @@ contract RBAC {
    * @TODO - when solidity supports dynamic arrays as arguments to modifiers, provide this
    *  see: https://github.com/ethereum/solidity/issues/2467
    */
-  // modifier onlyRoles(string[] _roles) {
+  // modifier onlyRoles(string[] memory _roles) {
   //     bool hasAnyRole = false;
   //     for (uint8 i = 0; i < _roles.length; i++) {
   //         if (hasRole(msg.sender, _roles[i])) {

--- a/contracts/examples/RBACWithAdmin.sol
+++ b/contracts/examples/RBACWithAdmin.sol
@@ -45,7 +45,7 @@ contract RBACWithAdmin is RBAC {
    * @param _account the account that will have the role
    * @param _roleName the name of the role
    */
-  function adminAddRole(address _account, string _roleName)
+  function adminAddRole(address _account, string memory _roleName)
     public
     onlyAdmin
   {

--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -21,7 +21,7 @@ contract TokenDestructible is Ownable {
    * @notice The called token contracts could try to re-enter this contract. Only
    supply token contracts you trust.
    */
-  function destroy(address[] _tokens) public onlyOwner {
+  function destroy(address[] memory _tokens) public onlyOwner {
 
     // Transfer tokens to owner
     for (uint256 i = 0; i < _tokens.length; i++) {

--- a/contracts/mocks/BouncerMock.sol
+++ b/contracts/mocks/BouncerMock.sol
@@ -12,7 +12,7 @@ contract SignatureBouncerMock is SignatureBouncer {
     return isValidSignature(_address, _signature);
   }
 
-  function onlyWithValidSignature(bytes _signature)
+  function onlyWithValidSignature(bytes memory _signature)
     public
     onlyValidSignature(_signature)
     view
@@ -20,7 +20,7 @@ contract SignatureBouncerMock is SignatureBouncer {
 
   }
 
-  function checkValidSignatureAndMethod(address _address, bytes _signature)
+  function checkValidSignatureAndMethod(address _address, bytes memory _signature)
     public
     view
     returns (bool)
@@ -28,7 +28,7 @@ contract SignatureBouncerMock is SignatureBouncer {
     return isValidSignatureAndMethod(_address, _signature);
   }
 
-  function onlyWithValidSignatureAndMethod(bytes _signature)
+  function onlyWithValidSignatureAndMethod(bytes memory _signature)
     public
     onlyValidSignatureAndMethod(_signature)
     view
@@ -38,9 +38,9 @@ contract SignatureBouncerMock is SignatureBouncer {
 
   function checkValidSignatureAndData(
     address _address,
-    bytes,
+    bytes memory,
     uint,
-    bytes _signature
+    bytes memory _signature
   )
     public
     view
@@ -49,7 +49,7 @@ contract SignatureBouncerMock is SignatureBouncer {
     return isValidSignatureAndData(_address, _signature);
   }
 
-  function onlyWithValidSignatureAndData(uint, bytes _signature)
+  function onlyWithValidSignatureAndData(uint, bytes memory _signature)
     public
     onlyValidSignatureAndData(_signature)
     view

--- a/contracts/mocks/DetailedERC20Mock.sol
+++ b/contracts/mocks/DetailedERC20Mock.sol
@@ -6,8 +6,8 @@ import "../token/ERC20/DetailedERC20.sol";
 
 contract DetailedERC20Mock is StandardToken, DetailedERC20 {
   constructor(
-    string _name,
-    string _symbol,
+    string memory _name,
+    string memory _symbol,
     uint8 _decimals
   )
     DetailedERC20(_name, _symbol, _decimals)

--- a/contracts/mocks/ECRecoveryMock.sol
+++ b/contracts/mocks/ECRecoveryMock.sol
@@ -7,7 +7,7 @@ import "../ECRecovery.sol";
 contract ECRecoveryMock {
   using ECRecovery for bytes32;
 
-  function recover(bytes32 _hash, bytes _signature)
+  function recover(bytes32 _hash, bytes memory _signature)
     public
     pure
     returns (address)

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -5,7 +5,7 @@ import "../proposals/ERC1046/TokenMetadata.sol";
 
 
 contract ERC20WithMetadataMock is StandardToken, ERC20WithMetadata {
-  constructor(string _tokenURI) public
+  constructor(string memory _tokenURI) public
     ERC20WithMetadata(_tokenURI)
   {
   }

--- a/contracts/mocks/ERC223TokenMock.sol
+++ b/contracts/mocks/ERC223TokenMock.sol
@@ -4,7 +4,7 @@ import "../token/ERC20/StandardToken.sol";
 
 
 contract ERC223ContractInterface {
-  function tokenFallback(address _from, uint256 _value, bytes _data) external;
+  function tokenFallback(address _from, uint256 _value, bytes calldata _data) external;
 }
 
 
@@ -15,7 +15,7 @@ contract ERC223TokenMock is StandardToken {
   }
 
   // ERC223 compatible transfer function (except the name)
-  function transferERC223(address _to, uint256 _value, bytes _data) public
+  function transferERC223(address _to, uint256 _value, bytes memory _data) public
     returns (bool success)
   {
     transfer(_to, _value);

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -24,7 +24,7 @@ contract ERC721ReceiverMock is ERC721Receiver {
     address _operator,
     address _from,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public
     returns(bytes4)

--- a/contracts/mocks/ERC721TokenMock.sol
+++ b/contracts/mocks/ERC721TokenMock.sol
@@ -9,7 +9,7 @@ import "../token/ERC721/ERC721Token.sol";
  * and a public setter for metadata URI
  */
 contract ERC721TokenMock is ERC721Token {
-  constructor(string name, string symbol) public
+  constructor(string memory name, string memory symbol) public
     ERC721Token(name, symbol)
   { }
 
@@ -25,7 +25,7 @@ contract ERC721TokenMock is ERC721Token {
     return super._exists(_tokenId);
   }
 
-  function setTokenURI(uint256 _tokenId, string _uri) public {
+  function setTokenURI(uint256 _tokenId, string memory _uri) public {
     super._setTokenURI(_tokenId, _uri);
   }
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -6,7 +6,7 @@ import { MerkleProof } from "../MerkleProof.sol";
 contract MerkleProofWrapper {
 
   function verifyProof(
-    bytes32[] _proof,
+    bytes32[] memory _proof,
     bytes32 _root,
     bytes32 _leaf
   )

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -9,7 +9,7 @@ contract MessageHelper {
   function showMessage(
     bytes32 _message,
     uint256 _number,
-    string _text
+    string memory _text
   )
     public
     returns (bool)
@@ -21,7 +21,7 @@ contract MessageHelper {
   function buyMessage(
     bytes32 _message,
     uint256 _number,
-    string _text
+    string memory _text
   )
     public
     payable
@@ -39,7 +39,7 @@ contract MessageHelper {
     require(false);
   }
 
-  function call(address _to, bytes _data) public returns (bool) {
+  function call(address _to, bytes memory _data) public returns (bool) {
     // solium-disable-next-line security/no-low-level-calls
     if (_to.call(_data))
       return true;

--- a/contracts/mocks/RBACMock.sol
+++ b/contracts/mocks/RBACMock.sol
@@ -16,7 +16,7 @@ contract RBACMock is RBACWithAdmin {
     _;
   }
 
-  constructor(address[] _advisors)
+  constructor(address[] memory _advisors)
     public
   {
     addRole(msg.sender, ROLE_ADVISOR);

--- a/contracts/ownership/Contactable.sol
+++ b/contracts/ownership/Contactable.sol
@@ -16,7 +16,7 @@ contract Contactable is Ownable {
     * @dev Allows the owner to set a string with their contact information.
     * @param _info The contact information to attach to the contract.
     */
-  function setContactInformation(string _info) public onlyOwner {
+  function setContactInformation(string memory _info) public onlyOwner {
     contactInformation = _info;
   }
 }

--- a/contracts/ownership/HasNoTokens.sol
+++ b/contracts/ownership/HasNoTokens.sol
@@ -21,7 +21,7 @@ contract HasNoTokens is CanReclaimToken {
   function tokenFallback(
     address _from,
     uint256 _value,
-    bytes _data
+    bytes memory _data
   )
     external
     pure

--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -21,7 +21,7 @@ contract SplitPayment {
   /**
    * @dev Constructor
    */
-  constructor(address[] _payees, uint256[] _shares) public payable {
+  constructor(address[] memory _payees, uint256[] memory _shares) public payable {
     require(_payees.length == _shares.length);
     require(_payees.length > 0);
 

--- a/contracts/proposals/ERC1046/TokenMetadata.sol
+++ b/contracts/proposals/ERC1046/TokenMetadata.sol
@@ -10,20 +10,20 @@ import "../../token/ERC20/ERC20.sol";
  * @dev TODO - update https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/ERC721.sol#L17 when 1046 is finalized
  */
 contract ERC20TokenMetadata is ERC20 {
-  function tokenURI() external view returns (string);
+  function tokenURI() external view returns (string memory);
 }
 
 
 contract ERC20WithMetadata is ERC20TokenMetadata {
   string private tokenURI_ = "";
 
-  constructor(string _tokenURI)
+  constructor(string memory _tokenURI)
     public
   {
     tokenURI_ = _tokenURI;
   }
 
-  function tokenURI() external view returns (string) {
+  function tokenURI() external view returns (string memory) {
     return tokenURI_;
   }
 }

--- a/contracts/token/ERC20/DetailedERC20.sol
+++ b/contracts/token/ERC20/DetailedERC20.sol
@@ -14,7 +14,7 @@ contract DetailedERC20 is ERC20 {
   string public symbol;
   uint8 public decimals;
 
-  constructor(string _name, string _symbol, uint8 _decimals) public {
+  constructor(string memory _name, string memory _symbol, uint8 _decimals) public {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;

--- a/contracts/token/ERC721/DeprecatedERC721.sol
+++ b/contracts/token/ERC721/DeprecatedERC721.sol
@@ -11,5 +11,5 @@ import "./ERC721.sol";
 contract DeprecatedERC721 is ERC721 {
   function takeOwnership(uint256 _tokenId) public;
   function transfer(address _to, uint256 _tokenId) public;
-  function tokensOf(address _owner) public view returns (uint256[]);
+  function tokensOf(address _owner) public view returns (uint256[] memory);
 }

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -26,9 +26,9 @@ contract ERC721Enumerable is ERC721Basic {
  * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Metadata is ERC721Basic {
-  function name() external view returns (string _name);
-  function symbol() external view returns (string _symbol);
-  function tokenURI(uint256 _tokenId) public view returns (string);
+  function name() external view returns (string memory _name);
+  function symbol() external view returns (string memory _symbol);
+  function tokenURI(uint256 _tokenId) public view returns (string memory);
 }
 
 

--- a/contracts/token/ERC721/ERC721Basic.sol
+++ b/contracts/token/ERC721/ERC721Basic.sol
@@ -74,7 +74,7 @@ contract ERC721Basic is ERC165 {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public;
 }

--- a/contracts/token/ERC721/ERC721BasicToken.sol
+++ b/contracts/token/ERC721/ERC721BasicToken.sol
@@ -179,7 +179,7 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public
   {
@@ -295,7 +295,7 @@ contract ERC721BasicToken is SupportsInterfaceWithLookup, ERC721Basic {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     internal
     returns (bool)

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -8,7 +8,7 @@ contract ERC721Holder is ERC721Receiver {
     address,
     address,
     uint256,
-    bytes
+    bytes memory
   )
     public
     returns(bytes4)

--- a/contracts/token/ERC721/ERC721Receiver.sol
+++ b/contracts/token/ERC721/ERC721Receiver.sol
@@ -31,7 +31,7 @@ contract ERC721Receiver {
     address _operator,
     address _from,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public
     returns(bytes4);

--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -37,7 +37,7 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
   /**
    * @dev Constructor function
    */
-  constructor(string _name, string _symbol) public {
+  constructor(string memory _name, string memory _symbol) public {
     name_ = _name;
     symbol_ = _symbol;
 
@@ -50,7 +50,7 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
    * @dev Gets the token name
    * @return string representing the token name
    */
-  function name() external view returns (string) {
+  function name() external view returns (string memory) {
     return name_;
   }
 
@@ -58,7 +58,7 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
    * @dev Gets the token symbol
    * @return string representing the token symbol
    */
-  function symbol() external view returns (string) {
+  function symbol() external view returns (string memory) {
     return symbol_;
   }
 
@@ -67,7 +67,7 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
    * Throws if the token ID does not exist. May return an empty string.
    * @param _tokenId uint256 ID of the token to query
    */
-  function tokenURI(uint256 _tokenId) public view returns (string) {
+  function tokenURI(uint256 _tokenId) public view returns (string memory) {
     require(_exists(_tokenId));
     return tokenURIs[_tokenId];
   }
@@ -115,7 +115,7 @@ contract ERC721Token is SupportsInterfaceWithLookup, ERC721BasicToken, ERC721 {
    * @param _tokenId uint256 ID of the token to set its URI
    * @param _uri string URI to assign
    */
-  function _setTokenURI(uint256 _tokenId, string _uri) internal {
+  function _setTokenURI(uint256 _tokenId, string memory _uri) internal {
     require(_exists(_tokenId));
     tokenURIs[_tokenId] = _uri;
   }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description
Solidity v050 will no longer allow default data locations for function parameters (and return parameters) (https://github.com/ethereum/solidity/pull/4014), so all such instances have been made explicit `memory` locations. 
<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
