### PR TITLE
Proposal DecentralizedPausable

### DIFF
--- a/contracts/lifecycle/DecentralizedPausable.sol
+++ b/contracts/lifecycle/DecentralizedPausable.sol
@@ -20,7 +20,7 @@ contract DecentralizedPausable is Pausable {
    * @dev Modifier to make a function callable only when the contract is not paused.
    */
   modifier whenNotPaused() {
-    if(paused) {
+    if (paused) {
       require(unpausedUsers[pauseStartBlock][msg.sender]);
     }
     _;
@@ -30,7 +30,7 @@ contract DecentralizedPausable is Pausable {
    * @dev Modifier to make a function callable only when the contract is paused.
    */
   modifier whenPaused() {
-    if(paused) {
+    if (paused) {
       require(!unpausedUsers[pauseStartBlock][msg.sender]);
     } else {
       revert();

--- a/contracts/lifecycle/DecentralizedPausable.sol
+++ b/contracts/lifecycle/DecentralizedPausable.sol
@@ -1,0 +1,58 @@
+pragma solidity ^0.4.24;
+
+
+import "./Pausable.sol";
+
+
+/**
+ * @title DecentralizedPausable
+ * @dev Base contract which allows children to implement an emergency stop mechanism.
+ * Only the owner can control pause, that is centralized. so, user must be able to unpause himself for decentralized.
+ */
+contract DecentralizedPausable is Pausable {
+  event UserUnpause(address indexed _user);
+
+  uint public pauseStartBlock;
+  mapping(uint => mapping(address => bool)) public unpausedUsers;
+
+
+  /**
+   * @dev Modifier to make a function callable only when the contract is not paused.
+   */
+  modifier whenNotPaused() {
+    if(paused) {
+      require(unpausedUsers[pauseStartBlock][msg.sender]);
+    }
+    _;
+  }
+
+  /**
+   * @dev Modifier to make a function callable only when the contract is paused.
+   */
+  modifier whenPaused() {
+    if(paused) {
+      require(!unpausedUsers[pauseStartBlock][msg.sender]);
+    } else {
+      revert();
+    }
+    _;
+  }
+
+  /**
+   * @dev called by the owner to pause, triggers stopped state and record that block.number.
+   */
+  function pause() onlyOwner whenNotPaused public {
+    paused = true;
+    pauseStartBlock = block.number;
+    emit Pause();
+  }
+
+  /**
+   * @dev called by a user to unpause only himself. it's for decentralized controllable.
+   */
+  function unpauseOnlySelf() whenPaused public {
+    require(owner != msg.sender); // owner can not calle this.
+    unpausedUsers[pauseStartBlock][msg.sender] = true;
+    emit UserUnpause(msg.sender);
+  }
+}

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -7,25 +7,19 @@ import "../ownership/Ownable.sol";
 /**
  * @title Pausable
  * @dev Base contract which allows children to implement an emergency stop mechanism.
- * Only the owner can control pause, that is centralized. so, user must be able to unpause himself for decentralized.
  */
 contract Pausable is Ownable {
   event Pause();
   event Unpause();
-  event UserUnpause(address indexed _user);
 
   bool public paused = false;
-  uint public pauseStartBlock;
-  mapping(uint => mapping(address => bool)) public unpausedUsers;
 
 
   /**
    * @dev Modifier to make a function callable only when the contract is not paused.
    */
   modifier whenNotPaused() {
-    if(paused) {
-      require(unpausedUsers[pauseStartBlock][msg.sender]);
-    }
+    require(!paused);
     _;
   }
 
@@ -33,11 +27,7 @@ contract Pausable is Ownable {
    * @dev Modifier to make a function callable only when the contract is paused.
    */
   modifier whenPaused() {
-    if(paused) {
-      require(!unpausedUsers[pauseStartBlock][msg.sender]);
-    } else {
-      revert();
-    }
+    require(paused);
     _;
   }
 
@@ -46,7 +36,6 @@ contract Pausable is Ownable {
    */
   function pause() onlyOwner whenNotPaused public {
     paused = true;
-    pauseStartBlock = block.number;
     emit Pause();
   }
 
@@ -56,13 +45,5 @@ contract Pausable is Ownable {
   function unpause() onlyOwner whenPaused public {
     paused = false;
     emit Unpause();
-  }
-
-  /**
-   * @dev called by a user to unpause only himself. it's for decentralized controllable.
-   */
-  function unpauseUser() whenPaused public {
-    unpausedUsers[pauseStartBlock][msg.sender] = true;
-    emit UserUnpause(msg.sender);
   }
 }

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -7,19 +7,25 @@ import "../ownership/Ownable.sol";
 /**
  * @title Pausable
  * @dev Base contract which allows children to implement an emergency stop mechanism.
+ * Only the owner can control pause, that is centralized. so, user must be able to unpause himself for decentralized.
  */
 contract Pausable is Ownable {
   event Pause();
   event Unpause();
+  event UserUnpause(address indexed _user);
 
   bool public paused = false;
+  uint public pauseStartBlock;
+  mapping(uint => mapping(address => bool)) public unpausedUsers;
 
 
   /**
    * @dev Modifier to make a function callable only when the contract is not paused.
    */
   modifier whenNotPaused() {
-    require(!paused);
+    if(paused) {
+      require(unpausedUsers[pauseStartBlock][msg.sender]);
+    }
     _;
   }
 
@@ -27,7 +33,11 @@ contract Pausable is Ownable {
    * @dev Modifier to make a function callable only when the contract is paused.
    */
   modifier whenPaused() {
-    require(paused);
+    if(paused) {
+      require(!unpausedUsers[pauseStartBlock][msg.sender]);
+    } else {
+      revert();
+    }
     _;
   }
 
@@ -36,6 +46,7 @@ contract Pausable is Ownable {
    */
   function pause() onlyOwner whenNotPaused public {
     paused = true;
+    pauseStartBlock = block.number;
     emit Pause();
   }
 
@@ -45,5 +56,13 @@ contract Pausable is Ownable {
   function unpause() onlyOwner whenPaused public {
     paused = false;
     emit Unpause();
+  }
+
+  /**
+   * @dev called by a user to unpause only himself. it's for decentralized controllable.
+   */
+  function unpauseUser() whenPaused public {
+    unpausedUsers[pauseStartBlock][msg.sender] = true;
+    emit UserUnpause(msg.sender);
   }
 }

--- a/contracts/mocks/DecentralizedPausableMock.sol
+++ b/contracts/mocks/DecentralizedPausableMock.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.24;
+
+
+import "../lifecycle/DecentralizedPausable.sol";
+
+
+// mock class using Pausable
+contract DecentralizedPausableMock is DecentralizedPausable {
+  bool public drasticMeasureTaken;
+  uint256 public count;
+
+  constructor() public {
+    drasticMeasureTaken = false;
+    count = 0;
+  }
+
+  function normalProcess() external whenNotPaused {
+    count++;
+  }
+
+  function drasticMeasure() external whenPaused {
+    drasticMeasureTaken = true;
+  }
+
+}

--- a/test/lifecycle/DecentralizedPausable.test.js
+++ b/test/lifecycle/DecentralizedPausable.test.js
@@ -53,8 +53,8 @@ contract('DecentralizedPausable', function (accounts) {
   it('should resume allowing normal process specify unpaused user.', async function () {
     let DecentralizedPausable = await DecentralizedPausableMock.new();
     await DecentralizedPausable.pause();
-    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
-    await DecentralizedPausable.normalProcess({from: accounts[1]});
+    await DecentralizedPausable.unpauseOnlySelf({ from: accounts[1] });
+    await DecentralizedPausable.normalProcess({ from: accounts[1] });
     let count0 = await DecentralizedPausable.count();
 
     assert.equal(count0, 1);
@@ -64,13 +64,12 @@ contract('DecentralizedPausable', function (accounts) {
     let DecentralizedPausable = await DecentralizedPausableMock.new();
     await DecentralizedPausable.pause();
     await assertRevert(DecentralizedPausable.unpauseOnlySelf());
-
   });
 
   it('can not perform normal process to not specify unpaused user.', async function () {
     let DecentralizedPausable = await DecentralizedPausableMock.new();
     await DecentralizedPausable.pause();
-    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
+    await DecentralizedPausable.unpauseOnlySelf({ from: accounts[1] });
     await assertRevert(DecentralizedPausable.normalProcess());
 
     await DecentralizedPausable.drasticMeasure();
@@ -82,15 +81,15 @@ contract('DecentralizedPausable', function (accounts) {
   it('can not perform normal process when second pause.', async function () {
     let DecentralizedPausable = await DecentralizedPausableMock.new();
     await DecentralizedPausable.pause();
-    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
-    await DecentralizedPausable.normalProcess({from: accounts[1]});
+    await DecentralizedPausable.unpauseOnlySelf({ from: accounts[1] });
+    await DecentralizedPausable.normalProcess({ from: accounts[1] });
     let count0 = await DecentralizedPausable.count();
 
     assert.equal(count0, 1);
 
     await DecentralizedPausable.unpause();
     await DecentralizedPausable.pause();
-    await assertRevert(DecentralizedPausable.normalProcess({from: accounts[1]}));
+    await assertRevert(DecentralizedPausable.normalProcess({ from: accounts[1] }));
   });
 
   it('should prevent drastic measure after pause is over', async function () {

--- a/test/lifecycle/DecentralizedPausable.test.js
+++ b/test/lifecycle/DecentralizedPausable.test.js
@@ -1,0 +1,106 @@
+
+import assertRevert from '../helpers/assertRevert';
+const DecentralizedPausableMock = artifacts.require('DecentralizedPausableMock');
+
+contract('DecentralizedPausable', function (accounts) {
+  it('can perform normal process in non-pause', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    let count0 = await DecentralizedPausable.count();
+    assert.equal(count0, 0);
+
+    await DecentralizedPausable.normalProcess();
+    let count1 = await DecentralizedPausable.count();
+    assert.equal(count1, 1);
+  });
+
+  it('can not perform normal process in pause', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    let count0 = await DecentralizedPausable.count();
+    assert.equal(count0, 0);
+
+    await assertRevert(DecentralizedPausable.normalProcess());
+    let count1 = await DecentralizedPausable.count();
+    assert.equal(count1, 0);
+  });
+
+  it('can not take drastic measure in non-pause', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await assertRevert(DecentralizedPausable.drasticMeasure());
+    const drasticMeasureTaken = await DecentralizedPausable.drasticMeasureTaken();
+    assert.isFalse(drasticMeasureTaken);
+  });
+
+  it('can take a drastic measure in a pause', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.drasticMeasure();
+    let drasticMeasureTaken = await DecentralizedPausable.drasticMeasureTaken();
+
+    assert.isTrue(drasticMeasureTaken);
+  });
+
+  it('should resume allowing normal process after pause is over', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.unpause();
+    await DecentralizedPausable.normalProcess();
+    let count0 = await DecentralizedPausable.count();
+
+    assert.equal(count0, 1);
+  });
+
+  it('should resume allowing normal process specify unpaused user.', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
+    await DecentralizedPausable.normalProcess({from: accounts[1]});
+    let count0 = await DecentralizedPausable.count();
+
+    assert.equal(count0, 1);
+  });
+
+  it('the owner can not call unpauseOnlySelf.', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await assertRevert(DecentralizedPausable.unpauseOnlySelf());
+
+  });
+
+  it('can not perform normal process to not specify unpaused user.', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
+    await assertRevert(DecentralizedPausable.normalProcess());
+
+    await DecentralizedPausable.drasticMeasure();
+    let drasticMeasureTaken = await DecentralizedPausable.drasticMeasureTaken();
+
+    assert.isTrue(drasticMeasureTaken);
+  });
+
+  it('can not perform normal process when second pause.', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.unpauseOnlySelf({from: accounts[1]});
+    await DecentralizedPausable.normalProcess({from: accounts[1]});
+    let count0 = await DecentralizedPausable.count();
+
+    assert.equal(count0, 1);
+
+    await DecentralizedPausable.unpause();
+    await DecentralizedPausable.pause();
+    await assertRevert(DecentralizedPausable.normalProcess({from: accounts[1]}));
+  });
+
+  it('should prevent drastic measure after pause is over', async function () {
+    let DecentralizedPausable = await DecentralizedPausableMock.new();
+    await DecentralizedPausable.pause();
+    await DecentralizedPausable.unpause();
+
+    await assertRevert(DecentralizedPausable.drasticMeasure());
+
+    const drasticMeasureTaken = await DecentralizedPausable.drasticMeasureTaken();
+    assert.isFalse(drasticMeasureTaken);
+  });
+});


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description
<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
This is proposal of Decentralized Pausable. If emergency happends, then the contract owner should be pause contract as soon. but, it is centralized process. so, this contract allow to that a user can be unpause himself after that owner paused to contract.
<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
