### PR TITLE
Remove chai-as-promised

### DIFF
--- a/contracts/mocks/DestructibleMock.sol
+++ b/contracts/mocks/DestructibleMock.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.24;
 
 import "../lifecycle/Destructible.sol";
 
+
 contract DestructibleMock is Destructible {
   function() payable public {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,8 +158,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -180,14 +179,12 @@
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-      "dev": true
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -1660,8 +1657,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bip39": {
       "version": "2.5.0",
@@ -1680,7 +1676,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1689,7 +1684,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.0.5"
       }
@@ -1697,8 +1691,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -1768,8 +1761,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -1781,7 +1773,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.2",
         "cipher-base": "^1.0.0",
@@ -1843,8 +1834,7 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1970,15 +1960,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "requires": {
-        "check-error": "^1.0.2"
-      }
-    },
     "chai-bignumber": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/chai-bignumber/-/chai-bignumber-2.0.2.tgz",
@@ -2039,14 +2020,12 @@
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -2233,8 +2212,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coinstring": {
       "version": "2.3.0",
@@ -2333,8 +2311,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2387,8 +2364,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.4",
@@ -2425,7 +2401,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -2437,7 +2412,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -2672,8 +2646,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -2760,7 +2733,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
@@ -2811,7 +2783,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -2847,7 +2818,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -3430,8 +3400,17 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -3550,15 +3529,6 @@
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
       "dev": true
     },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
-      }
-    },
     "ethereumjs-account": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
@@ -3642,7 +3612,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
       "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -3772,7 +3741,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
       "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -3782,7 +3750,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-      "dev": true,
       "requires": {
         "create-hash": "^1.1.1"
       }
@@ -3829,8 +3796,7 @@
     "expand-template": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz",
-      "integrity": "sha1-bDAzIxd6YrGyLAcCefeGEoe2mxo=",
-      "dev": true
+      "integrity": "sha1-bDAzIxd6YrGyLAcCefeGEoe2mxo="
     },
     "expand-tilde": {
       "version": "2.0.2",
@@ -4642,7 +4608,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4663,12 +4630,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4683,17 +4652,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4810,7 +4782,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4822,6 +4795,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4836,6 +4810,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4843,12 +4818,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4867,6 +4844,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4947,7 +4925,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4959,6 +4938,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5044,7 +5024,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5080,6 +5061,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5099,6 +5081,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5142,12 +5125,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5194,7 +5179,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -5306,8 +5290,7 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "dev": true
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "github-username": {
       "version": "4.1.0",
@@ -5546,8 +5529,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -5613,7 +5595,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1"
       }
@@ -5622,7 +5603,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.0"
@@ -5648,7 +5628,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -5785,14 +5764,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -6046,7 +6023,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -6069,8 +6045,7 @@
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-number": {
       "version": "2.1.0",
@@ -6215,8 +6190,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -6548,7 +6522,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
       "integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
-      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -7224,14 +7197,12 @@
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-      "dev": true
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7245,8 +7216,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -7273,7 +7243,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -7349,8 +7318,7 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -7424,8 +7392,7 @@
     "node-abi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.0.tgz",
-      "integrity": "sha512-AbW35CPRE4vdieOse46V+16dKispLNv3PQwgqlcfg7GQeQHcLu3gvp3fbU2gTh7d8NfGjp5CJh+j4Hpyb0XzaA==",
-      "dev": true
+      "integrity": "sha512-AbW35CPRE4vdieOse46V+16dKispLNv3PQwgqlcfg7GQeQHcLu3gvp3fbU2gTh7d8NfGjp5CJh+j4Hpyb0XzaA=="
     },
     "node-dir": {
       "version": "0.1.8",
@@ -7477,8 +7444,7 @@
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "dev": true
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "3.0.6",
@@ -7534,7 +7500,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -7545,8 +7510,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "number-to-bn": {
       "version": "1.7.0",
@@ -7575,8 +7539,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -7669,7 +7632,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7763,8 +7725,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
@@ -8032,7 +7993,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
       "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-      "dev": true,
       "requires": {
         "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
@@ -8053,14 +8013,12 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -8112,8 +8070,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -8157,7 +8114,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
       "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8234,7 +8190,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8245,14 +8200,12 @@
         "deep-extend": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -8299,7 +8252,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8626,7 +8578,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
       "requires": {
         "hash-base": "^2.0.0",
         "inherits": "^2.0.1"
@@ -8635,8 +8586,7 @@
     "rlp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
-      "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
-      "dev": true
+      "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
     },
     "run-async": {
       "version": "2.3.0",
@@ -8680,8 +8630,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -8736,7 +8685,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
       "integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
-      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "bip66": "^1.1.3",
@@ -8827,8 +8775,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -8869,7 +8816,6 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1"
       }
@@ -8912,8 +8858,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
       "version": "1.0.0",
@@ -8925,7 +8870,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "dev": true,
       "requires": {
         "once": "^1.3.1",
         "unzip-response": "^1.0.0",
@@ -9511,7 +9455,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -9533,7 +9476,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -9542,7 +9484,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -9576,7 +9517,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
@@ -9584,8 +9524,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -9747,7 +9686,6 @@
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
       "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-      "dev": true,
       "requires": {
         "chownr": "^1.0.1",
         "mkdirp": "^0.5.1",
@@ -9759,7 +9697,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-      "dev": true,
       "requires": {
         "bl": "^1.0.0",
         "end-of-stream": "^1.0.0",
@@ -10172,8 +10109,7 @@
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "urix": {
       "version": "0.1.0",
@@ -10228,8 +10164,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -11098,7 +11033,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "dev": true,
       "requires": {
         "string-width": "^1.0.2"
       }
@@ -11128,8 +11062,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -11226,8 +11159,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "homepage": "https://github.com/OpenZeppelin/zeppelin-solidity",
   "devDependencies": {
     "chai": "^4.1.2",
-    "chai-as-promised": "^7.0.0",
     "chai-bignumber": "^2.0.2",
     "coveralls": "^3.0.1",
     "dotenv": "^4.0.0",

--- a/test/access/SignatureBouncer.test.js
+++ b/test/access/SignatureBouncer.test.js
@@ -4,7 +4,6 @@ const { getBouncerSigner } = require('../helpers/sign');
 const Bouncer = artifacts.require('SignatureBouncerMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 const UINT_VALUE = 23;

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -5,7 +5,6 @@ const { ethGetBalance } = require('../helpers/web3');
 const BigNumber = web3.BigNumber;
 
 const should = require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -27,11 +26,11 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
 
   describe('accepting payments', function () {
     it('should accept sends', async function () {
-      await this.crowdsale.send(value).should.be.fulfilled;
+      await this.crowdsale.send(value);
     });
 
     it('should accept payments', async function () {
-      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser }).should.be.fulfilled;
+      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
     });
   });
 

--- a/test/crowdsale/CappedCrowdsale.test.js
+++ b/test/crowdsale/CappedCrowdsale.test.js
@@ -1,10 +1,10 @@
 const { ether } = require('../helpers/ether');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -25,23 +25,32 @@ contract('CappedCrowdsale', function ([_, wallet]) {
 
   describe('creating a valid crowdsale', function () {
     it('should fail with zero cap', async function () {
-      await CappedCrowdsale.new(rate, wallet, 0, this.token.address).should.be.rejectedWith(EVMRevert);
+      await expectThrow(
+        CappedCrowdsale.new(rate, wallet, 0, this.token.address),
+        EVMRevert,
+      );
     });
   });
 
   describe('accepting payments', function () {
     it('should accept payments within cap', async function () {
-      await this.crowdsale.send(cap.minus(lessThanCap)).should.be.fulfilled;
-      await this.crowdsale.send(lessThanCap).should.be.fulfilled;
+      await this.crowdsale.send(cap.minus(lessThanCap));
+      await this.crowdsale.send(lessThanCap);
     });
 
     it('should reject payments outside cap', async function () {
       await this.crowdsale.send(cap);
-      await this.crowdsale.send(1).should.be.rejectedWith(EVMRevert);
+      await expectThrow(
+        this.crowdsale.send(1),
+        EVMRevert,
+      );
     });
 
     it('should reject payments that exceed cap', async function () {
-      await this.crowdsale.send(cap.plus(1)).should.be.rejectedWith(EVMRevert);
+      await expectThrow(
+        this.crowdsale.send(cap.plus(1)),
+        EVMRevert,
+      );
     });
   });
 

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -4,7 +4,6 @@ const { ethGetBalance } = require('../helpers/web3');
 const BigNumber = web3.BigNumber;
 
 const should = require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -25,8 +24,8 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
 
   describe('accepting payments', function () {
     it('should accept payments', async function () {
-      await this.crowdsale.send(value).should.be.fulfilled;
-      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser }).should.be.fulfilled;
+      await this.crowdsale.send(value);
+      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
     });
   });
 

--- a/test/crowdsale/FinalizableCrowdsale.test.js
+++ b/test/crowdsale/FinalizableCrowdsale.test.js
@@ -1,12 +1,12 @@
 const { advanceBlock } = require('../helpers/advanceToBlock');
 const { increaseTimeTo, duration } = require('../helpers/increaseTime');
 const { latestTime } = require('../helpers/latestTime');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const BigNumber = web3.BigNumber;
 
 const should = require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -34,23 +34,23 @@ contract('FinalizableCrowdsale', function ([_, owner, wallet, thirdparty]) {
   });
 
   it('cannot be finalized before ending', async function () {
-    await this.crowdsale.finalize({ from: owner }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.crowdsale.finalize({ from: owner }), EVMRevert);
   });
 
   it('cannot be finalized by third party after ending', async function () {
     await increaseTimeTo(this.afterClosingTime);
-    await this.crowdsale.finalize({ from: thirdparty }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.crowdsale.finalize({ from: thirdparty }), EVMRevert);
   });
 
   it('can be finalized by owner after ending', async function () {
     await increaseTimeTo(this.afterClosingTime);
-    await this.crowdsale.finalize({ from: owner }).should.be.fulfilled;
+    await this.crowdsale.finalize({ from: owner });
   });
 
   it('cannot be finalized twice', async function () {
     await increaseTimeTo(this.afterClosingTime);
     await this.crowdsale.finalize({ from: owner });
-    await this.crowdsale.finalize({ from: owner }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.crowdsale.finalize({ from: owner }), EVMRevert);
   });
 
   it('logs finalized', async function () {

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -6,7 +6,6 @@ const { latestTime } = require('../helpers/latestTime');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -1,10 +1,10 @@
 const { ether } = require('../helpers/ether');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -30,27 +30,27 @@ contract('IndividuallyCappedCrowdsale', function ([_, wallet, alice, bob, charli
 
     describe('accepting payments', function () {
       it('should accept payments within cap', async function () {
-        await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(bob, { value: lessThanCapBoth }).should.be.fulfilled;
+        await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
+        await this.crowdsale.buyTokens(bob, { value: lessThanCapBoth });
       });
 
       it('should reject payments outside cap', async function () {
         await this.crowdsale.buyTokens(alice, { value: capAlice });
-        await this.crowdsale.buyTokens(alice, { value: 1 }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(alice, { value: 1 }), EVMRevert);
       });
 
       it('should reject payments that exceed cap', async function () {
-        await this.crowdsale.buyTokens(alice, { value: capAlice.plus(1) }).should.be.rejectedWith(EVMRevert);
-        await this.crowdsale.buyTokens(bob, { value: capBob.plus(1) }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(alice, { value: capAlice.plus(1) }), EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(bob, { value: capBob.plus(1) }), EVMRevert);
       });
 
       it('should manage independent caps', async function () {
-        await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(bob, { value: lessThanCapAlice }).should.be.rejectedWith(EVMRevert);
+        await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
+        await expectThrow(this.crowdsale.buyTokens(bob, { value: lessThanCapAlice }), EVMRevert);
       });
 
       it('should default to a cap of zero', async function () {
-        await this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }), EVMRevert);
       });
     });
 
@@ -78,20 +78,20 @@ contract('IndividuallyCappedCrowdsale', function ([_, wallet, alice, bob, charli
 
     describe('accepting payments', function () {
       it('should accept payments within cap', async function () {
-        await this.crowdsale.buyTokens(bob, { value: lessThanCapBoth }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }).should.be.fulfilled;
+        await this.crowdsale.buyTokens(bob, { value: lessThanCapBoth });
+        await this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth });
       });
 
       it('should reject payments outside cap', async function () {
         await this.crowdsale.buyTokens(bob, { value: capBob });
-        await this.crowdsale.buyTokens(bob, { value: 1 }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(bob, { value: 1 }), EVMRevert);
         await this.crowdsale.buyTokens(charlie, { value: capBob });
-        await this.crowdsale.buyTokens(charlie, { value: 1 }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(charlie, { value: 1 }), EVMRevert);
       });
 
       it('should reject payments that exceed cap', async function () {
-        await this.crowdsale.buyTokens(bob, { value: capBob.plus(1) }).should.be.rejectedWith(EVMRevert);
-        await this.crowdsale.buyTokens(charlie, { value: capBob.plus(1) }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(bob, { value: capBob.plus(1) }), EVMRevert);
+        await expectThrow(this.crowdsale.buyTokens(charlie, { value: capBob.plus(1) }), EVMRevert);
       });
     });
 

--- a/test/crowdsale/MintedCrowdsale.behaviour.js
+++ b/test/crowdsale/MintedCrowdsale.behaviour.js
@@ -3,7 +3,6 @@ const { ethGetBalance } = require('../helpers/web3');
 const BigNumber = web3.BigNumber;
 
 const should = require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -13,8 +12,8 @@ function shouldBehaveLikeMintedCrowdsale ([_, investor, wallet, purchaser], rate
   describe('as a minted crowdsale', function () {
     describe('accepting payments', function () {
       it('should accept payments', async function () {
-        await this.crowdsale.send(value).should.be.fulfilled;
-        await this.crowdsale.buyTokens(investor, { value: value, from: purchaser }).should.be.fulfilled;
+        await this.crowdsale.send(value);
+        await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
       });
     });
 

--- a/test/crowdsale/PostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/PostDeliveryCrowdsale.test.js
@@ -1,13 +1,13 @@
 const { advanceBlock } = require('../helpers/advanceToBlock');
 const { increaseTimeTo, duration } = require('../helpers/increaseTime');
 const { latestTime } = require('../helpers/latestTime');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 const { ether } = require('../helpers/ether');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -46,14 +46,14 @@ contract('PostDeliveryCrowdsale', function ([_, investor, wallet, purchaser]) {
   it('should not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
     await increaseTimeTo(this.beforeEndTime);
     await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
-    await this.crowdsale.withdrawTokens({ from: investor }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.crowdsale.withdrawTokens({ from: investor }), EVMRevert);
   });
 
   it('should allow beneficiaries to withdraw tokens after crowdsale ends', async function () {
     await increaseTimeTo(this.openingTime);
     await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
     await increaseTimeTo(this.afterClosingTime);
-    await this.crowdsale.withdrawTokens({ from: investor }).should.be.fulfilled;
+    await this.crowdsale.withdrawTokens({ from: investor });
   });
 
   it('should return the amount of tokens bought', async function () {

--- a/test/crowdsale/TimedCrowdsale.test.js
+++ b/test/crowdsale/TimedCrowdsale.test.js
@@ -2,12 +2,12 @@ const { ether } = require('../helpers/ether');
 const { advanceBlock } = require('../helpers/advanceToBlock');
 const { increaseTimeTo, duration } = require('../helpers/increaseTime');
 const { latestTime } = require('../helpers/latestTime');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -43,20 +43,20 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
 
   describe('accepting payments', function () {
     it('should reject payments before start', async function () {
-      await this.crowdsale.send(value).should.be.rejectedWith(EVMRevert);
-      await this.crowdsale.buyTokens(investor, { from: purchaser, value: value }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.crowdsale.send(value), EVMRevert);
+      await expectThrow(this.crowdsale.buyTokens(investor, { from: purchaser, value: value }), EVMRevert);
     });
 
     it('should accept payments after start', async function () {
       await increaseTimeTo(this.openingTime);
-      await this.crowdsale.send(value).should.be.fulfilled;
-      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser }).should.be.fulfilled;
+      await this.crowdsale.send(value);
+      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
     });
 
     it('should reject payments after end', async function () {
       await increaseTimeTo(this.afterClosingTime);
-      await this.crowdsale.send(value).should.be.rejectedWith(EVMRevert);
-      await this.crowdsale.buyTokens(investor, { value: value, from: purchaser }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.crowdsale.send(value), EVMRevert);
+      await expectThrow(this.crowdsale.buyTokens(investor, { value: value, from: purchaser }), EVMRevert);
     });
   });
 });

--- a/test/crowdsale/WhitelistedCrowdsale.test.js
+++ b/test/crowdsale/WhitelistedCrowdsale.test.js
@@ -1,9 +1,9 @@
 const { ether } = require('../helpers/ether');
+const { expectThrow } = require('../helpers/expectThrow');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 const WhitelistedCrowdsale = artifacts.require('WhitelistedCrowdsaleImpl');
@@ -24,20 +24,20 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
 
     describe('accepting payments', function () {
       it('should accept payments to whitelisted (from whichever buyers)', async function () {
-        await this.crowdsale.sendTransaction({ value, from: authorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized }).should.be.fulfilled;
+        await this.crowdsale.sendTransaction({ value, from: authorized });
+        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized });
+        await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized });
       });
 
       it('should reject payments to not whitelisted (from whichever buyers)', async function () {
-        await this.crowdsale.sendTransaction({ value, from: unauthorized }).should.be.rejected;
-        await this.crowdsale.buyTokens(unauthorized, { value: value, from: unauthorized }).should.be.rejected;
-        await this.crowdsale.buyTokens(unauthorized, { value: value, from: authorized }).should.be.rejected;
+        await expectThrow(this.crowdsale.sendTransaction({ value, from: unauthorized }));
+        await expectThrow(this.crowdsale.buyTokens(unauthorized, { value: value, from: unauthorized }));
+        await expectThrow(this.crowdsale.buyTokens(unauthorized, { value: value, from: authorized }));
       });
 
       it('should reject payments to addresses removed from whitelist', async function () {
         await this.crowdsale.removeAddressFromWhitelist(authorized);
-        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.rejected;
+        await expectThrow(this.crowdsale.buyTokens(authorized, { value: value, from: authorized }));
       });
     });
 
@@ -61,22 +61,22 @@ contract('WhitelistedCrowdsale', function ([_, wallet, authorized, unauthorized,
 
     describe('accepting payments', function () {
       it('should accept payments to whitelisted (from whichever buyers)', async function () {
-        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: authorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: unauthorized }).should.be.fulfilled;
+        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized });
+        await this.crowdsale.buyTokens(authorized, { value: value, from: unauthorized });
+        await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: authorized });
+        await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: unauthorized });
       });
 
       it('should reject payments to not whitelisted (with whichever buyers)', async function () {
-        await this.crowdsale.send(value).should.be.rejected;
-        await this.crowdsale.buyTokens(unauthorized, { value: value, from: unauthorized }).should.be.rejected;
-        await this.crowdsale.buyTokens(unauthorized, { value: value, from: authorized }).should.be.rejected;
+        await expectThrow(this.crowdsale.send(value));
+        await expectThrow(this.crowdsale.buyTokens(unauthorized, { value: value, from: unauthorized }));
+        await expectThrow(this.crowdsale.buyTokens(unauthorized, { value: value, from: authorized }));
       });
 
       it('should reject payments to addresses removed from whitelist', async function () {
         await this.crowdsale.removeAddressFromWhitelist(anotherAuthorized);
-        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized }).should.be.fulfilled;
-        await this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: authorized }).should.be.rejected;
+        await this.crowdsale.buyTokens(authorized, { value: value, from: authorized });
+        await expectThrow(this.crowdsale.buyTokens(anotherAuthorized, { value: value, from: authorized }));
       });
     });
 

--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -1,21 +1,30 @@
-async function expectThrow (promise) {
+async function expectThrow (promise, message) {
   try {
     await promise;
   } catch (error) {
-    // TODO: Check jump destination to destinguish between a throw
-    //       and an actual invalid jump.
-    const invalidOpcode = error.message.search('invalid opcode') >= 0;
-    // TODO: When we contract A calls contract B, and B throws, instead
-    //       of an 'invalid jump', we get an 'out of gas' error. How do
-    //       we distinguish this from an actual out of gas event? (The
-    //       ganache log actually show an 'invalid jump' event.)
-    const outOfGas = error.message.search('out of gas') >= 0;
-    const revert = error.message.search('revert') >= 0;
-    assert(
-      invalidOpcode || outOfGas || revert,
-      'Expected throw, got \'' + error + '\' instead',
-    );
-    return;
+    // Message is an optional parameter here
+    if (message) {
+      assert(
+        error.message.search(message) >= 0,
+        'Expected \'' + message + '\', got \'' + error + '\' instead',
+      );
+      return;
+    } else {
+      // TODO: Check jump destination to destinguish between a throw
+      //       and an actual invalid jump.
+      const invalidOpcode = error.message.search('invalid opcode') >= 0;
+      // TODO: When we contract A calls contract B, and B throws, instead
+      //       of an 'invalid jump', we get an 'out of gas' error. How do
+      //       we distinguish this from an actual out of gas event? (The
+      //       ganache log actually show an 'invalid jump' event.)
+      const outOfGas = error.message.search('out of gas') >= 0;
+      const revert = error.message.search('revert') >= 0;
+      assert(
+        invalidOpcode || outOfGas || revert,
+        'Expected throw, got \'' + error + '\' instead',
+      );
+      return;
+    }
   }
   assert.fail('Expected throw not received');
 }

--- a/test/introspection/SupportsInterfaceWithLookup.test.js
+++ b/test/introspection/SupportsInterfaceWithLookup.test.js
@@ -4,7 +4,6 @@ const { assertRevert } = require('../helpers/assertRevert');
 const SupportsInterfaceWithLookup = artifacts.require('SupportsInterfaceWithLookupMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 contract('SupportsInterfaceWithLookup', function (accounts) {

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -4,7 +4,6 @@ const { expectThrow } = require('../helpers/expectThrow');
 const ECRecoveryMock = artifacts.require('ECRecoveryMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 contract('ECRecovery', function (accounts) {

--- a/test/ownership/Ownable.behaviour.js
+++ b/test/ownership/Ownable.behaviour.js
@@ -1,9 +1,9 @@
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 function shouldBehaveLikeOwnable (accounts) {
@@ -25,12 +25,12 @@ function shouldBehaveLikeOwnable (accounts) {
       const other = accounts[2];
       const owner = await this.ownable.owner.call();
       owner.should.not.eq(other);
-      await this.ownable.transferOwnership(other, { from: other }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.ownable.transferOwnership(other, { from: other }), EVMRevert);
     });
 
     it('should guard ownership against stuck state', async function () {
       let originalOwner = await this.ownable.owner();
-      await this.ownable.transferOwnership(null, { from: originalOwner }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.ownable.transferOwnership(null, { from: originalOwner }), EVMRevert);
     });
 
     it('loses owner after renouncement', async function () {
@@ -44,7 +44,7 @@ function shouldBehaveLikeOwnable (accounts) {
       const other = accounts[2];
       const owner = await this.ownable.owner.call();
       owner.should.not.eq(other);
-      await this.ownable.renounceOwnership({ from: other }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.ownable.renounceOwnership({ from: other }), EVMRevert);
     });
   });
 }

--- a/test/ownership/Superuser.test.js
+++ b/test/ownership/Superuser.test.js
@@ -4,7 +4,6 @@ const expectEvent = require('../helpers/expectEvent');
 const Superuser = artifacts.require('Superuser');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 contract('Superuser', function (accounts) {

--- a/test/ownership/Whitelist.test.js
+++ b/test/ownership/Whitelist.test.js
@@ -4,7 +4,6 @@ const expectEvent = require('../helpers/expectEvent');
 const WhitelistMock = artifacts.require('WhitelistMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 contract('Whitelist', function (accounts) {
@@ -69,8 +68,7 @@ contract('Whitelist', function (accounts) {
 
     it('should allow whitelisted address to call #onlyWhitelistedCanDoThis', async function () {
       await this.mock.addAddressToWhitelist(whitelistedAddress1, { from: owner });
-      await this.mock.onlyWhitelistedCanDoThis({ from: whitelistedAddress1 })
-        .should.be.fulfilled;
+      await this.mock.onlyWhitelistedCanDoThis({ from: whitelistedAddress1 });
     });
   });
 

--- a/test/ownership/rbac/RBAC.test.js
+++ b/test/ownership/rbac/RBAC.test.js
@@ -4,7 +4,6 @@ const expectEvent = require('../../helpers/expectEvent');
 const RBACMock = artifacts.require('RBACMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 const ROLE_ADVISOR = 'advisor';
@@ -25,47 +24,36 @@ contract('RBAC', function (accounts) {
 
   context('in normal conditions', () => {
     it('allows admin to call #onlyAdminsCanDoThis', async () => {
-      await mock.onlyAdminsCanDoThis({ from: admin })
-        .should.be.fulfilled;
+      await mock.onlyAdminsCanDoThis({ from: admin });
     });
     it('allows admin to call #onlyAdvisorsCanDoThis', async () => {
-      await mock.onlyAdvisorsCanDoThis({ from: admin })
-        .should.be.fulfilled;
+      await mock.onlyAdvisorsCanDoThis({ from: admin });
     });
     it('allows advisors to call #onlyAdvisorsCanDoThis', async () => {
-      await mock.onlyAdvisorsCanDoThis({ from: advisors[0] })
-        .should.be.fulfilled;
+      await mock.onlyAdvisorsCanDoThis({ from: advisors[0] });
     });
     it('allows admin to call #eitherAdminOrAdvisorCanDoThis', async () => {
-      await mock.eitherAdminOrAdvisorCanDoThis({ from: admin })
-        .should.be.fulfilled;
+      await mock.eitherAdminOrAdvisorCanDoThis({ from: admin });
     });
     it('allows advisors to call #eitherAdminOrAdvisorCanDoThis', async () => {
-      await mock.eitherAdminOrAdvisorCanDoThis({ from: advisors[0] })
-        .should.be.fulfilled;
+      await mock.eitherAdminOrAdvisorCanDoThis({ from: advisors[0] });
     });
     it('does not allow admins to call #nobodyCanDoThis', async () => {
-      await expectThrow(
-        mock.nobodyCanDoThis({ from: admin })
-      );
+      await expectThrow(mock.nobodyCanDoThis({ from: admin }));
     });
     it('does not allow advisors to call #nobodyCanDoThis', async () => {
-      await expectThrow(
-        mock.nobodyCanDoThis({ from: advisors[0] })
-      );
+      await expectThrow(mock.nobodyCanDoThis({ from: advisors[0] }));
     });
     it('does not allow anyone to call #nobodyCanDoThis', async () => {
-      await expectThrow(
-        mock.nobodyCanDoThis({ from: anyone })
-      );
+      await expectThrow(mock.nobodyCanDoThis({ from: anyone }));
     });
     it('allows an admin to remove an advisor\'s role', async () => {
       await mock.removeAdvisor(advisors[0], { from: admin })
-        .should.be.fulfilled;
+      ;
     });
     it('allows admins to #adminRemoveRole', async () => {
       await mock.adminRemoveRole(advisors[3], ROLE_ADVISOR, { from: admin })
-        .should.be.fulfilled;
+      ;
     });
 
     it('announces a RoleAdded event on addRole', async () => {
@@ -85,14 +73,10 @@ contract('RBAC', function (accounts) {
 
   context('in adversarial conditions', () => {
     it('does not allow an advisor to remove another advisor', async () => {
-      await expectThrow(
-        mock.removeAdvisor(advisors[1], { from: advisors[0] })
-      );
+      await expectThrow(mock.removeAdvisor(advisors[1], { from: advisors[0] }));
     });
     it('does not allow "anyone" to remove an advisor', async () => {
-      await expectThrow(
-        mock.removeAdvisor(advisors[0], { from: anyone })
-      );
+      await expectThrow(mock.removeAdvisor(advisors[0], { from: anyone }));
     });
   });
 });

--- a/test/payment/ConditionalEscrow.test.js
+++ b/test/payment/ConditionalEscrow.test.js
@@ -1,4 +1,5 @@
 const { shouldBehaveLikeEscrow } = require('./Escrow.behaviour');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 
 const BigNumber = web3.BigNumber;
@@ -35,7 +36,7 @@ contract('ConditionalEscrow', function (accounts) {
     it('reverts on withdrawals', async function () {
       await this.escrow.deposit(payee, { from: owner, value: amount });
 
-      await this.escrow.withdraw(payee, { from: owner }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.withdraw(payee, { from: owner }), EVMRevert);
     });
   });
 });

--- a/test/payment/Escrow.behaviour.js
+++ b/test/payment/Escrow.behaviour.js
@@ -1,4 +1,5 @@
 const expectEvent = require('../helpers/expectEvent');
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 const { ethGetBalance } = require('../helpers/web3');
 
@@ -28,7 +29,7 @@ function shouldBehaveLikeEscrow (owner, [payee1, payee2]) {
       });
 
       it('only the owner can deposit', async function () {
-        await this.escrow.deposit(payee1, { from: payee2 }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.escrow.deposit(payee1, { from: payee2 }), EVMRevert);
       });
 
       it('emits a deposited event', async function () {
@@ -84,7 +85,7 @@ function shouldBehaveLikeEscrow (owner, [payee1, payee2]) {
       });
 
       it('only the owner can withdraw', async function () {
-        await this.escrow.withdraw(payee1, { from: payee1 }).should.be.rejectedWith(EVMRevert);
+        await expectThrow(this.escrow.withdraw(payee1, { from: payee1 }), EVMRevert);
       });
 
       it('emits a withdrawn event', async function () {

--- a/test/payment/RefundEscrow.test.js
+++ b/test/payment/RefundEscrow.test.js
@@ -1,3 +1,4 @@
+const { expectThrow } = require('../helpers/expectThrow');
 const { EVMRevert } = require('../helpers/EVMRevert');
 const expectEvent = require('../helpers/expectEvent');
 const { ethGetBalance } = require('../helpers/web3');
@@ -28,17 +29,17 @@ contract('RefundEscrow', function ([owner, beneficiary, refundee1, refundee2]) {
 
     it('does not refund refundees', async function () {
       await this.escrow.deposit(refundee1, { from: owner, value: amount });
-      await this.escrow.withdraw(refundee1).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.withdraw(refundee1), EVMRevert);
     });
 
     it('does not allow beneficiary withdrawal', async function () {
       await this.escrow.deposit(refundee1, { from: owner, value: amount });
-      await this.escrow.beneficiaryWithdraw().should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.beneficiaryWithdraw(), EVMRevert);
     });
   });
 
   it('only owner can enter closed state', async function () {
-    await this.escrow.close({ from: beneficiary }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.escrow.close({ from: beneficiary }), EVMRevert);
 
     const receipt = await this.escrow.close({ from: owner });
 
@@ -53,11 +54,11 @@ contract('RefundEscrow', function ([owner, beneficiary, refundee1, refundee2]) {
     });
 
     it('rejects deposits', async function () {
-      await this.escrow.deposit(refundee1, { from: owner, value: amount }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.deposit(refundee1, { from: owner, value: amount }), EVMRevert);
     });
 
     it('does not refund refundees', async function () {
-      await this.escrow.withdraw(refundee1).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.withdraw(refundee1), EVMRevert);
     });
 
     it('allows beneficiary withdrawal', async function () {
@@ -70,7 +71,7 @@ contract('RefundEscrow', function ([owner, beneficiary, refundee1, refundee2]) {
   });
 
   it('only owner can enter refund state', async function () {
-    await this.escrow.enableRefunds({ from: beneficiary }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.escrow.enableRefunds({ from: beneficiary }), EVMRevert);
 
     const receipt = await this.escrow.enableRefunds({ from: owner });
 
@@ -85,7 +86,7 @@ contract('RefundEscrow', function ([owner, beneficiary, refundee1, refundee2]) {
     });
 
     it('rejects deposits', async function () {
-      await this.escrow.deposit(refundee1, { from: owner, value: amount }).should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.deposit(refundee1, { from: owner, value: amount }), EVMRevert);
     });
 
     it('refunds refundees', async function () {
@@ -99,7 +100,7 @@ contract('RefundEscrow', function ([owner, beneficiary, refundee1, refundee2]) {
     });
 
     it('does not allow beneficiary withdrawal', async function () {
-      await this.escrow.beneficiaryWithdraw().should.be.rejectedWith(EVMRevert);
+      await expectThrow(this.escrow.beneficiaryWithdraw(), EVMRevert);
     });
   });
 });

--- a/test/payment/SplitPayment.test.js
+++ b/test/payment/SplitPayment.test.js
@@ -3,10 +3,10 @@ const { ethGetBalance, ethSendTransaction } = require('../helpers/web3');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
+const { expectThrow } = require('../helpers/expectThrow');
 const EVMThrow = require('../helpers/EVMThrow.js');
 const SplitPayment = artifacts.require('SplitPayment');
 
@@ -38,12 +38,12 @@ contract('SplitPayment', function ([owner, payee1, payee2, payee3, nonpayee1, pa
   });
 
   it('should throw if no funds to claim', async function () {
-    await this.contract.claim({ from: payee1 }).should.be.rejectedWith(EVMThrow);
+    await expectThrow(this.contract.claim({ from: payee1 }), EVMThrow);
   });
 
   it('should throw if non-payee want to claim', async function () {
     await ethSendTransaction({ from: payer1, to: this.contract.address, value: amount });
-    await this.contract.claim({ from: nonpayee1 }).should.be.rejectedWith(EVMThrow);
+    await expectThrow(this.contract.claim({ from: nonpayee1 }), EVMThrow);
   });
 
   it('should distribute funds to payees', async function () {

--- a/test/proposals/ERC1046/TokenMetadata.test.js
+++ b/test/proposals/ERC1046/TokenMetadata.test.js
@@ -1,7 +1,6 @@
 const ERC20WithMetadata = artifacts.require('ERC20WithMetadataMock');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 const metadataURI = 'https://example.com';

--- a/test/token/ERC20/BurnableToken.behaviour.js
+++ b/test/token/ERC20/BurnableToken.behaviour.js
@@ -5,7 +5,6 @@ const BigNumber = web3.BigNumber;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC20/DetailedERC20.test.js
+++ b/test/token/ERC20/DetailedERC20.test.js
@@ -1,7 +1,6 @@
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC20/MintableToken.behaviour.js
+++ b/test/token/ERC20/MintableToken.behaviour.js
@@ -3,7 +3,6 @@ const { assertRevert } = require('../../helpers/assertRevert');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC20/SafeERC20.test.js
+++ b/test/token/ERC20/SafeERC20.test.js
@@ -1,7 +1,7 @@
+const { expectThrow } = require('../../helpers/expectThrow');
 const { EVMRevert } = require('../../helpers/EVMRevert');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .should();
 
 const SafeERC20Helper = artifacts.require('SafeERC20Helper');
@@ -12,26 +12,26 @@ contract('SafeERC20', function () {
   });
 
   it('should throw on failed transfer', async function () {
-    await this.helper.doFailingTransfer().should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.helper.doFailingTransfer(), EVMRevert);
   });
 
   it('should throw on failed transferFrom', async function () {
-    await this.helper.doFailingTransferFrom().should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.helper.doFailingTransferFrom(), EVMRevert);
   });
 
   it('should throw on failed approve', async function () {
-    await this.helper.doFailingApprove().should.be.rejectedWith(EVMRevert);
+    await expectThrow(this.helper.doFailingApprove(), EVMRevert);
   });
 
   it('should not throw on succeeding transfer', async function () {
-    await this.helper.doSucceedingTransfer().should.be.fulfilled;
+    await this.helper.doSucceedingTransfer();
   });
 
   it('should not throw on succeeding transferFrom', async function () {
-    await this.helper.doSucceedingTransferFrom().should.be.fulfilled;
+    await this.helper.doSucceedingTransferFrom();
   });
 
   it('should not throw on succeeding approve', async function () {
-    await this.helper.doSucceedingApprove().should.be.fulfilled;
+    await this.helper.doSucceedingApprove();
   });
 });

--- a/test/token/ERC20/StandardBurnableToken.test.js
+++ b/test/token/ERC20/StandardBurnableToken.test.js
@@ -7,7 +7,6 @@ const BigNumber = web3.BigNumber;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC20/TokenTimelock.test.js
+++ b/test/token/ERC20/TokenTimelock.test.js
@@ -1,10 +1,10 @@
 const { latestTime } = require('../../helpers/latestTime');
 const { increaseTimeTo, duration } = require('../../helpers/increaseTime');
+const { expectThrow } = require('../../helpers/expectThrow');
 
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -22,32 +22,32 @@ contract('TokenTimelock', function ([_, owner, beneficiary]) {
   });
 
   it('cannot be released before time limit', async function () {
-    await this.timelock.release().should.be.rejected;
+    await expectThrow(this.timelock.release());
   });
 
   it('cannot be released just before time limit', async function () {
     await increaseTimeTo(this.releaseTime - duration.seconds(3));
-    await this.timelock.release().should.be.rejected;
+    await expectThrow(this.timelock.release());
   });
 
   it('can be released just after limit', async function () {
     await increaseTimeTo(this.releaseTime + duration.seconds(1));
-    await this.timelock.release().should.be.fulfilled;
+    await this.timelock.release();
     const balance = await this.token.balanceOf(beneficiary);
     balance.should.be.bignumber.equal(amount);
   });
 
   it('can be released after time limit', async function () {
     await increaseTimeTo(this.releaseTime + duration.years(1));
-    await this.timelock.release().should.be.fulfilled;
+    await this.timelock.release();
     const balance = await this.token.balanceOf(beneficiary);
     balance.should.be.bignumber.equal(amount);
   });
 
   it('cannot be released twice', async function () {
     await increaseTimeTo(this.releaseTime + duration.years(1));
-    await this.timelock.release().should.be.fulfilled;
-    await this.timelock.release().should.be.rejected;
+    await this.timelock.release();
+    await expectThrow(this.timelock.release());
     const balance = await this.token.balanceOf(beneficiary);
     balance.should.be.bignumber.equal(amount);
   });

--- a/test/token/ERC20/TokenVesting.test.js
+++ b/test/token/ERC20/TokenVesting.test.js
@@ -1,3 +1,4 @@
+const { expectThrow } = require('../../helpers/expectThrow');
 const { EVMRevert } = require('../../helpers/EVMRevert');
 const { latestTime } = require('../../helpers/latestTime');
 const { increaseTimeTo, duration } = require('../../helpers/increaseTime');
@@ -6,7 +7,6 @@ const { ethGetBlock } = require('../../helpers/web3');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -29,12 +29,15 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
   });
 
   it('cannot be released before cliff', async function () {
-    await this.vesting.release(this.token.address).should.be.rejectedWith(EVMRevert);
+    await expectThrow(
+      this.vesting.release(this.token.address),
+      EVMRevert,
+    );
   });
 
   it('can be released after cliff', async function () {
     await increaseTimeTo(this.start + this.cliff + duration.weeks(1));
-    await this.vesting.release(this.token.address).should.be.fulfilled;
+    await this.vesting.release(this.token.address);
   });
 
   it('should release proper amount after cliff', async function () {
@@ -72,12 +75,15 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
   });
 
   it('should be revoked by owner if revocable is set', async function () {
-    await this.vesting.revoke(this.token.address, { from: owner }).should.be.fulfilled;
+    await this.vesting.revoke(this.token.address, { from: owner });
   });
 
   it('should fail to be revoked by owner if revocable not set', async function () {
     const vesting = await TokenVesting.new(beneficiary, this.start, this.cliff, this.duration, false, { from: owner });
-    await vesting.revoke(this.token.address, { from: owner }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(
+      vesting.revoke(this.token.address, { from: owner }),
+      EVMRevert,
+    );
   });
 
   it('should return the non-vested tokens when revoked by owner', async function () {
@@ -110,6 +116,9 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
     await this.vesting.revoke(this.token.address, { from: owner });
 
-    await this.vesting.revoke(this.token.address, { from: owner }).should.be.rejectedWith(EVMRevert);
+    await expectThrow(
+      this.vesting.revoke(this.token.address, { from: owner }),
+      EVMRevert,
+    );
   });
 });

--- a/test/token/ERC721/ERC721BasicToken.behaviour.js
+++ b/test/token/ERC721/ERC721BasicToken.behaviour.js
@@ -8,7 +8,6 @@ const ERC721Receiver = artifacts.require('ERC721ReceiverMock.sol');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC721/ERC721BasicToken.test.js
+++ b/test/token/ERC721/ERC721BasicToken.test.js
@@ -5,7 +5,6 @@ const BigNumber = web3.BigNumber;
 const ERC721BasicToken = artifacts.require('ERC721BasicTokenMock.sol');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC721/ERC721MintBurn.behaviour.js
+++ b/test/token/ERC721/ERC721MintBurn.behaviour.js
@@ -2,7 +2,6 @@ const { assertRevert } = require('../../helpers/assertRevert');
 const BigNumber = web3.BigNumber;
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 

--- a/test/token/ERC721/ERC721Token.test.js
+++ b/test/token/ERC721/ERC721Token.test.js
@@ -8,7 +8,6 @@ const BigNumber = web3.BigNumber;
 const ERC721Token = artifacts.require('ERC721TokenMock.sol');
 
 require('chai')
-  .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
 


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Addresses #1091 -- it's about @nventuro's comment about removing `chai-as-promised`

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
I'm doing a few things here:
1. I enhanced expectThrow to test for one particular EVM message, e.g. `invalid opcode`
2. I change all test cases to either just `await` and be done, or I use `expectThrow` and test for a specific exception message
3. I remove chai-as-promised from package.json

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
