### PR TITLE
feat: Add safeIsContract check To AddressUtils.sol

### DIFF
--- a/contracts/AddressUtils.sol
+++ b/contracts/AddressUtils.sol
@@ -7,7 +7,7 @@ import "./ECRecovery.sol";
  */
 library AddressUtils {
 
-  using ECRecovery for ECRecovery.recover;
+  using ECRecovery for bytes32;
 
   /**
    * Returns whether the target address is a contract
@@ -37,7 +37,7 @@ library AddressUtils {
    * @return whether the target address is a contract
    */
   function safeIsContract(address addr, bytes32 hash, bytes sig) internal view returns (bool) {
-    return ECRecovery.recover(hash, sig) == addr;
+    return hash.recover(sig) == addr;
   }
 
 }

--- a/contracts/AddressUtils.sol
+++ b/contracts/AddressUtils.sol
@@ -1,29 +1,43 @@
 pragma solidity ^0.4.24;
 
+import "./ECRecovery.sol";
 
 /**
  * Utility library of inline functions on addresses
  */
 library AddressUtils {
 
+  using ECRecovery for ECRecovery.recover;
+
   /**
    * Returns whether the target address is a contract
    * @dev This function will return false if invoked during the constructor of a contract,
-   * as the code is not actually created until after the constructor finishes.
+   * as the code is not actually created until after the constructor finishes. For more info
+   * see https://ethereum.stackexchange.com/a/14016/36603
    * @param addr address to check
    * @return whether the target address is a contract
    */
   function isContract(address addr) internal view returns (bool) {
     uint256 size;
-    // XXX Currently there is no better way to check if there is a contract in an address
-    // than to check the size of the code at that address.
-    // See https://ethereum.stackexchange.com/a/14016/36603
-    // for more details about how this works.
+  
     // TODO Check this again before the Serenity release, because all addresses will be
     // contracts then.
     // solium-disable-next-line security/no-inline-assembly
     assembly { size := extcodesize(addr) }
     return size > 0;
+  }
+
+  /**
+   * Returns whether the target address is a contract safely by checking the ECDSA signature 
+   * for a private key, which contracts do not have
+   * @dev securely check if an address is a contract
+   * @param addr address to check
+   * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
+   * @param sig bytes signature, the signature is generated using web3.eth.sign()
+   * @return whether the target address is a contract
+   */
+  function safeIsContract(address addr, bytes32 hash, bytes sig) internal view returns (bool) {
+    return ECRecovery.recover(hash, sig) == addr;
   }
 
 }


### PR DESCRIPTION
# 🚀 Description
Adds a safe way to check if an address is a contract while not removing the current isContract method used by other contracts. Despite the warning that the constructor of a contract will execute with code size zero, other developers might use the implementation believing that the current isContract method check is sufficient for their use case. 

<!-- 2. Describe the changes introduced in this pull request -->

Adds a single method "safeIsContract" to the AddressUtils library that uses the ECRecovery library's recover function to check for the existence of a private key, which contracts do not have. 

<!--    Include any context necessary for understanding the PR's purpose. -->

https://www.reddit.com/r/ethereum/comments/916xni/how_to_pwn_fomo3d_a_beginners_guide/
Exploits like this exist from developers not understanding the risks of using the current isContract method. 

