### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,7 @@
     "no-dupe-keys": "error",
     "no-mixed-spaces-and-tabs": ["error", "smart-tabs"],
     "no-redeclare": ["error", {"builtinGlobals": true}],
-    "no-trailing-spaces": ["error", { "skipBlankLines": true }],
+    "no-trailing-spaces": ["error", { "skipBlankLines": false }],
     "no-undef": "error",
     "no-use-before-define": "off",
     "no-var": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
     "comma-dangle": ["warn", "always-multiline"],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "dot-notation": ["error", {"allowKeywords": true, "allowPattern": ""}],
-    "eol-last": "warn",
+    "eol-last": ["error", "always"],
     "eqeqeq": ["error", "smart"],
     "generator-star-spacing": ["error", "before"],
     "indent": ["error", 2],

--- a/test/Bounty.test.js
+++ b/test/Bounty.test.js
@@ -25,7 +25,7 @@ contract('Bounty', function ([_, owner, researcher]) {
 
     it('can set reward', async function () {
       await sendReward(owner, this.bounty.address, reward);
-      
+
       const balance = await ethGetBalance(this.bounty.address);
       balance.should.be.bignumber.eq(reward);
     });


### PR DESCRIPTION
# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

This adds a so called `.editorconfig` file, which makes it easy for a wide variety of editors to automatically code in OpenZeppelin's preferred 2-space indentation style. You can find more information about EditorConfig [right here](https://editorconfig.org/). You can refer to [this list of projects](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig) to see that among the most prominent users of EditorConfig are:

- Babel,
- Django, and
- Homebrew (among many other)

__Question:__ Should this be documented somewhere? A lot of editors supports EditorConfig natively, so nothing special needs to be done. These are the editors that support it natively: [https://editorconfig.org/#download]. Below there is a list of plugins as well. Since I use Neovim, I simply had to install [editorconfig-vim](https://github.com/editorconfig/editorconfig-vim#readme)

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
