### PR TITLE
assertRevert: Fix late return bug

### DIFF
--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -1,11 +1,12 @@
 async function assertRevert (promise) {
   try {
     await promise;
-    assert.fail('Expected revert not received');
   } catch (error) {
     const revertFound = error.message.search('revert') >= 0;
     assert(revertFound, `Expected "revert", got ${error} instead`);
+    return;
   }
+  assert.fail('Expected revert not received');
 }
 
 module.exports = {


### PR DESCRIPTION


<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #775

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
We now ensure that if an exception is thrown while awaiting the promise,
the exception _has_ to be a revert. We throw 'Expected revert not
received' only afterwards. This solves any problems with confusing the
word 'revert'.
<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
