### PR TITLE
Crowdsale inheritance order

### DIFF
--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -10,7 +10,7 @@ import "../validation/TimedCrowdsale.sol";
  * @dev Extension of Crowdsale where an owner can do extra work
  * after finishing.
  */
-contract FinalizableCrowdsale is TimedCrowdsale, Ownable {
+contract FinalizableCrowdsale is Ownable, TimedCrowdsale {
   using SafeMath for uint256;
 
   bool public isFinalized = false;

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -9,7 +9,7 @@ import "../../ownership/Ownable.sol";
  * @title IndividuallyCappedCrowdsale
  * @dev Crowdsale with per-user caps.
  */
-contract IndividuallyCappedCrowdsale is Crowdsale, Ownable {
+contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   using SafeMath for uint256;
 
   mapping(address => uint256) public contributions;


### PR DESCRIPTION
Some derived Crowdsale contracts were impossible to build due to the specified inheritance order of the Crowdsales (see ##1124), this prevents that.

Fixes #1124.
Fixes #1110.