### PR TITLE
Simplify claim payment calculation in contract SplitPayment

### DIFF
--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -13,6 +13,7 @@ contract SplitPayment {
 
   uint256 public totalShares = 0;
   uint256 public totalReleased = 0;
+  uint256 public totalFundsPerShare = 0;
 
   mapping(address => uint256) public shares;
   mapping(address => uint256) public released;
@@ -33,7 +34,11 @@ contract SplitPayment {
   /**
    * @dev payable fallback
    */
-  function () external payable {}
+  function () external payable {
+    uint256 newFunds = msg.value;
+    uint256 fundsPerShare = newFunds.div(totalShares);
+    totalFundsPerShare = totalFundsPerShare.add(fundsPerShare);
+  }
 
   /**
    * @dev Claim your share of the balance.
@@ -43,11 +48,9 @@ contract SplitPayment {
 
     require(shares[payee] > 0);
 
-    uint256 totalReceived = address(this).balance.add(totalReleased);
-    uint256 payment = totalReceived.mul(
-      shares[payee]).div(
-        totalShares).sub(
-          released[payee]
+    uint256 payment = totalFundsPerShare.mul(
+      shares[payee]).sub(
+        released[payee]
     );
 
     require(payment != 0);

--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -12,7 +12,6 @@ contract SplitPayment {
   using SafeMath for uint256;
 
   uint256 public totalShares = 0;
-  uint256 public totalReleased = 0;
   uint256 public totalFundsPerShare = 0;
 
   mapping(address => uint256) public shares;
@@ -57,7 +56,6 @@ contract SplitPayment {
     require(address(this).balance >= payment);
 
     released[payee] = released[payee].add(payment);
-    totalReleased = totalReleased.add(payment);
 
     payee.transfer(payment);
   }

--- a/test/payment/SplitPayment.test.js
+++ b/test/payment/SplitPayment.test.js
@@ -90,10 +90,6 @@ contract('SplitPayment', function ([_, owner, payee1, payee2, payee3, nonpayee1,
       // end balance should be zero
       const endBalance = await ethGetBalance(this.contract.address);
       endBalance.should.be.bignumber.equal(0);
-
-      // check correct funds released accounting
-      const totalReleased = await this.contract.totalReleased.call();
-      totalReleased.should.be.bignumber.equal(initBalance);
     });
   });
 });

--- a/test/payment/SplitPayment.test.js
+++ b/test/payment/SplitPayment.test.js
@@ -38,6 +38,11 @@ contract('SplitPayment', function ([_, owner, payee1, payee2, payee3, nonpayee1,
 
       const balance = await ethGetBalance(this.contract.address);
       balance.should.be.bignumber.equal(amount);
+
+      // check correct totalFundsPerShare calculation
+      const totalFundsPerShare = await this.contract.totalFundsPerShare.call();
+      const totalShares = await this.contract.totalShares.call();
+      totalFundsPerShare.should.be.bignumber.equal(amount / totalShares);
     });
 
     it('should store shares if address is payee', async function () {


### PR DESCRIPTION
# 🚀 Description
In Contract **SplitPayment**
* adds state variable `totalFundsPerShare` which is updated when funds are deposited into contract.
* Uses `totalFundsPerShare` to simplify and reduce math operations to calculate `payment` in function `claim()`.
* adds a test for value of `totalFundsPerShare` in **SplitPayment.test.spec**.

**Note:**  State variable `totalReleased` now only serves an accounting purpose. This variable could be removed if accounting of total released is not needed.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
