### PR TITLE
SplitPayment now requires payees.

### DIFF
--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -23,6 +23,7 @@ contract SplitPayment {
    */
   constructor(address[] _payees, uint256[] _shares) public payable {
     require(_payees.length == _shares.length);
+    require(_payees.length > 0);
 
     for (uint256 i = 0; i < _payees.length; i++) {
       addPayee(_payees[i], _shares[i]);

--- a/test/payment/SplitPayment.test.js
+++ b/test/payment/SplitPayment.test.js
@@ -13,68 +13,82 @@ const SplitPayment = artifacts.require('SplitPayment');
 contract('SplitPayment', function ([owner, payee1, payee2, payee3, nonpayee1, payer1]) {
   const amount = web3.toWei(1.0, 'ether');
 
-  beforeEach(async function () {
-    this.payees = [payee1, payee2, payee3];
-    this.shares = [20, 10, 70];
-
-    this.contract = await SplitPayment.new(this.payees, this.shares);
+  it('cannot be created with no payees', async function () {
+    await expectThrow(SplitPayment.new([], []), EVMThrow);
   });
 
-  it('should accept payments', async function () {
-    await ethSendTransaction({ from: owner, to: this.contract.address, value: amount });
-
-    const balance = await ethGetBalance(this.contract.address);
-    balance.should.be.bignumber.equal(amount);
+  it('requires shares for each payee', async function () {
+    await expectThrow(SplitPayment.new([payee1, payee2, payee3], [20, 30]), EVMThrow);
   });
 
-  it('should store shares if address is payee', async function () {
-    const shares = await this.contract.shares.call(payee1);
-    shares.should.be.bignumber.not.equal(0);
+  it('requires a payee for each share', async function () {
+    await expectThrow(SplitPayment.new([payee1, payee2], [20, 30, 40]), EVMThrow);
   });
 
-  it('should not store shares if address is not payee', async function () {
-    const shares = await this.contract.shares.call(nonpayee1);
-    shares.should.be.bignumber.equal(0);
-  });
+  context('with deployed contract', function () {
+    beforeEach(async function () {
+      this.payees = [payee1, payee2, payee3];
+      this.shares = [20, 10, 70];
 
-  it('should throw if no funds to claim', async function () {
-    await expectThrow(this.contract.claim({ from: payee1 }), EVMThrow);
-  });
+      this.contract = await SplitPayment.new(this.payees, this.shares);
+    });
 
-  it('should throw if non-payee want to claim', async function () {
-    await ethSendTransaction({ from: payer1, to: this.contract.address, value: amount });
-    await expectThrow(this.contract.claim({ from: nonpayee1 }), EVMThrow);
-  });
+    it('should accept payments', async function () {
+      await ethSendTransaction({ from: owner, to: this.contract.address, value: amount });
 
-  it('should distribute funds to payees', async function () {
-    await ethSendTransaction({ from: payer1, to: this.contract.address, value: amount });
+      const balance = await ethGetBalance(this.contract.address);
+      balance.should.be.bignumber.equal(amount);
+    });
 
-    // receive funds
-    const initBalance = await ethGetBalance(this.contract.address);
-    initBalance.should.be.bignumber.equal(amount);
+    it('should store shares if address is payee', async function () {
+      const shares = await this.contract.shares.call(payee1);
+      shares.should.be.bignumber.not.equal(0);
+    });
 
-    // distribute to payees
-    const initAmount1 = await ethGetBalance(payee1);
-    await this.contract.claim({ from: payee1 });
-    const profit1 = await ethGetBalance(payee1) - initAmount1;
-    assert(Math.abs(profit1 - web3.toWei(0.20, 'ether')) < 1e16);
+    it('should not store shares if address is not payee', async function () {
+      const shares = await this.contract.shares.call(nonpayee1);
+      shares.should.be.bignumber.equal(0);
+    });
 
-    const initAmount2 = await ethGetBalance(payee2);
-    await this.contract.claim({ from: payee2 });
-    const profit2 = await ethGetBalance(payee2) - initAmount2;
-    assert(Math.abs(profit2 - web3.toWei(0.10, 'ether')) < 1e16);
+    it('should throw if no funds to claim', async function () {
+      await expectThrow(this.contract.claim({ from: payee1 }), EVMThrow);
+    });
 
-    const initAmount3 = await ethGetBalance(payee3);
-    await this.contract.claim({ from: payee3 });
-    const profit3 = await ethGetBalance(payee3) - initAmount3;
-    assert(Math.abs(profit3 - web3.toWei(0.70, 'ether')) < 1e16);
+    it('should throw if non-payee want to claim', async function () {
+      await ethSendTransaction({ from: payer1, to: this.contract.address, value: amount });
+      await expectThrow(this.contract.claim({ from: nonpayee1 }), EVMThrow);
+    });
 
-    // end balance should be zero
-    const endBalance = await ethGetBalance(this.contract.address);
-    endBalance.should.be.bignumber.equal(0);
+    it('should distribute funds to payees', async function () {
+      await ethSendTransaction({ from: payer1, to: this.contract.address, value: amount });
 
-    // check correct funds released accounting
-    const totalReleased = await this.contract.totalReleased.call();
-    totalReleased.should.be.bignumber.equal(initBalance);
+      // receive funds
+      const initBalance = await ethGetBalance(this.contract.address);
+      initBalance.should.be.bignumber.equal(amount);
+
+      // distribute to payees
+      const initAmount1 = await ethGetBalance(payee1);
+      await this.contract.claim({ from: payee1 });
+      const profit1 = await ethGetBalance(payee1) - initAmount1;
+      assert(Math.abs(profit1 - web3.toWei(0.20, 'ether')) < 1e16);
+
+      const initAmount2 = await ethGetBalance(payee2);
+      await this.contract.claim({ from: payee2 });
+      const profit2 = await ethGetBalance(payee2) - initAmount2;
+      assert(Math.abs(profit2 - web3.toWei(0.10, 'ether')) < 1e16);
+
+      const initAmount3 = await ethGetBalance(payee3);
+      await this.contract.claim({ from: payee3 });
+      const profit3 = await ethGetBalance(payee3) - initAmount3;
+      assert(Math.abs(profit3 - web3.toWei(0.70, 'ether')) < 1e16);
+
+      // end balance should be zero
+      const endBalance = await ethGetBalance(this.contract.address);
+      endBalance.should.be.bignumber.equal(0);
+
+      // check correct funds released accounting
+      const totalReleased = await this.contract.totalReleased.call();
+      totalReleased.should.be.bignumber.equal(initBalance);
+    });
   });
 });


### PR DESCRIPTION
The current implementation of `SplitPayment` allows deployment of an instance with no payees, which will cause every single call to `claim` to revert (because `shares[payee] > 0` will always be false ), making all Ether sent to it lost forever. This PR prevents that scenario.