### PR TITLE
Prefix all parameters with underscore

### DIFF
--- a/contracts/AddressUtils.sol
+++ b/contracts/AddressUtils.sol
@@ -10,10 +10,10 @@ library AddressUtils {
    * Returns whether the target address is a contract
    * @dev This function will return false if invoked during the constructor of a contract,
    * as the code is not actually created until after the constructor finishes.
-   * @param addr address to check
+   * @param _addr address to check
    * @return whether the target address is a contract
    */
-  function isContract(address addr) internal view returns (bool) {
+  function isContract(address _addr) internal view returns (bool) {
     uint256 size;
     // XXX Currently there is no better way to check if there is a contract in an address
     // than to check the size of the code at that address.
@@ -22,7 +22,7 @@ library AddressUtils {
     // TODO Check this again before the Serenity release, because all addresses will be
     // contracts then.
     // solium-disable-next-line security/no-inline-assembly
-    assembly { size := extcodesize(addr) }
+    assembly { size := extcodesize(_addr) }
     return size > 0;
   }
 

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -36,13 +36,13 @@ contract Bounty is PullPayment, Destructible {
 
   /**
    * @dev Transfers the contract funds to the researcher that proved the contract is broken.
-   * @param target contract
+   * @param _target contract
    */
-  function claim(Target target) public {
-    address researcher = researchers[target];
+  function claim(Target _target) public {
+    address researcher = researchers[_target];
     require(researcher != address(0));
     // Check Target contract invariants
-    require(!target.checkInvariant());
+    require(!_target.checkInvariant());
     asyncTransfer(researcher, address(this).balance);
     claimed = true;
   }

--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -12,10 +12,10 @@ library ECRecovery {
 
   /**
    * @dev Recover signer address from a message by using their signature
-   * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
-   * @param sig bytes signature, the signature is generated using web3.eth.sign()
+   * @param _hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
+   * @param _sig bytes signature, the signature is generated using web3.eth.sign()
    */
-  function recover(bytes32 hash, bytes sig)
+  function recover(bytes32 _hash, bytes _sig)
     internal
     pure
     returns (address)
@@ -25,7 +25,7 @@ library ECRecovery {
     uint8 v;
 
     // Check the signature length
-    if (sig.length != 65) {
+    if (_sig.length != 65) {
       return (address(0));
     }
 
@@ -34,9 +34,9 @@ library ECRecovery {
     // currently is to use assembly.
     // solium-disable-next-line security/no-inline-assembly
     assembly {
-      r := mload(add(sig, 32))
-      s := mload(add(sig, 64))
-      v := byte(0, mload(add(sig, 96)))
+      r := mload(add(_sig, 32))
+      s := mload(add(_sig, 64))
+      v := byte(0, mload(add(_sig, 96)))
     }
 
     // Version of signature should be 27 or 28, but 0 and 1 are also possible versions
@@ -49,7 +49,7 @@ library ECRecovery {
       return (address(0));
     } else {
       // solium-disable-next-line arg-overflow
-      return ecrecover(hash, v, r, s);
+      return ecrecover(_hash, v, r, s);
     }
   }
 
@@ -58,7 +58,7 @@ library ECRecovery {
    * @dev prefix a bytes32 value with "\x19Ethereum Signed Message:"
    * and hash the result
    */
-  function toEthSignedMessageHash(bytes32 hash)
+  function toEthSignedMessageHash(bytes32 _hash)
     internal
     pure
     returns (bytes32)
@@ -66,7 +66,7 @@ library ECRecovery {
     // 32 is the length in bytes of hash,
     // enforced by the type signature above
     return keccak256(
-      abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)
+      abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash)
     );
   }
 }

--- a/contracts/access/SignatureBouncer.sol
+++ b/contracts/access/SignatureBouncer.sol
@@ -146,12 +146,12 @@ contract SignatureBouncer is Ownable, RBAC {
    * and then recover the signature and check it against the bouncer role
    * @return bool
    */
-  function isValidDataHash(bytes32 hash, bytes _sig)
+  function isValidDataHash(bytes32 _hash, bytes _sig)
     internal
     view
     returns (bool)
   {
-    address signer = hash
+    address signer = _hash
       .toEthSignedMessageHash()
       .recover(_sig);
     return hasRole(signer, ROLE_BOUNCER);

--- a/contracts/access/rbac/Roles.sol
+++ b/contracts/access/rbac/Roles.sol
@@ -15,41 +15,41 @@ library Roles {
   /**
    * @dev give an address access to this role
    */
-  function add(Role storage role, address addr)
+  function add(Role storage _role, address _addr)
     internal
   {
-    role.bearer[addr] = true;
+    _role.bearer[_addr] = true;
   }
 
   /**
    * @dev remove an address' access to this role
    */
-  function remove(Role storage role, address addr)
+  function remove(Role storage _role, address _addr)
     internal
   {
-    role.bearer[addr] = false;
+    _role.bearer[_addr] = false;
   }
 
   /**
    * @dev check if an address has this role
    * // reverts
    */
-  function check(Role storage role, address addr)
+  function check(Role storage _role, address _addr)
     view
     internal
   {
-    require(has(role, addr));
+    require(has(_role, _addr));
   }
 
   /**
    * @dev check if an address has this role
    * @return bool
    */
-  function has(Role storage role, address addr)
+  function has(Role storage _role, address _addr)
     view
     internal
     returns (bool)
   {
-    return role.bearer[addr];
+    return _role.bearer[_addr];
   }
 }

--- a/contracts/examples/RBACWithAdmin.sol
+++ b/contracts/examples/RBACWithAdmin.sol
@@ -42,25 +42,25 @@ contract RBACWithAdmin is RBAC {
 
   /**
    * @dev add a role to an address
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _addr address
+   * @param _roleName the name of the role
    */
-  function adminAddRole(address addr, string roleName)
+  function adminAddRole(address _addr, string _roleName)
     onlyAdmin
     public
   {
-    addRole(addr, roleName);
+    addRole(_addr, _roleName);
   }
 
   /**
    * @dev remove a role from an address
-   * @param addr address
-   * @param roleName the name of the role
+   * @param _addr address
+   * @param _roleName the name of the role
    */
-  function adminRemoveRole(address addr, string roleName)
+  function adminRemoveRole(address _addr, string _roleName)
     onlyAdmin
     public
   {
-    removeRole(addr, roleName);
+    removeRole(_addr, _roleName);
   }
 }

--- a/contracts/examples/SimpleSavingsWallet.sol
+++ b/contracts/examples/SimpleSavingsWallet.sol
@@ -31,10 +31,10 @@ contract SimpleSavingsWallet is Heritable {
   /**
    * @dev wallet can send funds
    */
-  function sendTo(address payee, uint256 amount) public onlyOwner {
-    require(payee != address(0) && payee != address(this));
-    require(amount > 0);
-    payee.transfer(amount);
-    emit Sent(payee, amount, address(this).balance);
+  function sendTo(address _payee, uint256 _amount) public onlyOwner {
+    require(_payee != address(0) && _payee != address(this));
+    require(_amount > 0);
+    _payee.transfer(_amount);
+    emit Sent(_payee, _amount, address(this).balance);
   }
 }

--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -16,16 +16,16 @@ contract TokenDestructible is Ownable {
 
   /**
    * @notice Terminate contract and refund to owner
-   * @param tokens List of addresses of ERC20 or ERC20Basic token contracts to
+   * @param _tokens List of addresses of ERC20 or ERC20Basic token contracts to
    refund.
    * @notice The called token contracts could try to re-enter this contract. Only
    supply token contracts you trust.
    */
-  function destroy(address[] tokens) onlyOwner public {
+  function destroy(address[] _tokens) onlyOwner public {
 
     // Transfer tokens to owner
-    for (uint256 i = 0; i < tokens.length; i++) {
-      ERC20Basic token = ERC20Basic(tokens[i]);
+    for (uint256 i = 0; i < _tokens.length; i++) {
+      ERC20Basic token = ERC20Basic(_tokens[i]);
       uint256 balance = token.balanceOf(this);
       token.transfer(owner, balance);
     }

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -6,19 +6,19 @@ pragma solidity ^0.4.24;
  * @dev Assorted math operations
  */
 library Math {
-  function max64(uint64 a, uint64 b) internal pure returns (uint64) {
-    return a >= b ? a : b;
+  function max64(uint64 _a, uint64 _b) internal pure returns (uint64) {
+    return _a >= _b ? _a : _b;
   }
 
-  function min64(uint64 a, uint64 b) internal pure returns (uint64) {
-    return a < b ? a : b;
+  function min64(uint64 _a, uint64 _b) internal pure returns (uint64) {
+    return _a < _b ? _a : _b;
   }
 
-  function max256(uint256 a, uint256 b) internal pure returns (uint256) {
-    return a >= b ? a : b;
+  function max256(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    return _a >= _b ? _a : _b;
   }
 
-  function min256(uint256 a, uint256 b) internal pure returns (uint256) {
-    return a < b ? a : b;
+  function min256(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    return _a < _b ? _a : _b;
   }
 }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -10,43 +10,43 @@ library SafeMath {
   /**
   * @dev Multiplies two numbers, throws on overflow.
   */
-  function mul(uint256 a, uint256 b) internal pure returns (uint256 c) {
+  function mul(uint256 _a, uint256 _b) internal pure returns (uint256 c) {
     // Gas optimization: this is cheaper than asserting 'a' not being zero, but the
     // benefit is lost if 'b' is also tested.
     // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
-    if (a == 0) {
+    if (_a == 0) {
       return 0;
     }
 
-    c = a * b;
-    assert(c / a == b);
+    c = _a * _b;
+    assert(c / _a == _b);
     return c;
   }
 
   /**
   * @dev Integer division of two numbers, truncating the quotient.
   */
-  function div(uint256 a, uint256 b) internal pure returns (uint256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
-    // uint256 c = a / b;
-    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-    return a / b;
+  function div(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    // assert(_b > 0); // Solidity automatically throws when dividing by 0
+    // uint256 c = _a / _b;
+    // assert(_a == _b * c + _a % _b); // There is no case in which this doesn't hold
+    return _a / _b;
   }
 
   /**
   * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
   */
-  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-    assert(b <= a);
-    return a - b;
+  function sub(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    assert(_b <= _a);
+    return _a - _b;
   }
 
   /**
   * @dev Adds two numbers, throws on overflow.
   */
-  function add(uint256 a, uint256 b) internal pure returns (uint256 c) {
-    c = a + b;
-    assert(c >= a);
+  function add(uint256 _a, uint256 _b) internal pure returns (uint256 c) {
+    c = _a + _b;
+    assert(c >= _a);
     return c;
   }
 }

--- a/contracts/mocks/BasicTokenMock.sol
+++ b/contracts/mocks/BasicTokenMock.sol
@@ -7,9 +7,9 @@ import "../token/ERC20/BasicToken.sol";
 // mock class using BasicToken
 contract BasicTokenMock is BasicToken {
 
-  constructor(address initialAccount, uint256 initialBalance) public {
-    balances[initialAccount] = initialBalance;
-    totalSupply_ = initialBalance;
+  constructor(address _initialAccount, uint256 _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
+    totalSupply_ = _initialBalance;
   }
 
 }

--- a/contracts/mocks/BurnableTokenMock.sol
+++ b/contracts/mocks/BurnableTokenMock.sol
@@ -5,9 +5,9 @@ import "../token/ERC20/BurnableToken.sol";
 
 contract BurnableTokenMock is BurnableToken {
 
-  constructor(address initialAccount, uint initialBalance) public {
-    balances[initialAccount] = initialBalance;
-    totalSupply_ = initialBalance;
+  constructor(address _initialAccount, uint _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
+    totalSupply_ = _initialBalance;
   }
 
 }

--- a/contracts/mocks/ECRecoveryMock.sol
+++ b/contracts/mocks/ECRecoveryMock.sol
@@ -7,19 +7,19 @@ import "../ECRecovery.sol";
 contract ECRecoveryMock {
   using ECRecovery for bytes32;
 
-  function recover(bytes32 hash, bytes sig)
+  function recover(bytes32 _hash, bytes _sig)
     public
     pure
     returns (address)
   {
-    return hash.recover(sig);
+    return _hash.recover(_sig);
   }
 
-  function toEthSignedMessageHash(bytes32 hash)
+  function toEthSignedMessageHash(bytes32 _hash)
     public
     pure
     returns (bytes32)
   {
-    return hash.toEthSignedMessageHash();
+    return _hash.toEthSignedMessageHash();
   }
 }

--- a/contracts/mocks/ERC223TokenMock.sol
+++ b/contracts/mocks/ERC223TokenMock.sol
@@ -10,9 +10,9 @@ contract ERC223ContractInterface {
 
 contract ERC223TokenMock is BasicToken {
 
-  constructor(address initialAccount, uint256 initialBalance) public {
-    balances[initialAccount] = initialBalance;
-    totalSupply_ = initialBalance;
+  constructor(address _initialAccount, uint256 _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
+    totalSupply_ = _initialBalance;
   }
 
   // ERC223 compatible transfer function (except the name)

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -8,19 +8,19 @@ contract MathMock {
   uint64 public result64;
   uint256 public result256;
 
-  function max64(uint64 a, uint64 b) public {
-    result64 = Math.max64(a, b);
+  function max64(uint64 _a, uint64 _b) public {
+    result64 = Math.max64(_a, _b);
   }
 
-  function min64(uint64 a, uint64 b) public {
-    result64 = Math.min64(a, b);
+  function min64(uint64 _a, uint64 _b) public {
+    result64 = Math.min64(_a, _b);
   }
 
-  function max256(uint256 a, uint256 b) public {
-    result256 = Math.max256(a, b);
+  function max256(uint256 _a, uint256 _b) public {
+    result256 = Math.max256(_a, _b);
   }
 
-  function min256(uint256 a, uint256 b) public {
-    result256 = Math.min256(a, b);
+  function min256(uint256 _a, uint256 _b) public {
+    result256 = Math.min256(_a, _b);
   }
 }

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -7,30 +7,30 @@ contract MessageHelper {
   event Buy(bytes32 b32, uint256 number, string text, uint256 value);
 
   function showMessage(
-    bytes32 message,
-    uint256 number,
-    string text
+    bytes32 _message,
+    uint256 _number,
+    string _text
   )
     public
     returns (bool)
   {
-    emit Show(message, number, text);
+    emit Show(_message, _number, _text);
     return true;
   }
 
   function buyMessage(
-    bytes32 message,
-    uint256 number,
-    string text
+    bytes32 _message,
+    uint256 _number,
+    string _text
   )
     public
     payable
     returns (bool)
   {
     emit Buy(
-      message,
-      number,
-      text,
+      _message,
+      _number,
+      _text,
       msg.value);
     return true;
   }
@@ -39,9 +39,9 @@ contract MessageHelper {
     require(false);
   }
 
-  function call(address to, bytes data) public returns (bool) {
+  function call(address _to, bytes _data) public returns (bool) {
     // solium-disable-next-line security/no-low-level-calls
-    if (to.call(data))
+    if (_to.call(_data))
       return true;
     else
       return false;

--- a/contracts/mocks/PausableTokenMock.sol
+++ b/contracts/mocks/PausableTokenMock.sol
@@ -6,8 +6,8 @@ import "../token/ERC20/PausableToken.sol";
 // mock class using PausableToken
 contract PausableTokenMock is PausableToken {
 
-  constructor(address initialAccount, uint initialBalance) public {
-    balances[initialAccount] = initialBalance;
+  constructor(address _initialAccount, uint _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
   }
 
 }

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -10,8 +10,8 @@ contract PullPaymentMock is PullPayment {
   constructor() public payable { }
 
   // test helper function to call asyncTransfer
-  function callTransfer(address dest, uint256 amount) public {
-    asyncTransfer(dest, amount);
+  function callTransfer(address _dest, uint256 _amount) public {
+    asyncTransfer(_dest, _amount);
   }
 
 }

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.4.24;
 
 contract ReentrancyAttack {
 
-  function callSender(bytes4 data) public {
+  function callSender(bytes4 _data) public {
     // solium-disable-next-line security/no-low-level-calls
-    require(msg.sender.call(abi.encodeWithSelector(data)));
+    require(msg.sender.call(abi.encodeWithSelector(_data)));
   }
 
 }

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -16,26 +16,26 @@ contract ReentrancyMock is ReentrancyGuard {
     count();
   }
 
-  function countLocalRecursive(uint256 n) public nonReentrant {
-    if (n > 0) {
+  function countLocalRecursive(uint256 _n) public nonReentrant {
+    if (_n > 0) {
       count();
-      countLocalRecursive(n - 1);
+      countLocalRecursive(_n - 1);
     }
   }
 
-  function countThisRecursive(uint256 n) public nonReentrant {
-    if (n > 0) {
+  function countThisRecursive(uint256 _n) public nonReentrant {
+    if (_n > 0) {
       count();
       // solium-disable-next-line security/no-low-level-calls
-      bool result = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
+      bool result = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", _n - 1));
       require(result == true);
     }
   }
 
-  function countAndCall(ReentrancyAttack attacker) public nonReentrant {
+  function countAndCall(ReentrancyAttack _attacker) public nonReentrant {
     count();
     bytes4 func = bytes4(keccak256("callback()"));
-    attacker.callSender(func);
+    _attacker.callSender(func);
   }
 
   function count() private {

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -6,19 +6,19 @@ import "../math/SafeMath.sol";
 
 contract SafeMathMock {
 
-  function mul(uint256 a, uint256 b) public pure returns (uint256) {
-    return SafeMath.mul(a, b);
+  function mul(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return SafeMath.mul(_a, _b);
   }
 
-  function div(uint256 a, uint256 b) public pure returns (uint256) {
-    return SafeMath.div(a, b);
+  function div(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return SafeMath.div(_a, _b);
   }
 
-  function sub(uint256 a, uint256 b) public pure returns (uint256) {
-    return SafeMath.sub(a, b);
+  function sub(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return SafeMath.sub(_a, _b);
   }
 
-  function add(uint256 a, uint256 b) public pure returns (uint256) {
-    return SafeMath.add(a, b);
+  function add(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return SafeMath.add(_a, _b);
   }
 }

--- a/contracts/mocks/StandardBurnableTokenMock.sol
+++ b/contracts/mocks/StandardBurnableTokenMock.sol
@@ -5,9 +5,9 @@ import "../token/ERC20/StandardBurnableToken.sol";
 
 contract StandardBurnableTokenMock is StandardBurnableToken {
 
-  constructor(address initialAccount, uint initialBalance) public {
-    balances[initialAccount] = initialBalance;
-    totalSupply_ = initialBalance;
+  constructor(address _initialAccount, uint _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
+    totalSupply_ = _initialBalance;
   }
 
 }

--- a/contracts/mocks/StandardTokenMock.sol
+++ b/contracts/mocks/StandardTokenMock.sol
@@ -6,9 +6,9 @@ import "../token/ERC20/StandardToken.sol";
 // mock class using StandardToken
 contract StandardTokenMock is StandardToken {
 
-  constructor(address initialAccount, uint256 initialBalance) public {
-    balances[initialAccount] = initialBalance;
-    totalSupply_ = initialBalance;
+  constructor(address _initialAccount, uint256 _initialBalance) public {
+    balances[_initialAccount] = _initialBalance;
+    totalSupply_ = _initialBalance;
   }
 
 }

--- a/contracts/ownership/CanReclaimToken.sol
+++ b/contracts/ownership/CanReclaimToken.sol
@@ -16,11 +16,11 @@ contract CanReclaimToken is Ownable {
 
   /**
    * @dev Reclaim all ERC20Basic compatible tokens
-   * @param token ERC20Basic The address of the token contract
+   * @param _token ERC20Basic The address of the token contract
    */
-  function reclaimToken(ERC20Basic token) external onlyOwner {
-    uint256 balance = token.balanceOf(this);
-    token.safeTransfer(owner, balance);
+  function reclaimToken(ERC20Basic _token) external onlyOwner {
+    uint256 balance = _token.balanceOf(this);
+    _token.safeTransfer(owner, balance);
   }
 
 }

--- a/contracts/ownership/Contactable.sol
+++ b/contracts/ownership/Contactable.sol
@@ -14,9 +14,9 @@ contract Contactable is Ownable {
 
   /**
     * @dev Allows the owner to set a string with their contact information.
-    * @param info The contact information to attach to the contract.
+    * @param _info The contact information to attach to the contract.
     */
-  function setContactInformation(string info) onlyOwner public {
-    contactInformation = info;
+  function setContactInformation(string _info) onlyOwner public {
+    contactInformation = _info;
   }
 }

--- a/contracts/ownership/HasNoContracts.sol
+++ b/contracts/ownership/HasNoContracts.sol
@@ -13,10 +13,10 @@ contract HasNoContracts is Ownable {
 
   /**
    * @dev Reclaim ownership of Ownable contracts
-   * @param contractAddr The address of the Ownable to be reclaimed.
+   * @param _contractAddr The address of the Ownable to be reclaimed.
    */
-  function reclaimContract(address contractAddr) external onlyOwner {
-    Ownable contractInst = Ownable(contractAddr);
+  function reclaimContract(address _contractAddr) external onlyOwner {
+    Ownable contractInst = Ownable(_contractAddr);
     contractInst.transferOwnership(owner);
   }
 }

--- a/contracts/ownership/HasNoTokens.sol
+++ b/contracts/ownership/HasNoTokens.sol
@@ -14,14 +14,14 @@ contract HasNoTokens is CanReclaimToken {
 
  /**
   * @dev Reject all ERC223 compatible tokens
-  * @param from_ address The address that is transferring the tokens
-  * @param value_ uint256 the amount of the specified token
-  * @param data_ Bytes The data passed from the caller.
+  * @param _from address The address that is transferring the tokens
+  * @param _value uint256 the amount of the specified token
+  * @param _data Bytes The data passed from the caller.
   */
-  function tokenFallback(address from_, uint256 value_, bytes data_) external pure {
-    from_;
-    value_;
-    data_;
+  function tokenFallback(address _from, uint256 _value, bytes _data) external pure {
+    _from;
+    _value;
+    _data;
     revert();
   }
 

--- a/contracts/ownership/Heritable.sol
+++ b/contracts/ownership/Heritable.sol
@@ -50,11 +50,11 @@ contract Heritable is Ownable {
     setHeartbeatTimeout(_heartbeatTimeout);
   }
 
-  function setHeir(address newHeir) public onlyOwner {
-    require(newHeir != owner);
+  function setHeir(address _newHeir) public onlyOwner {
+    require(_newHeir != owner);
     heartbeat();
-    emit HeirChanged(owner, newHeir);
-    heir_ = newHeir;
+    emit HeirChanged(owner, _newHeir);
+    heir_ = _newHeir;
   }
 
   /**
@@ -113,11 +113,11 @@ contract Heritable is Ownable {
     timeOfDeath_ = 0;
   }
 
-  function setHeartbeatTimeout(uint256 newHeartbeatTimeout)
+  function setHeartbeatTimeout(uint256 _newHeartbeatTimeout)
     internal onlyOwner
   {
     require(ownerLives());
-    heartbeatTimeout_ = newHeartbeatTimeout;
+    heartbeatTimeout_ = _newHeartbeatTimeout;
   }
 
   function ownerLives() internal view returns (bool) {

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -8,13 +8,13 @@ import "./ERC20Basic.sol";
  * @dev see https://github.com/ethereum/EIPs/issues/20
  */
 contract ERC20 is ERC20Basic {
-  function allowance(address owner, address spender)
+  function allowance(address _owner, address _spender)
     public view returns (uint256);
 
-  function transferFrom(address from, address to, uint256 value)
+  function transferFrom(address _from, address _to, uint256 _value)
     public returns (bool);
 
-  function approve(address spender, uint256 value) public returns (bool);
+  function approve(address _spender, uint256 _value) public returns (bool);
   event Approval(
     address indexed owner,
     address indexed spender,

--- a/contracts/token/ERC20/ERC20Basic.sol
+++ b/contracts/token/ERC20/ERC20Basic.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.4.24;
  */
 contract ERC20Basic {
   function totalSupply() public view returns (uint256);
-  function balanceOf(address who) public view returns (uint256);
-  function transfer(address to, uint256 value) public returns (bool);
+  function balanceOf(address _who) public view returns (uint256);
+  function transfer(address _to, uint256 _value) public returns (bool);
   event Transfer(address indexed from, address indexed to, uint256 value);
 }

--- a/contracts/token/ERC20/RBACMintableToken.sol
+++ b/contracts/token/ERC20/RBACMintableToken.sol
@@ -25,17 +25,17 @@ contract RBACMintableToken is MintableToken, RBAC {
 
   /**
    * @dev add a minter role to an address
-   * @param minter address
+   * @param _minter address
    */
-  function addMinter(address minter) onlyOwner public {
-    addRole(minter, ROLE_MINTER);
+  function addMinter(address _minter) onlyOwner public {
+    addRole(_minter, ROLE_MINTER);
   }
 
   /**
    * @dev remove a minter role from an address
-   * @param minter address
+   * @param _minter address
    */
-  function removeMinter(address minter) onlyOwner public {
-    removeRole(minter, ROLE_MINTER);
+  function removeMinter(address _minter) onlyOwner public {
+    removeRole(_minter, ROLE_MINTER);
   }
 }

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -11,22 +11,22 @@ import "./ERC20.sol";
  * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
  */
 library SafeERC20 {
-  function safeTransfer(ERC20Basic token, address to, uint256 value) internal {
-    require(token.transfer(to, value));
+  function safeTransfer(ERC20Basic _token, address _to, uint256 _value) internal {
+    require(_token.transfer(_to, _value));
   }
 
   function safeTransferFrom(
-    ERC20 token,
-    address from,
-    address to,
-    uint256 value
+    ERC20 _token,
+    address _from,
+    address _to,
+    uint256 _value
   )
     internal
   {
-    require(token.transferFrom(from, to, value));
+    require(_token.transferFrom(_from, _to, _value));
   }
 
-  function safeApprove(ERC20 token, address spender, uint256 value) internal {
-    require(token.approve(spender, value));
+  function safeApprove(ERC20 _token, address _spender, uint256 _value) internal {
+    require(_token.approve(_spender, _value));
   }
 }

--- a/contracts/token/ERC20/TokenVesting.sol
+++ b/contracts/token/ERC20/TokenVesting.sol
@@ -39,7 +39,7 @@ contract TokenVesting is Ownable {
    * of the balance will have vested.
    * @param _beneficiary address of the beneficiary to whom vested tokens are transferred
    * @param _cliff duration in seconds of the cliff in which tokens will begin to vest
-   * @param _start the time (as Unix time) at which point vesting starts 
+   * @param _start the time (as Unix time) at which point vesting starts
    * @param _duration duration in seconds of the period in which the tokens will vest
    * @param _revocable whether the vesting is revocable or not
    */
@@ -64,16 +64,16 @@ contract TokenVesting is Ownable {
 
   /**
    * @notice Transfers vested tokens to beneficiary.
-   * @param token ERC20 token which is being vested
+   * @param _token ERC20 token which is being vested
    */
-  function release(ERC20Basic token) public {
-    uint256 unreleased = releasableAmount(token);
+  function release(ERC20Basic _token) public {
+    uint256 unreleased = releasableAmount(_token);
 
     require(unreleased > 0);
 
-    released[token] = released[token].add(unreleased);
+    released[_token] = released[_token].add(unreleased);
 
-    token.safeTransfer(beneficiary, unreleased);
+    _token.safeTransfer(beneficiary, unreleased);
 
     emit Released(unreleased);
   }
@@ -81,43 +81,43 @@ contract TokenVesting is Ownable {
   /**
    * @notice Allows the owner to revoke the vesting. Tokens already vested
    * remain in the contract, the rest are returned to the owner.
-   * @param token ERC20 token which is being vested
+   * @param _token ERC20 token which is being vested
    */
-  function revoke(ERC20Basic token) public onlyOwner {
+  function revoke(ERC20Basic _token) public onlyOwner {
     require(revocable);
-    require(!revoked[token]);
+    require(!revoked[_token]);
 
-    uint256 balance = token.balanceOf(this);
+    uint256 balance = _token.balanceOf(this);
 
-    uint256 unreleased = releasableAmount(token);
+    uint256 unreleased = releasableAmount(_token);
     uint256 refund = balance.sub(unreleased);
 
-    revoked[token] = true;
+    revoked[_token] = true;
 
-    token.safeTransfer(owner, refund);
+    _token.safeTransfer(owner, refund);
 
     emit Revoked();
   }
 
   /**
    * @dev Calculates the amount that has already vested but hasn't been released yet.
-   * @param token ERC20 token which is being vested
+   * @param _token ERC20 token which is being vested
    */
-  function releasableAmount(ERC20Basic token) public view returns (uint256) {
-    return vestedAmount(token).sub(released[token]);
+  function releasableAmount(ERC20Basic _token) public view returns (uint256) {
+    return vestedAmount(_token).sub(released[_token]);
   }
 
   /**
    * @dev Calculates the amount that has already vested.
-   * @param token ERC20 token which is being vested
+   * @param _token ERC20 token which is being vested
    */
-  function vestedAmount(ERC20Basic token) public view returns (uint256) {
-    uint256 currentBalance = token.balanceOf(this);
-    uint256 totalBalance = currentBalance.add(released[token]);
+  function vestedAmount(ERC20Basic _token) public view returns (uint256) {
+    uint256 currentBalance = _token.balanceOf(this);
+    uint256 totalBalance = currentBalance.add(released[_token]);
 
     if (block.timestamp < cliff) {
       return 0;
-    } else if (block.timestamp >= start.add(duration) || revoked[token]) {
+    } else if (block.timestamp >= start.add(duration) || revoked[_token]) {
       return totalBalance;
     } else {
       return totalBalance.mul(block.timestamp.sub(start)).div(duration);


### PR DESCRIPTION
# 🚀 Description

Consistently use an underscore as a prefix to identify parameters.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
