### PR TITLE
Use address(this) instead of this

### DIFF
--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -41,7 +41,7 @@ contract TokenTimelock {
     // solium-disable-next-line security/no-block-members
     require(block.timestamp >= releaseTime);
 
-    uint256 amount = token.balanceOf(this);
+    uint256 amount = token.balanceOf(address(this));
     require(amount > 0);
 
     token.safeTransfer(beneficiary, amount);

--- a/contracts/token/ERC20/TokenVesting.sol
+++ b/contracts/token/ERC20/TokenVesting.sol
@@ -87,7 +87,7 @@ contract TokenVesting is Ownable {
     require(revocable);
     require(!revoked[token]);
 
-    uint256 balance = token.balanceOf(this);
+    uint256 balance = token.balanceOf(address(this));
 
     uint256 unreleased = releasableAmount(token);
     uint256 refund = balance.sub(unreleased);
@@ -112,7 +112,7 @@ contract TokenVesting is Ownable {
    * @param token ERC20 token which is being vested
    */
   function vestedAmount(ERC20Basic token) public view returns (uint256) {
-    uint256 currentBalance = token.balanceOf(this);
+    uint256 currentBalance = token.balanceOf(address(this));
     uint256 totalBalance = currentBalance.add(released[token]);
 
     if (block.timestamp < cliff) {


### PR DESCRIPTION


# 🚀 Description
It's preferred to use `address(this)` vs `this`

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
