### PR TITLE
Disable Solium's error-reason rule

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -5,6 +5,7 @@
     "quotes": ["error", "double"],
     "no-empty-blocks": "off",
     "uppercase": "off",
+    "error-reason": "off",
     "indentation": ["error", 2],
     "max-len": ["warning", 79],
     "no-constant": ["error"],


### PR DESCRIPTION
We won't provide error reasons until #888 is closed (which won't be soon), so we should disable this rule until then, to reduce noise on the linter output.