### PR TITLE
Made some Solium rules mandatory.

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -4,11 +4,12 @@
   "rules": {
     "error-reason": "off",
     "indentation": ["error", 2],
-    "max-len": ["warning", 79],
+    "max-len": ["error", 79],
     "no-constant": ["error"],
     "no-empty-blocks": "off",
     "quotes": ["error", "double"],
     "uppercase": "off",
+    "visibility-first": "error",
 
     "security/enforce-explicit-visibility": ["error"],
     "security/no-block-members": ["warning"],


### PR DESCRIPTION
Now that #1105 has been merged, we should enforce the `visibility-first` and `max-len` rules, to make sure our code style remains consistent.