### PR TITLE
Add note about next tag in releasing document

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,10 +34,10 @@ git push upstream vX.Y.Z-rc.R
 
 Draft the release notes in our [GitHub releases](https://github.com/OpenZeppelin/openzeppelin-solidity/releases). Make sure to mark it as a pre-release! Try to be consistent with our previous release notes in the title and format of the text. Release candidates don't need a detailed changelog, but make sure to include a link to GitHub's compare page.
 
-Once the CI run for the new tag is green, publish on npm.
+Once the CI run for the new tag is green, publish on npm under the `next` tag.
 
 ```
-npm publish
+npm publish --tag next
 ```
 
 Publish the release notes on GitHub and ask our community manager to announce the release candidate on at least Slack and Twitter.
@@ -66,6 +66,12 @@ npm publish
 ```
 
 Publish the release notes on GitHub and ask our community manager to announce the release!
+
+Delete the `next` tag in the npm package as there is no longer a release candidate.
+
+```
+npm dist-tag rm --otp $2FA_CODE openzeppelin-solidity next
+```
 
 ## Merging the release branch
 


### PR DESCRIPTION
I forgot to point out that release candidates need to be published under the `next` tag instead of the default `latest` tag.