### PR TITLE
reentrancy mutex gas optimization

### DIFF
--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -9,17 +9,8 @@ pragma solidity ^0.4.24;
  */
 contract ReentrancyGuard {
 
-  /// @dev Constant for unlocked guard state - non-zero to prevent extra gas costs.
-  /// See: https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1056
-  uint private constant REENTRANCY_GUARD_FREE = 1;
-
-  /// @dev Constant for locked guard state
-  uint private constant REENTRANCY_GUARD_LOCKED = 2;
-
-  /**
-   * @dev We use a single lock for the whole contract.
-   */
-  uint private reentrancyLock = REENTRANCY_GUARD_FREE;
+  /// @dev counter to allow mutex lock with only one SSTORE operation
+  uint private guardCounter = 1;
 
   /**
    * @dev Prevents a contract from calling itself, directly or indirectly.
@@ -30,10 +21,9 @@ contract ReentrancyGuard {
    * wrapper marked as `nonReentrant`.
    */
   modifier nonReentrant() {
-    require(reentrancyLock == REENTRANCY_GUARD_FREE);
-    reentrancyLock = REENTRANCY_GUARD_LOCKED;
+    uint localCounter = ++guardCounter;
     _;
-    reentrancyLock = REENTRANCY_GUARD_FREE;
+    require(localCounter == guardCounter);
   }
 
 }


### PR DESCRIPTION
Implementation of reentrancy mutex that is using only one SSTORE operation.
Expected to reduce the original mutex implementation by half. From roughly 10k gas to 5k gas.
