### PR TITLE
Remove Math.min64 and Math.max64

### DIFF
--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -6,19 +6,11 @@ pragma solidity ^0.4.24;
  * @dev Assorted math operations
  */
 library Math {
-  function max64(uint64 _a, uint64 _b) internal pure returns (uint64) {
+  function max(uint256 _a, uint256 _b) internal pure returns (uint256) {
     return _a >= _b ? _a : _b;
   }
 
-  function min64(uint64 _a, uint64 _b) internal pure returns (uint64) {
-    return _a < _b ? _a : _b;
-  }
-
-  function max256(uint256 _a, uint256 _b) internal pure returns (uint256) {
-    return _a >= _b ? _a : _b;
-  }
-
-  function min256(uint256 _a, uint256 _b) internal pure returns (uint256) {
+  function min(uint256 _a, uint256 _b) internal pure returns (uint256) {
     return _a < _b ? _a : _b;
   }
 }

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -5,13 +5,11 @@ import "../../contracts/math/Math.sol";
 
 
 contract MathMock {
-  uint256 public result;
-
-  function max(uint256 _a, uint256 _b) public {
-    result = Math.max(_a, _b);
+  function max(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return Math.max(_a, _b);
   }
 
-  function min(uint256 _a, uint256 _b) public {
-    result = Math.min(_a, _b);
+  function min(uint256 _a, uint256 _b) public pure returns (uint256) {
+    return Math.min(_a, _b);
   }
 }

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -5,22 +5,13 @@ import "../../contracts/math/Math.sol";
 
 
 contract MathMock {
-  uint64 public result64;
-  uint256 public result256;
+  uint256 public result;
 
-  function max64(uint64 _a, uint64 _b) public {
-    result64 = Math.max64(_a, _b);
+  function max(uint256 _a, uint256 _b) public {
+    result = Math.max(_a, _b);
   }
 
-  function min64(uint64 _a, uint64 _b) public {
-    result64 = Math.min64(_a, _b);
-  }
-
-  function max256(uint256 _a, uint256 _b) public {
-    result256 = Math.max256(_a, _b);
-  }
-
-  function min256(uint256 _a, uint256 _b) public {
-    result256 = Math.min256(_a, _b);
+  function min(uint256 _a, uint256 _b) public {
+    result = Math.min(_a, _b);
   }
 }

--- a/test/library/Math.test.js
+++ b/test/library/Math.test.js
@@ -1,25 +1,21 @@
 const MathMock = artifacts.require('MathMock');
 
 contract('Math', function () {
-  let math;
-
   beforeEach(async function () {
-    math = await MathMock.new();
+    this.math = await MathMock.new();
   });
 
   it('returns max correctly', async function () {
     const a = 5678;
     const b = 1234;
-    await math.max(a, b);
-    const result = await math.result();
+    const result = await this.math.max(a, b);
     assert.equal(result, a);
   });
 
   it('returns min correctly', async function () {
     const a = 5678;
     const b = 1234;
-    await math.min(a, b);
-    const result = await math.result();
+    const result = await this.math.min(a, b);
 
     assert.equal(result, b);
   });

--- a/test/library/Math.test.js
+++ b/test/library/Math.test.js
@@ -7,36 +7,19 @@ contract('Math', function () {
     math = await MathMock.new();
   });
 
-  it('returns max64 correctly', async function () {
+  it('returns max correctly', async function () {
     const a = 5678;
     const b = 1234;
-    await math.max64(a, b);
-    const result = await math.result64();
+    await math.max(a, b);
+    const result = await math.result();
     assert.equal(result, a);
   });
 
-  it('returns min64 correctly', async function () {
+  it('returns min correctly', async function () {
     const a = 5678;
     const b = 1234;
-    await math.min64(a, b);
-    const result = await math.result64();
-
-    assert.equal(result, b);
-  });
-
-  it('returns max256 correctly', async function () {
-    const a = 5678;
-    const b = 1234;
-    await math.max256(a, b);
-    const result = await math.result256();
-    assert.equal(result, a);
-  });
-
-  it('returns min256 correctly', async function () {
-    const a = 5678;
-    const b = 1234;
-    await math.min256(a, b);
-    const result = await math.result256();
+    await math.min(a, b);
+    const result = await math.result();
 
     assert.equal(result, b);
   });

--- a/test/library/Math.test.js
+++ b/test/library/Math.test.js
@@ -1,22 +1,34 @@
 const MathMock = artifacts.require('MathMock');
 
 contract('Math', function () {
+  const min = 1234;
+  const max = 5678;
+
   beforeEach(async function () {
     this.math = await MathMock.new();
   });
 
-  it('returns max correctly', async function () {
-    const a = 5678;
-    const b = 1234;
-    const result = await this.math.max(a, b);
-    assert.equal(result, a);
+  describe('max', function () {
+    it('is correctly detected in first argument position', async function () {
+      const result = await this.math.max(max, min);
+      assert.equal(result, max);
+    });
+
+    it('is correctly detected in second argument position', async function () {
+      const result = await this.math.max(min, max);
+      assert.equal(result, max);
+    });
   });
 
-  it('returns min correctly', async function () {
-    const a = 5678;
-    const b = 1234;
-    const result = await this.math.min(a, b);
+  describe('min', function () {
+    it('is correctly detected in first argument position', async function () {
+      const result = await this.math.min(min, max);
+      assert.equal(result, min);
+    });
 
-    assert.equal(result, b);
+    it('is correctly detected in second argument position', async function () {
+      const result = await this.math.min(max, min);
+      assert.equal(result, min);
+    });
   });
 });


### PR DESCRIPTION
These two functions were added at a point where we used `uint64` values in a contract, but we have since made everything `uint256` and this is what we recommend so we should remove the 64-bit variants.