### PR TITLE
Initialize `MAX_UINT` more neatly

### DIFF
--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -7,7 +7,7 @@ require('chai')
   .should();
 
 contract('SafeMath', () => {
-  const MAX_UINT = new BigNumber('115792089237316195423570985008687907853269984665640564039457584007913129639935');
+  const MAX_UINT = new BigNumber(2).pow(256).minus(1);
 
   beforeEach(async function () {
     this.safeMath = await SafeMathMock.new();


### PR DESCRIPTION
Use 2 ^ 256 - 1 instead that huge constant value.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->

Initialize `MAX_UINT` in a manner which makes it clear why this is indeed the maximum `uint` value.

<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [x ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x ] ✅ I've added tests where applicable to test my new functionality.
- [x ] 📖 I've made sure that my contracts are well-documented.
- [x ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
