### PR TITLE
feat: use require in SafeMath

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -3,15 +3,15 @@ pragma solidity ^0.4.24;
 
 /**
  * @title SafeMath
- * @dev Math operations with safety checks that throw on error
+ * @dev Math operations with safety checks that revert on error
  */
 library SafeMath {
 
   /**
-  * @dev Multiplies two numbers, throws on overflow.
+  * @dev Multiplies two numbers, reverts on overflow.
   */
   function mul(uint256 _a, uint256 _b) internal pure returns (uint256) {
-    // Gas optimization: this is cheaper than asserting 'a' not being zero, but the
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
     // benefit is lost if 'b' is also tested.
     // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
     if (_a == 0) {
@@ -19,7 +19,7 @@ library SafeMath {
     }
 
     uint256 c = _a * _b;
-    assert(c / _a == _b);
+    require(c / _a == _b);
 
     return c;
   }
@@ -28,7 +28,7 @@ library SafeMath {
   * @dev Integer division of two numbers, truncating the quotient.
   */
   function div(uint256 _a, uint256 _b) internal pure returns (uint256) {
-    // assert(_b > 0); // Solidity automatically throws when dividing by 0
+    require(_b > 0); // Solidity only automatically asserts when dividing by 0
     uint256 c = _a / _b;
     // assert(_a == _b * c + _a % _b); // There is no case in which this doesn't hold
 
@@ -36,21 +36,21 @@ library SafeMath {
   }
 
   /**
-  * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+  * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
   */
   function sub(uint256 _a, uint256 _b) internal pure returns (uint256) {
-    assert(_b <= _a);
+    require(_b <= _a);
     uint256 c = _a - _b;
 
     return c;
   }
 
   /**
-  * @dev Adds two numbers, throws on overflow.
+  * @dev Adds two numbers, reverts on overflow.
   */
   function add(uint256 _a, uint256 _b) internal pure returns (uint256) {
     uint256 c = _a + _b;
-    assert(c >= _a);
+    require(c >= _a);
 
     return c;
   }

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -1,4 +1,4 @@
-const { assertJump } = require('../helpers/assertJump');
+const { assertRevert } = require('../helpers/assertRevert');
 const BigNumber = web3.BigNumber;
 const SafeMathMock = artifacts.require('SafeMathMock');
 
@@ -22,11 +22,11 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.plus(b));
     });
 
-    it('throws an error on addition overflow', async function () {
+    it('throws an revert error on addition overflow', async function () {
       const a = MAX_UINT;
       const b = new BigNumber(1);
 
-      await assertJump(this.safeMath.add(a, b));
+      await assertRevert(this.safeMath.add(a, b));
     });
   });
 
@@ -39,11 +39,11 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.minus(b));
     });
 
-    it('throws an error if subtraction result would be negative', async function () {
+    it('throws an revert error if subtraction result would be negative', async function () {
       const a = new BigNumber(1234);
       const b = new BigNumber(5678);
 
-      await assertJump(this.safeMath.sub(a, b));
+      await assertRevert(this.safeMath.sub(a, b));
     });
   });
 
@@ -64,11 +64,11 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.times(b));
     });
 
-    it('throws an error on multiplication overflow', async function () {
+    it('throws an revert error on multiplication overflow', async function () {
       const a = MAX_UINT;
       const b = new BigNumber(2);
 
-      await assertJump(this.safeMath.mul(a, b));
+      await assertRevert(this.safeMath.mul(a, b));
     });
   });
 
@@ -81,11 +81,11 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.div(b));
     });
 
-    it('throws an error on zero division', async function () {
+    it('throws an revert error on zero division', async function () {
       const a = new BigNumber(5678);
       const b = new BigNumber(0);
 
-      await assertJump(this.safeMath.div(a, b));
+      await assertRevert(this.safeMath.div(a, b));
     });
   });
 });

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -22,7 +22,7 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.plus(b));
     });
 
-    it('throws an revert error on addition overflow', async function () {
+    it('throws a revert error on addition overflow', async function () {
       const a = MAX_UINT;
       const b = new BigNumber(1);
 
@@ -39,7 +39,7 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.minus(b));
     });
 
-    it('throws an revert error if subtraction result would be negative', async function () {
+    it('throws a revert error if subtraction result would be negative', async function () {
       const a = new BigNumber(1234);
       const b = new BigNumber(5678);
 
@@ -64,7 +64,7 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.times(b));
     });
 
-    it('throws an revert error on multiplication overflow', async function () {
+    it('throws a revert error on multiplication overflow', async function () {
       const a = MAX_UINT;
       const b = new BigNumber(2);
 
@@ -81,7 +81,7 @@ contract('SafeMath', () => {
       result.should.be.bignumber.equal(a.div(b));
     });
 
-    it('throws an revert error on zero division', async function () {
+    it('throws a revert error on zero division', async function () {
       const a = new BigNumber(5678);
       const b = new BigNumber(0);
 


### PR DESCRIPTION
Following #1121 and #1120, changes `SafeMath` to use `revert`s instead of `assert`s.

Fixes #1120.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
