### PR TITLE
Changed SplitPayment require to assert.

### DIFF
--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -51,7 +51,7 @@ contract SplitPayment {
     );
 
     require(payment != 0);
-    require(address(this).balance >= payment);
+    assert(address(this).balance >= payment);
 
     released[payee] = released[payee].add(payment);
     totalReleased = totalReleased.add(payment);


### PR DESCRIPTION
Now that we've come to a decision in #1120, we should move towards `assert` when the tested condition is not input validation but implementation correctness. In this case, if a payee is due a non-zero payment, the contract not having the required funds indicates a bug in the contract.