### PR TITLE
Switch to container-based Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 group: beta
 language: node_js
 node_js:


### PR DESCRIPTION
Travis jobs have been intermittently failing because of [some issues on their side](https://www.traviscistatus.com/incidents/hgmftqkw1sdl) with `sudo: required` builds. This configuration line [apparently](https://docs.travis-ci.com/user/reference/trusty/#fully-virtualized-via-sudo-required) means that the job will run in a virtual machine, as opposed to [`sudo: false`](https://docs.travis-ci.com/user/reference/trusty/#container-based-with-sudo-false) which means the job will run in a container.

It doesn't look like we will need `sudo`, and the container-based run would be apparently slightly faster to boot. Let's see how this works.

(The first run is expected to be slower because it rebuilds the cache after a configuration change, IIRC.)