### PR TITLE
remove arrow functions from js tests

### DIFF
--- a/test/access/SignatureBouncer.test.js
+++ b/test/access/SignatureBouncer.test.js
@@ -13,13 +13,13 @@ const UINT_VALUE = 23;
 const BYTES_VALUE = web3.toHex('test');
 const INVALID_SIGNATURE = '0xabcd';
 
-contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
+contract('Bouncer', function ([_, owner, anyone, bouncerAddress, authorizedUser]) {
   beforeEach(async function () {
     this.bouncer = await Bouncer.new({ from: owner });
     this.roleBouncer = await this.bouncer.ROLE_BOUNCER();
   });
 
-  context('management', () => {
+  context('management', function () {
     it('has a default owner of self', async function () {
       (await this.bouncer.owner()).should.eq(owner);
     });
@@ -57,14 +57,14 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
     });
   });
 
-  context('with bouncer address', () => {
+  context('with bouncer address', function () {
     beforeEach(async function () {
       await this.bouncer.addBouncer(bouncerAddress, { from: owner });
       this.signFor = getBouncerSigner(this.bouncer, bouncerAddress);
     });
 
-    describe('modifiers', () => {
-      context('plain signature', () => {
+    describe('modifiers', function () {
+      context('plain signature', function () {
         it('allows valid signature for sender', async function () {
           await this.bouncer.onlyWithValidSignature(this.signFor(authorizedUser), { from: authorizedUser });
         });
@@ -89,7 +89,7 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
         });
       });
 
-      context('method signature', () => {
+      context('method signature', function () {
         it('allows valid signature with correct method for sender', async function () {
           await this.bouncer.onlyWithValidSignatureAndMethod(
             this.signFor(authorizedUser, 'onlyWithValidSignatureAndMethod'), { from: authorizedUser }
@@ -124,7 +124,7 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
         });
       });
 
-      context('method and data signature', () => {
+      context('method and data signature', function () {
         it('allows valid signature with correct method and data for sender', async function () {
           await this.bouncer.onlyWithValidSignatureAndData(UINT_VALUE,
             this.signFor(authorizedUser, 'onlyWithValidSignatureAndData', [UINT_VALUE]), { from: authorizedUser }
@@ -165,8 +165,8 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
       });
     });
 
-    context('signature validation', () => {
-      context('plain signature', () => {
+    context('signature validation', function () {
+      context('plain signature', function () {
         it('validates valid signature for valid user', async function () {
           (await this.bouncer.checkValidSignature(authorizedUser, this.signFor(authorizedUser))).should.eq(true);
         });
@@ -185,7 +185,7 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
         });
       });
 
-      context('method signature', () => {
+      context('method signature', function () {
         it('validates valid signature with correct method for valid user', async function () {
           (await this.bouncer.checkValidSignatureAndMethod(authorizedUser,
             this.signFor(authorizedUser, 'checkValidSignatureAndMethod'))
@@ -208,7 +208,7 @@ contract('Bouncer', ([_, owner, anyone, bouncerAddress, authorizedUser]) => {
         });
       });
 
-      context('method and data signature', () => {
+      context('method and data signature', function () {
         it('validates valid signature with correct method and data for valid user', async function () {
           (await this.bouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
             this.signFor(authorizedUser, 'checkValidSignatureAndData', [authorizedUser, BYTES_VALUE, UINT_VALUE]))

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -63,7 +63,7 @@ contract('ECRecovery', function ([_, anyone]) {
     }
   });
 
-  context('toEthSignedMessage', () => {
+  context('toEthSignedMessage', function () {
     it('should prefix hashes correctly', async function () {
       const hashedMessage = web3.sha3(TEST_MESSAGE);
       (await ecrecovery.toEthSignedMessageHash(hashedMessage)).should.eq(hashMessage(TEST_MESSAGE));

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -7,7 +7,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
-contract('SafeMath', () => {
+contract('SafeMath', function () {
   const MAX_UINT = new BigNumber(2).pow(256).minus(1);
 
   beforeEach(async function () {

--- a/test/ownership/HasNoContracts.test.js
+++ b/test/ownership/HasNoContracts.test.js
@@ -7,7 +7,7 @@ contract('HasNoContracts', function ([_, owner, anyone]) {
   let hasNoContracts = null;
   let ownable = null;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     // Create contract and token
     hasNoContracts = await HasNoContracts.new({ from: owner });
     ownable = await Ownable.new({ from: owner });

--- a/test/ownership/HasNoTokens.test.js
+++ b/test/ownership/HasNoTokens.test.js
@@ -13,7 +13,7 @@ contract('HasNoTokens', function ([_, owner, initialAccount, anyone]) {
   let hasNoTokens = null;
   let token = null;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     // Create contract and token
     hasNoTokens = await HasNoTokens.new({ from: owner });
     token = await ERC223TokenMock.new(initialAccount, 100);

--- a/test/ownership/Superuser.test.js
+++ b/test/ownership/Superuser.test.js
@@ -13,7 +13,7 @@ contract('Superuser', function ([_, firstOwner, newSuperuser, newOwner, anyone])
     this.superuser = await Superuser.new({ from: firstOwner });
   });
 
-  context('in normal conditions', () => {
+  context('in normal conditions', function () {
     it('should set the owner as the default superuser', async function () {
       (await this.superuser.isSuperuser(firstOwner)).should.be.be.true;
     });
@@ -53,7 +53,7 @@ contract('Superuser', function ([_, firstOwner, newSuperuser, newOwner, anyone])
     });
   });
 
-  context('in adversarial conditions', () => {
+  context('in adversarial conditions', function () {
     it('should prevent non-superusers from transfering the superuser role', async function () {
       await expectThrow(
         this.superuser.transferSuperuser(newOwner, { from: anyone })

--- a/test/ownership/rbac/RBAC.test.js
+++ b/test/ownership/rbac/RBAC.test.js
@@ -11,50 +11,50 @@ const ROLE_ADVISOR = 'advisor';
 contract('RBAC', function ([_, admin, anyone, advisor, otherAdvisor, futureAdvisor]) {
   let mock;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     mock = await RBACMock.new([advisor, otherAdvisor], { from: admin });
   });
 
-  context('in normal conditions', () => {
-    it('allows admin to call #onlyAdminsCanDoThis', async () => {
+  context('in normal conditions', function () {
+    it('allows admin to call #onlyAdminsCanDoThis', async function () {
       await mock.onlyAdminsCanDoThis({ from: admin });
     });
-    it('allows admin to call #onlyAdvisorsCanDoThis', async () => {
+    it('allows admin to call #onlyAdvisorsCanDoThis', async function () {
       await mock.onlyAdvisorsCanDoThis({ from: admin });
     });
-    it('allows advisors to call #onlyAdvisorsCanDoThis', async () => {
+    it('allows advisors to call #onlyAdvisorsCanDoThis', async function () {
       await mock.onlyAdvisorsCanDoThis({ from: advisor });
     });
-    it('allows admin to call #eitherAdminOrAdvisorCanDoThis', async () => {
+    it('allows admin to call #eitherAdminOrAdvisorCanDoThis', async function () {
       await mock.eitherAdminOrAdvisorCanDoThis({ from: admin });
     });
-    it('allows advisors to call #eitherAdminOrAdvisorCanDoThis', async () => {
+    it('allows advisors to call #eitherAdminOrAdvisorCanDoThis', async function () {
       await mock.eitherAdminOrAdvisorCanDoThis({ from: advisor });
     });
-    it('does not allow admins to call #nobodyCanDoThis', async () => {
+    it('does not allow admins to call #nobodyCanDoThis', async function () {
       await expectThrow(mock.nobodyCanDoThis({ from: admin }));
     });
-    it('does not allow advisors to call #nobodyCanDoThis', async () => {
+    it('does not allow advisors to call #nobodyCanDoThis', async function () {
       await expectThrow(mock.nobodyCanDoThis({ from: advisor }));
     });
-    it('does not allow anyone to call #nobodyCanDoThis', async () => {
+    it('does not allow anyone to call #nobodyCanDoThis', async function () {
       await expectThrow(mock.nobodyCanDoThis({ from: anyone }));
     });
-    it('allows an admin to remove an advisor\'s role', async () => {
+    it('allows an admin to remove an advisor\'s role', async function () {
       await mock.removeAdvisor(advisor, { from: admin });
     });
-    it('allows admins to #adminRemoveRole', async () => {
+    it('allows admins to #adminRemoveRole', async function () {
       await mock.adminRemoveRole(advisor, ROLE_ADVISOR, { from: admin });
     });
 
-    it('announces a RoleAdded event on addRole', async () => {
+    it('announces a RoleAdded event on addRole', async function () {
       await expectEvent.inTransaction(
         mock.adminAddRole(futureAdvisor, ROLE_ADVISOR, { from: admin }),
         'RoleAdded'
       );
     });
 
-    it('announces a RoleRemoved event on removeRole', async () => {
+    it('announces a RoleRemoved event on removeRole', async function () {
       await expectEvent.inTransaction(
         mock.adminRemoveRole(futureAdvisor, ROLE_ADVISOR, { from: admin }),
         'RoleRemoved'
@@ -62,11 +62,11 @@ contract('RBAC', function ([_, admin, anyone, advisor, otherAdvisor, futureAdvis
     });
   });
 
-  context('in adversarial conditions', () => {
-    it('does not allow an advisor to remove another advisor', async () => {
+  context('in adversarial conditions', function () {
+    it('does not allow an advisor to remove another advisor', async function () {
       await expectThrow(mock.removeAdvisor(otherAdvisor, { from: advisor }));
     });
-    it('does not allow "anyone" to remove an advisor', async () => {
+    it('does not allow "anyone" to remove an advisor', async function () {
       await expectThrow(mock.removeAdvisor(advisor, { from: anyone }));
     });
   });


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->
Fixes #1202 

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
This PR removes a number of arrow functions in the JS tests, which are [considered bad practice by Mocha](https://mochajs.org/#arrow-functions).

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- ~[ ] 📖 I've made sure that my contracts are well-documented.~
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
