### PR TITLE
Roles can now be transfered.

### DIFF
--- a/contracts/access/rbac/Roles.sol
+++ b/contracts/access/rbac/Roles.sol
@@ -44,6 +44,8 @@ library Roles {
   function transfer(Role storage _role, address _account)
     internal
   {
+    require(!has(_role, _account));
+
     check(_role, msg.sender);
     remove(_role, msg.sender);
     add(_role, _account);

--- a/contracts/access/rbac/Roles.sol
+++ b/contracts/access/rbac/Roles.sol
@@ -15,18 +15,14 @@ library Roles {
   /**
    * @dev give an account access to this role
    */
-  function add(Role storage _role, address _account)
-    internal
-  {
+  function add(Role storage _role, address _account) internal {
     _role.bearer[_account] = true;
   }
 
   /**
    * @dev give multiple accounts access to this role
    */
-  function addMany(Role storage _role, address[] _accounts)
-    internal
-  {
+  function addMany(Role storage _role, address[] _accounts) internal {
     for (uint256 i = 0; i < _accounts.length; ++i) {
       add(_role, _accounts[i]);
     }
@@ -35,15 +31,11 @@ library Roles {
   /**
    * @dev remove an account's access to this role
    */
-  function remove(Role storage _role, address _account)
-    internal
-  {
+  function remove(Role storage _role, address _account) internal {
     _role.bearer[_account] = false;
   }
 
-  function transfer(Role storage _role, address _account)
-    internal
-  {
+  function transfer(Role storage _role, address _account) internal {
     require(_account != address(0));
     require(!has(_role, _account));
     require(has(_role, msg.sender));
@@ -52,8 +44,7 @@ library Roles {
     add(_role, _account);
   }
 
-  function renounce(Role storage _role) internal
-  {
+  function renounce(Role storage _role) internal {
     remove(_role, msg.sender);
   }
 
@@ -61,10 +52,7 @@ library Roles {
    * @dev check if an account has this role
    * // reverts
    */
-  function check(Role storage _role, address _account)
-    internal
-    view
-  {
+  function check(Role storage _role, address _account) internal view {
     require(has(_role, _account));
   }
 

--- a/contracts/access/rbac/Roles.sol
+++ b/contracts/access/rbac/Roles.sol
@@ -41,6 +41,14 @@ library Roles {
     _role.bearer[_account] = false;
   }
 
+  function transfer(Role storage _role, address _account)
+    internal
+  {
+    check(_role, msg.sender);
+    remove(_role, msg.sender);
+    add(_role, _account);
+  }
+
   /**
    * @dev check if an account has this role
    * // reverts

--- a/contracts/access/rbac/Roles.sol
+++ b/contracts/access/rbac/Roles.sol
@@ -44,11 +44,17 @@ library Roles {
   function transfer(Role storage _role, address _account)
     internal
   {
+    require(_account != address(0));
     require(!has(_role, _account));
+    require(has(_role, msg.sender));
 
-    check(_role, msg.sender);
     remove(_role, msg.sender);
     add(_role, _account);
+  }
+
+  function renounce(Role storage _role) internal
+  {
+    remove(_role, msg.sender);
   }
 
   /**

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -20,6 +20,10 @@ contract RolesMock {
     dummyRole.remove(_account);
   }
 
+  function renounce() public {
+    dummyRole.renounce();
+  }
+
   function transfer(address _account) public {
     dummyRole.transfer(_account);
   }

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -20,6 +20,10 @@ contract RolesMock {
     dummyRole.remove(_account);
   }
 
+  function transfer(address _account) public {
+    dummyRole.transfer(_account);
+  }
+
   function check(address _account) public view {
     dummyRole.check(_account);
   }

--- a/test/access/rbac/Roles.test.js
+++ b/test/access/rbac/Roles.test.js
@@ -68,5 +68,36 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await this.roles.remove(anyone);
       });
     });
+
+    describe('transfering roles', function () {
+      context('from account with role', function () {
+        const from = authorized;
+
+        it('transfers to other account with no role', async function () {
+          await this.roles.transfer(anyone, { from });
+          await this.testRole(anyone, true);
+          await this.testRole(authorized, false);
+        });
+
+        it('transfers to other account with role', async function () {
+          await this.roles.transfer(otherAuthorized, { from });
+          await this.testRole(otherAuthorized, true);
+          await this.testRole(authorized, false);
+        });
+
+        it('transfers to self', async function () {
+          await this.roles.transfer(authorized, { from });
+          await this.testRole(authorized, true);
+        });
+      });
+
+      context('from account without role', function () {
+        const from = anyone;
+
+        it('reverts', async function () {
+          await assertRevert(this.roles.transfer(authorized, { from }));
+        });
+      });
+    });
   });
 });

--- a/test/access/rbac/Roles.test.js
+++ b/test/access/rbac/Roles.test.js
@@ -102,7 +102,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         const from = anyone;
 
         it('reverts', async function () {
-          await assertRevert(this.roles.transfer(authorized, { from }));
+          await assertRevert(this.roles.transfer(anyone, { from }));
         });
       });
     });

--- a/test/access/rbac/Roles.test.js
+++ b/test/access/rbac/Roles.test.js
@@ -5,7 +5,9 @@ const RolesMock = artifacts.require('RolesMock');
 require('chai')
   .should();
 
-contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
+contract.only('Roles', function ([_, authorized, otherAuthorized, anyone]) {
+  const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
   beforeEach(async function () {
     this.roles = await RolesMock.new();
     this.testRole = async (account, expected) => {
@@ -49,6 +51,10 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await this.roles.addMany([authorized, authorized]);
         await this.testRole(authorized, true);
       });
+
+      it('doesn\'t revert when adding roles to the null account', async function () {
+        await this.roles.add(ZERO_ADDRESS);
+      });
     });
   });
 
@@ -64,8 +70,12 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await this.testRole(otherAuthorized, true);
       });
 
-      it('removes unassigned roles', async function () {
+      it('doesn\'t revert when removing unassigned roles', async function () {
         await this.roles.remove(anyone);
+      });
+
+      it('doesn\'t revert when removing roles from the null account', async function () {
+        await this.roles.remove(ZERO_ADDRESS);
       });
     });
 

--- a/test/access/rbac/Roles.test.js
+++ b/test/access/rbac/Roles.test.js
@@ -5,7 +5,7 @@ const RolesMock = artifacts.require('RolesMock');
 require('chai')
   .should();
 
-contract.only('Roles', function ([_, authorized, otherAuthorized, anyone]) {
+contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
   const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
   beforeEach(async function () {
@@ -89,15 +89,12 @@ contract.only('Roles', function ([_, authorized, otherAuthorized, anyone]) {
           await this.testRole(authorized, false);
         });
 
-        it('transfers to other account with role', async function () {
-          await this.roles.transfer(otherAuthorized, { from });
-          await this.testRole(otherAuthorized, true);
-          await this.testRole(authorized, false);
+        it('reverts when transfering to an account with role', async function () {
+          await assertRevert(this.roles.transfer(otherAuthorized, { from }));
         });
 
-        it('transfers to self', async function () {
-          await this.roles.transfer(authorized, { from });
-          await this.testRole(authorized, true);
+        it('reverts when transfering to the null account', async function () {
+          await assertRevert(this.roles.transfer(ZERO_ADDRESS, { from }));
         });
       });
 
@@ -107,6 +104,17 @@ contract.only('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         it('reverts', async function () {
           await assertRevert(this.roles.transfer(authorized, { from }));
         });
+      });
+    });
+
+    describe('renouncing roles', function () {
+      it('renounces an assigned role', async function () {
+        await this.roles.renounce({ from: authorized });
+        await this.testRole(authorized, false);
+      });
+
+      it('doesn\'t revert when renouncing unassigned role', async function () {
+        await this.roles.renounce({ from: anyone });
       });
     });
   });


### PR DESCRIPTION
[note that this is going into the rbac-migration branch, which will be merged into master once #1146 is considered solved by it]

`Roles` can now be transfered to any account. Contracts that use the `Roles` library still need to explicitly provide access to this method, though.