### PR TITLE
Implementation of TokenEscrow contract (#1099)

### DIFF
--- a/contracts/payment/TokenEscrow.sol
+++ b/contracts/payment/TokenEscrow.sol
@@ -1,0 +1,73 @@
+pragma solidity ^0.4.24;
+
+import "../math/SafeMath.sol";
+import "../ownership/Ownable.sol";
+import "../token/ERC20/ERC20.sol";
+import "../token/ERC20/SafeERC20.sol";
+
+
+/**
+ * @title TokenEscrow
+ * @dev Holds tokens destinated to a payee until they withdraw them.
+ * The contract that uses the TokenEscrow as its payment method
+ * should be its owner, and provide public methods redirecting
+ * to the TokenEscrow's deposit and withdraw.
+ * Moreover, the TokenEscrow should also be allowed to transfer
+ * tokens from the payer to itself.
+ */
+contract TokenEscrow is Ownable {
+  using SafeMath for uint256;
+  using SafeERC20 for ERC20;
+
+  event Deposited(address indexed payee, uint256 tokenAmount);
+  event Withdrawn(address indexed payee, uint256 tokenAmount);
+
+  mapping(address => uint256) private deposits;
+
+  ERC20 token;
+
+  constructor (ERC20 _token) public {
+    require(_token != address(0));
+    token = _token;
+  }
+
+  function depositsOf(address _payee) public view returns (uint256) {
+    return deposits[_payee];
+  }
+
+  /**
+  * @dev Puts in escrow a certain amount of tokens as credit to be withdrawn.
+  * @param _payer Address holding tokens which will be put in escrow.
+  * @param _payee The destination address of the tokens.
+  * @param _amount The amount of tokens to deposit in escrow.
+  */
+  function deposit(
+    address _payer,
+    address _payee,
+    uint256 _amount
+  )
+    public
+    onlyOwner
+  {
+    deposits[_payee] = deposits[_payee].add(_amount);
+
+    token.safeTransferFrom(_payer, address(this), _amount);
+
+    emit Deposited(_payee, _amount);
+  }
+
+  /**
+  * @dev Withdraw accumulated tokens for a payee.
+  * @param _payee The address whose tokens will be withdrawn and transferred to.
+  */
+  function withdraw(address _payee) public onlyOwner {
+    uint256 payment = deposits[_payee];
+    assert(token.balanceOf(address(this)) >= payment);
+
+    deposits[_payee] = 0;
+
+    token.transfer(_payee, payment);
+
+    emit Withdrawn(_payee, payment);
+  }
+}

--- a/contracts/payment/TokenEscrow.sol
+++ b/contracts/payment/TokenEscrow.sol
@@ -24,7 +24,7 @@ contract TokenEscrow is Ownable {
 
   mapping(address => uint256) private deposits;
 
-  ERC20 token;
+  ERC20 public token;
 
   constructor (ERC20 _token) public {
     require(_token != address(0));
@@ -37,21 +37,13 @@ contract TokenEscrow is Ownable {
 
   /**
   * @dev Puts in escrow a certain amount of tokens as credit to be withdrawn.
-  * @param _payer Address holding tokens which will be put in escrow.
   * @param _payee The destination address of the tokens.
   * @param _amount The amount of tokens to deposit in escrow.
   */
-  function deposit(
-    address _payer,
-    address _payee,
-    uint256 _amount
-  )
-    public
-    onlyOwner
-  {
+  function deposit(address _payee, uint256 _amount) public onlyOwner {
     deposits[_payee] = deposits[_payee].add(_amount);
 
-    token.safeTransferFrom(_payer, address(this), _amount);
+    token.safeTransferFrom(msg.sender, address(this), _amount);
 
     emit Deposited(_payee, _amount);
   }
@@ -66,7 +58,7 @@ contract TokenEscrow is Ownable {
 
     deposits[_payee] = 0;
 
-    token.transfer(_payee, payment);
+    token.safeTransfer(_payee, payment);
 
     emit Withdrawn(_payee, payment);
   }

--- a/test/payment/TokenEscrow.test.js
+++ b/test/payment/TokenEscrow.test.js
@@ -1,0 +1,120 @@
+const { expectThrow } = require('../helpers/expectThrow');
+const { EVMRevert } = require('../helpers/EVMRevert');
+const expectEvent = require('../helpers/expectEvent');
+
+const BigNumber = web3.BigNumber;
+
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+const TokenEscrow = artifacts.require('TokenEscrow');
+const StandardToken = artifacts.require('StandardTokenMock');
+
+contract('TokenEscrow', function ([_, owner, payer, payee1, payee2]) {
+  const amount = new BigNumber(100);
+  const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+  it('requires a non-null token', async function () {
+    await expectThrow(
+      TokenEscrow.new(ZERO_ADDRESS, { from: owner }), EVMRevert
+    );
+  });
+
+  context('with token', function () {
+    beforeEach(async function () {
+      this.standardToken = await StandardToken.new(payer, amount * 2);
+      this.tokenEscrow = await TokenEscrow.new(this.standardToken.address, { from: owner });
+    });
+
+    context('when not approved by payer', function () {
+      it('reverts on deposits', async function () {
+        await expectThrow(
+          this.tokenEscrow.deposit(payer, payee1, amount, { from: owner }),
+          EVMRevert
+        );
+      });
+    });
+
+    context('when approved by payer', function () {
+      beforeEach(async function () {
+        this.standardToken.approve(this.tokenEscrow.address, amount * 2, { from: payer });
+      });
+
+      describe('deposits', function () {
+        it('can accept a single deposit', async function () {
+          await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+
+          (await this.standardToken.balanceOf(this.tokenEscrow.address)).should.be.bignumber.equal(amount);
+
+          (await this.tokenEscrow.depositsOf(payee1)).should.be.bignumber.equal(amount);
+        });
+
+        it('can accept an empty deposit', async function () {
+          await this.tokenEscrow.deposit(payer, payee1, new BigNumber(0), { from: owner });
+        });
+
+        it('only the owner can deposit', async function () {
+          await expectThrow(this.tokenEscrow.deposit(payer, payee1, amount, { from: payee2 }), EVMRevert);
+        });
+
+        it('emits a deposited event', async function () {
+          const receipt = await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+
+          const event = expectEvent.inLogs(receipt.logs, 'Deposited', { payee: payee1 });
+          event.args.tokenAmount.should.be.bignumber.equal(amount);
+        });
+
+        it('can add multiple deposits on a single account', async function () {
+          await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+          await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+
+          (await this.standardToken.balanceOf(this.tokenEscrow.address)).should.be.bignumber.equal(amount * 2);
+
+          (await this.tokenEscrow.depositsOf(payee1)).should.be.bignumber.equal(amount * 2);
+        });
+
+        it('can track deposits to multiple accounts', async function () {
+          for (const payee of [payee1, payee2]) {
+            await this.tokenEscrow.deposit(payer, payee, amount, { from: owner });
+            (await this.tokenEscrow.depositsOf(payee)).should.be.bignumber.equal(amount);
+          }
+
+          (await this.standardToken.balanceOf(this.tokenEscrow.address)).should.be.bignumber.equal(amount * 2);
+        });
+      });
+
+      describe('withdrawals', function () {
+        it('can withdraw payments', async function () {
+          const payeeInitialBalance = await this.standardToken.balanceOf(payee1);
+
+          await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+          await this.tokenEscrow.withdraw(payee1, { from: owner });
+
+          (await this.standardToken.balanceOf(this.tokenEscrow.address)).should.be.bignumber.equal(0);
+
+          (await this.tokenEscrow.depositsOf(payee1)).should.be.bignumber.equal(0);
+
+          const payeeFinalBalance = await this.standardToken.balanceOf(payee1);
+          payeeFinalBalance.sub(payeeInitialBalance).should.be.bignumber.equal(amount);
+        });
+
+        it('can do an empty withdrawal', async function () {
+          await this.tokenEscrow.withdraw(payee1, { from: owner });
+        });
+
+        it('only the owner can withdraw', async function () {
+          await expectThrow(this.tokenEscrow.withdraw(payee1, { from: payee1 }), EVMRevert);
+        });
+
+        it('emits a withdrawn event', async function () {
+          await this.tokenEscrow.deposit(payer, payee1, amount, { from: owner });
+          const receipt = await this.tokenEscrow.withdraw(payee1, { from: owner });
+
+          const event = expectEvent.inLogs(receipt.logs, 'Withdrawn', { payee: payee1 });
+          event.args.tokenAmount.should.be.bignumber.equal(amount);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #1099

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
Implementation of the `TokenEscrow` contract. Unlike the existing `Escrow` contract which handles ether, `TokenEscrow` can be used to put any ERC20 token in escrow, as long as it is previously approved by the holder of the tokens. Appart from that, the use case of `TokenEscrow` as a payment method should be pretty similar to `Escrow`.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).