### PR TITLE
Rename MerkleProof.verifyProof to MerkleProof.verify

### DIFF
--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -14,7 +14,7 @@ library MerkleProof {
    * @param _root Merkle root
    * @param _leaf Leaf of Merkle tree
    */
-  function verifyProof(
+  function verify(
     bytes32[] _proof,
     bytes32 _root,
     bytes32 _leaf

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -5,7 +5,7 @@ import { MerkleProof } from "../cryptography/MerkleProof.sol";
 
 contract MerkleProofWrapper {
 
-  function verifyProof(
+  function verify(
     bytes32[] _proof,
     bytes32 _root,
     bytes32 _leaf
@@ -14,6 +14,6 @@ contract MerkleProofWrapper {
     pure
     returns (bool)
   {
-    return MerkleProof.verifyProof(_proof, _root, _leaf);
+    return MerkleProof.verify(_proof, _root, _leaf);
   }
 }

--- a/test/library/MerkleProof.test.js
+++ b/test/library/MerkleProof.test.js
@@ -13,7 +13,7 @@ contract('MerkleProof', function () {
     merkleProof = await MerkleProofWrapper.new();
   });
 
-  describe('verifyProof', function () {
+  describe('verify', function () {
     it('should return true for a valid Merkle proof', async function () {
       const elements = ['a', 'b', 'c', 'd'];
       const merkleTree = new MerkleTree(elements);
@@ -24,7 +24,7 @@ contract('MerkleProof', function () {
 
       const leaf = bufferToHex(sha3(elements[0]));
 
-      (await merkleProof.verifyProof(proof, root, leaf)).should.equal(true);
+      (await merkleProof.verify(proof, root, leaf)).should.equal(true);
     });
 
     it('should return false for an invalid Merkle proof', async function () {
@@ -40,7 +40,7 @@ contract('MerkleProof', function () {
 
       const badProof = badMerkleTree.getHexProof(badElements[0]);
 
-      (await merkleProof.verifyProof(badProof, correctRoot, correctLeaf)).should.equal(false);
+      (await merkleProof.verify(badProof, correctRoot, correctLeaf)).should.equal(false);
     });
 
     it('should return false for a Merkle proof of invalid length', async function () {
@@ -54,7 +54,7 @@ contract('MerkleProof', function () {
 
       const leaf = bufferToHex(sha3(elements[0]));
 
-      (await merkleProof.verifyProof(badProof, root, leaf)).should.equal(false);
+      (await merkleProof.verify(badProof, root, leaf)).should.equal(false);
     });
   });
 });


### PR DESCRIPTION
Since the function can only be invoked with the synax `MerkleProof.verifyProof`, I think the `Proof` suffix in the function name is redundant.