### PR TITLE
Bumped required solidity version to 0.4.24

### DIFF
--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "../../token/ERC20/IERC20.sol";
 

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";

--- a/contracts/payment/ConditionalEscrow.sol
+++ b/contracts/payment/ConditionalEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./Escrow.sol";
 

--- a/contracts/payment/Escrow.sol
+++ b/contracts/payment/Escrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../math/SafeMath.sol";
 import "../ownership/Ownable.sol";

--- a/contracts/payment/RefundEscrow.sol
+++ b/contracts/payment/RefundEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ConditionalEscrow.sol";
 import "../ownership/Ownable.sol";


### PR DESCRIPTION
The latest compiler versions contain bugfixes and issue additional warnings: we should require them for all files.