### PR TITLE
Simplify IndividuallyCappedCrowdsale interface

### DIFF
--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -20,25 +20,8 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
    * @param _beneficiary Address to be capped
    * @param _cap Wei limit for individual contribution
    */
-  function setUserCap(address _beneficiary, uint256 _cap) external onlyOwner {
+  function setCap(address _beneficiary, uint256 _cap) external onlyOwner {
     caps_[_beneficiary] = _cap;
-  }
-
-  /**
-   * @dev Sets a group of users' maximum contribution.
-   * @param _beneficiaries List of addresses to be capped
-   * @param _cap Wei limit for individual contribution
-   */
-  function setGroupCap(
-    address[] _beneficiaries,
-    uint256 _cap
-  )
-    external
-    onlyOwner
-  {
-    for (uint256 i = 0; i < _beneficiaries.length; i++) {
-      caps_[_beneficiaries[i]] = _cap;
-    }
   }
 
   /**
@@ -46,7 +29,7 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
    * @param _beneficiary Address whose cap is to be checked
    * @return Current cap for individual user
    */
-  function getUserCap(address _beneficiary) public view returns (uint256) {
+  function getCap(address _beneficiary) public view returns (uint256) {
     return caps_[_beneficiary];
   }
 
@@ -55,7 +38,7 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
    * @param _beneficiary Address of contributor
    * @return User contribution so far
    */
-  function getUserContribution(address _beneficiary)
+  function getContribution(address _beneficiary)
     public view returns (uint256)
   {
     return contributions_[_beneficiary];

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -7,7 +7,7 @@ import "../../ownership/Ownable.sol";
 
 /**
  * @title IndividuallyCappedCrowdsale
- * @dev Crowdsale with per-user caps.
+ * @dev Crowdsale with per-beneficiary caps.
  */
 contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   using SafeMath for uint256;
@@ -16,7 +16,7 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   mapping(address => uint256) private caps_;
 
   /**
-   * @dev Sets a specific user's maximum contribution.
+   * @dev Sets a specific beneficiary's maximum contribution.
    * @param _beneficiary Address to be capped
    * @param _cap Wei limit for individual contribution
    */
@@ -25,18 +25,18 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   }
 
   /**
-   * @dev Returns the cap of a specific user.
+   * @dev Returns the cap of a specific beneficiary.
    * @param _beneficiary Address whose cap is to be checked
-   * @return Current cap for individual user
+   * @return Current cap for individual beneficiary
    */
   function getCap(address _beneficiary) public view returns (uint256) {
     return caps_[_beneficiary];
   }
 
   /**
-   * @dev Returns the amount contributed so far by a sepecific user.
+   * @dev Returns the amount contributed so far by a specific beneficiary.
    * @param _beneficiary Address of contributor
-   * @return User contribution so far
+   * @return Beneficiary contribution so far
    */
   function getContribution(address _beneficiary)
     public view returns (uint256)
@@ -45,7 +45,7 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   }
 
   /**
-   * @dev Extend parent behavior requiring purchase to respect the user's funding cap.
+   * @dev Extend parent behavior requiring purchase to respect the beneficiary's funding cap.
    * @param _beneficiary Token purchaser
    * @param _weiAmount Amount of wei contributed
    */
@@ -61,7 +61,7 @@ contract IndividuallyCappedCrowdsale is Ownable, Crowdsale {
   }
 
   /**
-   * @dev Extend parent behavior to update user contributions
+   * @dev Extend parent behavior to update beneficiary contributions
    * @param _beneficiary Token purchaser
    * @param _weiAmount Amount of wei contributed
    */

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -65,5 +65,4 @@ contract('IndividuallyCappedCrowdsale', function ([_, wallet, alice, bob, charli
       });
     });
   });
-
 });

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -23,8 +23,8 @@ contract('IndividuallyCappedCrowdsale', function ([_, wallet, alice, bob, charli
     beforeEach(async function () {
       this.token = await SimpleToken.new();
       this.crowdsale = await CappedCrowdsale.new(rate, wallet, this.token.address);
-      await this.crowdsale.setUserCap(alice, capAlice);
-      await this.crowdsale.setUserCap(bob, capBob);
+      await this.crowdsale.setCap(alice, capAlice);
+      await this.crowdsale.setCap(bob, capBob);
       await this.token.transfer(this.crowdsale.address, tokenSupply);
     });
 
@@ -56,48 +56,14 @@ contract('IndividuallyCappedCrowdsale', function ([_, wallet, alice, bob, charli
 
     describe('reporting state', function () {
       it('should report correct cap', async function () {
-        (await this.crowdsale.getUserCap(alice)).should.be.bignumber.equal(capAlice);
+        (await this.crowdsale.getCap(alice)).should.be.bignumber.equal(capAlice);
       });
 
       it('should report actual contribution', async function () {
         await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
-        (await this.crowdsale.getUserContribution(alice)).should.be.bignumber.equal(lessThanCapAlice);
+        (await this.crowdsale.getContribution(alice)).should.be.bignumber.equal(lessThanCapAlice);
       });
     });
   });
 
-  describe('group capping', function () {
-    beforeEach(async function () {
-      this.token = await SimpleToken.new();
-      this.crowdsale = await CappedCrowdsale.new(rate, wallet, this.token.address);
-      await this.crowdsale.setGroupCap([bob, charlie], capBob);
-      await this.token.transfer(this.crowdsale.address, tokenSupply);
-    });
-
-    describe('accepting payments', function () {
-      it('should accept payments within cap', async function () {
-        await this.crowdsale.buyTokens(bob, { value: lessThanCapBoth });
-        await this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth });
-      });
-
-      it('should reject payments outside cap', async function () {
-        await this.crowdsale.buyTokens(bob, { value: capBob });
-        await expectThrow(this.crowdsale.buyTokens(bob, { value: 1 }), EVMRevert);
-        await this.crowdsale.buyTokens(charlie, { value: capBob });
-        await expectThrow(this.crowdsale.buyTokens(charlie, { value: 1 }), EVMRevert);
-      });
-
-      it('should reject payments that exceed cap', async function () {
-        await expectThrow(this.crowdsale.buyTokens(bob, { value: capBob.plus(1) }), EVMRevert);
-        await expectThrow(this.crowdsale.buyTokens(charlie, { value: capBob.plus(1) }), EVMRevert);
-      });
-    });
-
-    describe('reporting state', function () {
-      it('should report correct cap', async function () {
-        (await this.crowdsale.getUserCap(bob)).should.be.bignumber.equal(capBob);
-        (await this.crowdsale.getUserCap(charlie)).should.be.bignumber.equal(capBob);
-      });
-    });
-  });
 });


### PR DESCRIPTION
This PR removes the concept of "user" from this crowdsale flavor, which is not present elsewhere in the crowdsales subsystem, and also removes the function `setGroupCap` which takes an array, as this is not customary across the OpenZeppelin API.