### PR TITLE
Role library now requires non-zero addresses.

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -14,8 +14,8 @@ library Roles {
    * @dev give an account access to this role
    */
   function add(Role storage role, address account) internal {
-    require(_account != address(0));
-    _role.bearer[_account] = true;
+    require(account != address(0));
+    role.bearer[account] = true;
   }
 
   /**

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -14,6 +14,7 @@ library Roles {
    * @dev give an account access to this role
    */
   function add(Role storage _role, address _account) internal {
+    require(_account != address(0));
     _role.bearer[_account] = true;
   }
 
@@ -21,6 +22,7 @@ library Roles {
    * @dev remove an account's access to this role
    */
   function remove(Role storage _role, address _account) internal {
+    require(_account != address(0));
     _role.bearer[_account] = false;
   }
 
@@ -33,6 +35,7 @@ library Roles {
     view
     returns (bool)
   {
+    require(_account != address(0));
     return _role.bearer[_account];
   }
 }

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -13,7 +13,7 @@ library Roles {
   /**
    * @dev give an account access to this role
    */
-  function add(Role storage _role, address _account) internal {
+  function add(Role storage role, address account) internal {
     require(_account != address(0));
     _role.bearer[_account] = true;
   }
@@ -21,21 +21,21 @@ library Roles {
   /**
    * @dev remove an account's access to this role
    */
-  function remove(Role storage _role, address _account) internal {
-    require(_account != address(0));
-    _role.bearer[_account] = false;
+  function remove(Role storage role, address account) internal {
+    require(account != address(0));
+    role.bearer[account] = false;
   }
 
   /**
    * @dev check if an account has this role
    * @return bool
    */
-  function has(Role storage _role, address _account)
+  function has(Role storage role, address account)
     internal
     view
     returns (bool)
   {
-    require(_account != address(0));
-    return _role.bearer[_account];
+    require(account != address(0));
+    return role.bearer[account];
   }
 }

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -133,6 +133,6 @@ contract SignatureBouncer is SignerRole {
       .toEthSignedMessageHash()
       .recover(_signature);
 
-    return (signer != address(0)) ? isSigner(signer) : false;
+    return signer != address(0) && isSigner(signer);
   }
 }

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -132,6 +132,7 @@ contract SignatureBouncer is SignerRole {
     address signer = _hash
       .toEthSignedMessageHash()
       .recover(_signature);
-    return isSigner(signer);
+
+    return (signer != address(0)) ? isSigner(signer) : false;
   }
 }

--- a/test/access/Roles.test.js
+++ b/test/access/Roles.test.js
@@ -1,3 +1,5 @@
+const { assertRevert } = require('../helpers/assertRevert');
+
 const RolesMock = artifacts.require('RolesMock');
 
 require('chai')
@@ -8,6 +10,10 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
 
   beforeEach(async function () {
     this.roles = await RolesMock.new();
+  });
+
+  it('reverts when querying roles for the null account', async function () {
+    await assertRevert(this.roles.has(ZERO_ADDRESS));
   });
 
   context('initially', function () {
@@ -30,8 +36,8 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         (await this.roles.has(authorized)).should.equal(true);
       });
 
-      it('doesn\'t revert when adding roles to the null account', async function () {
-        await this.roles.add(ZERO_ADDRESS);
+      it('reverts when adding roles to the null account', async function () {
+        await assertRevert(this.roles.add(ZERO_ADDRESS));
       });
     });
   });
@@ -53,8 +59,8 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await this.roles.remove(anyone);
       });
 
-      it('doesn\'t revert when removing roles from the null account', async function () {
-        await this.roles.remove(ZERO_ADDRESS);
+      it('reverts when removing roles from the null account', async function () {
+        await assertRevert(this.roles.remove(ZERO_ADDRESS));
       });
     });
   });

--- a/test/access/roles/PublicRole.behavior.js
+++ b/test/access/roles/PublicRole.behavior.js
@@ -1,3 +1,5 @@
+const { assertRevert } = require('../../helpers/assertRevert');
+
 require('chai')
   .should();
 
@@ -16,6 +18,10 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
       (await this.contract[`is${rolename}`](anyone)).should.equal(false);
     });
 
+    it('reverts when querying roles for the null account', async function () {
+      await assertRevert(this.contract[`is${rolename}`](ZERO_ADDRESS));
+    });
+
     describe('add', function () {
       it('adds role to a new account', async function () {
         await this.contract[`add${rolename}`](anyone, { from: authorized });
@@ -27,8 +33,8 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
         (await this.contract[`is${rolename}`](authorized)).should.equal(true);
       });
 
-      it('doesn\'t revert when adding role to the null account', async function () {
-        await this.contract[`add${rolename}`](ZERO_ADDRESS, { from: authorized });
+      it('reverts when adding role to the null account', async function () {
+        await assertRevert(this.contract[`add${rolename}`](ZERO_ADDRESS, { from: authorized }));
       });
     });
 
@@ -43,8 +49,8 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
         await this.contract[`remove${rolename}`](anyone);
       });
 
-      it('doesn\'t revert when removing role from the null account', async function () {
-        await this.contract[`remove${rolename}`](ZERO_ADDRESS);
+      it('reverts when removing role from the null account', async function () {
+        await assertRevert(this.contract[`remove${rolename}`](ZERO_ADDRESS));
       });
     });
 


### PR DESCRIPTION
The null address (0x00) is now considered a domain error in the Roles library, and all transactions involving it with revert. 