### PR TITLE
Include build directory in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.12.0",
   "description": "Secure Smart Contract library for Solidity",
   "files": [
+    "build",
     "contracts",
     "test"
   ],


### PR DESCRIPTION
https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1299 didn't work out because `truffle compile` hangs the packing process. I'm adding the directory but will compile manually. This has to be fixed ASAP in the next release cycle, because it's an error prone process.