### PR TITLE
Add unit test specific to Address utils (#1251)

### DIFF
--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.24;
+
+import "../utils/Address.sol";
+
+
+contract AddressImpl {
+  function isContract(address account)
+    external
+    view
+    returns (bool)
+  {
+    return Address.isContract(account); 
+  }
+  
+}

--- a/test/Address.test.js
+++ b/test/Address.test.js
@@ -1,0 +1,20 @@
+const AddressImpl = artifacts.require('AddressImpl');
+const SimpleToken = artifacts.require('SimpleToken');
+
+require('chai')
+  .should();
+
+contract('Address', function ([_, anyone]) {
+  beforeEach(async function () {
+    this.mock = await AddressImpl.new();
+  });
+
+  it('should return false for account address', async function () {
+    (await this.mock.isContract(anyone)).should.equal(false);
+  });
+
+  it('should return true for contract address', async function () {
+    const contract = await SimpleToken.new();
+    (await this.mock.isContract(contract.address)).should.equal(true);
+  });
+});


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

* Added AddressImpl as contract proxy to invoke and test Address library
* 'Is account address' verified on truffle 'creator' variable
* 'Is contract address' verified on SimpleToken instance deployed in truffle testing context

<!-- 3. Before submitting, please review the following checklist: -->

- [+] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [+] ✅ I've added tests where applicable to test my new functionality.
- [+] 📖 I've made sure that my contracts are well-documented.
- [+] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
