### PR TITLE
optimize ReentrancyGuard gas usage

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -21,8 +21,8 @@ contract ReentrancyGuard {
    * wrapper marked as `nonReentrant`.
    */
   modifier nonReentrant() {
-    _guardCounter += 1;
-    uint256 localCounter = _guardCounter;
+    uint256 localCounter = _guardCounter + 1;
+    _guardCounter = localCounter;
     _;
     require(localCounter == _guardCounter);
   }


### PR DESCRIPTION
Reduces the number of `sload` calls by one since `_guardCounter += 1;` by itself requires a `sload` and then an `sstore`
5808 gas -> 5595 gas

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [ ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:fix`).
