### PR TITLE
Add BigNumber support to expectEvent/inLogs (#1026)

### DIFF
--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -1,10 +1,11 @@
+const expectEvent = require('../helpers/expectEvent');
 const { ether } = require('../helpers/ether');
 const { assertRevert } = require('../helpers/assertRevert');
 const { ethGetBalance } = require('../helpers/web3');
 
 const BigNumber = web3.BigNumber;
 
-const should = require('chai')
+require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
@@ -40,13 +41,15 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
 
   describe('high-level purchase', function () {
     it('should log purchase', async function () {
-      const { logs } = await this.crowdsale.sendTransaction({ value: value, from: investor });
-      const event = logs.find(e => e.event === 'TokensPurchased');
-      should.exist(event);
-      event.args.purchaser.should.equal(investor);
-      event.args.beneficiary.should.equal(investor);
-      event.args.value.should.be.bignumber.equal(value);
-      event.args.amount.should.be.bignumber.equal(expectedTokenAmount);
+      const transaction = await this.crowdsale.sendTransaction({ value: value, from: investor });
+      expectEvent.inLogs(
+        transaction.logs,
+        'TokensPurchased',
+        {
+          purchaser: investor,
+          beneficiary: investor,
+          value: value,
+          amount: expectedTokenAmount });
     });
 
     it('should assign tokens to sender', async function () {

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -41,9 +41,9 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
 
   describe('high-level purchase', function () {
     it('should log purchase', async function () {
-      const transaction = await this.crowdsale.sendTransaction({ value: value, from: investor });
+      const { logs } = await this.crowdsale.sendTransaction({ value: value, from: investor });
       expectEvent.inLogs(
-        transaction.logs,
+        logs,
         'TokensPurchased',
         {
           purchaser: investor,

--- a/test/helpers/expectEvent.js
+++ b/test/helpers/expectEvent.js
@@ -1,24 +1,18 @@
-const should = require('chai').should();
+const BigNumber = web3.BigNumber;
+const should = require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
 
 function inLogs (logs, eventName, eventArgs = {}) {
   const event = logs.find(function (e) {
     if (e.event === eventName) {
-      let matches = true;
-
       for (const [k, v] of Object.entries(eventArgs)) {
-        if (toSimpleValue(e.args[k]) !== toSimpleValue(v)) {
-          matches = false;
-        }
+        contains(e.args, k, v);
       }
-
-      if (matches) {
-        return true;
-      }
+      return true;
     }
   });
-
   should.exist(event);
-
   return event;
 }
 
@@ -27,14 +21,18 @@ async function inTransaction (tx, eventName, eventArgs = {}) {
   return inLogs(logs, eventName, eventArgs);
 }
 
-function toSimpleValue (value) {
-  return isBigNumber(value)
-    ? value.toNumber()
-    : value;
+function contains (args, key, value) {
+  if (isBigNumber(args[key])) {
+    args[key].should.be.bignumber.equal(value);
+  } else {
+    args[key].should.be.equal(value);
+  }
 }
 
-function isBigNumber (value) {
-  return value.constructor.name === 'BigNumber';
+function isBigNumber (object) {
+  return object.isBigNumber ||
+    object instanceof BigNumber ||
+    (object.constructor && object.constructor.name === 'BigNumber');
 }
 
 module.exports = {

--- a/test/helpers/expectEvent.js
+++ b/test/helpers/expectEvent.js
@@ -1,4 +1,5 @@
 const should = require('chai').should();
+const _ = require('lodash');
 
 function inLogs (logs, eventName, eventArgs = {}) {
   const event = logs.find(function (e) {
@@ -6,7 +7,7 @@ function inLogs (logs, eventName, eventArgs = {}) {
       let matches = true;
 
       for (const [k, v] of Object.entries(eventArgs)) {
-        if (e.args[k] !== v) {
+        if (!_.isEqual(e.args[k], v)) {
           matches = false;
         }
       }

--- a/test/helpers/expectEvent.js
+++ b/test/helpers/expectEvent.js
@@ -1,5 +1,4 @@
 const should = require('chai').should();
-const _ = require('lodash');
 
 function inLogs (logs, eventName, eventArgs = {}) {
   const event = logs.find(function (e) {
@@ -7,7 +6,7 @@ function inLogs (logs, eventName, eventArgs = {}) {
       let matches = true;
 
       for (const [k, v] of Object.entries(eventArgs)) {
-        if (!_.isEqual(e.args[k], v)) {
+        if (toSimpleValue(e.args[k]) !== toSimpleValue(v)) {
           matches = false;
         }
       }
@@ -26,6 +25,16 @@ function inLogs (logs, eventName, eventArgs = {}) {
 async function inTransaction (tx, eventName, eventArgs = {}) {
   const { logs } = await tx;
   return inLogs(logs, eventName, eventArgs);
+}
+
+function toSimpleValue (value) {
+  return isBigNumber(value)
+    ? value.toNumber()
+    : value;
+}
+
+function isBigNumber (value) {
+  return value.constructor.name === 'BigNumber';
 }
 
 module.exports = {


### PR DESCRIPTION
* switched direct logs array check to expectEvent method in AllowanceCrowdsale.test.js

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->


# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

Condition for equality check in expectEvent.inLogs() method was changed to verify equality even compared objects are structs. It fixes issue where BigNumber emitted to event was not possible to validate as follow:

`const event = expectEvent.inLogs(currentSnapshotId.logs, 'Snapshot', { id: new BigNumber(1) });`

Now it works fine.

<!-- 3. Before submitting, please review the following checklist: -->

- [ +] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [ +] ✅ I've added tests where applicable to test my new functionality.
- [ +] 📖 I've made sure that my contracts are well-documented.
- [ +] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:fix`).
