### PR TITLE
Add asmERC20 implemetation to fix interaction with bad ERC20 after solc 0.4.22

### DIFF
--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "../../utils/Address.sol";
 import "./ERC20.sol";
 import "./IERC20.sol";
 
@@ -10,6 +11,8 @@ import "./IERC20.sol";
  * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
  */
 library SafeERC20 {
+  using Address for address;
+
   function safeTransfer(
     IERC20 token,
     address to,
@@ -39,5 +42,43 @@ library SafeERC20 {
     internal
   {
     require(token.approve(spender, value));
+  }
+
+  function handleReturnBool() internal pure returns(bool result) {
+    // solium-disable-next-line security/no-inline-assembly
+    assembly {
+      switch returndatasize()
+      case 0 { // not a std erc20
+        result := 1
+      }
+      case 32 { // std erc20
+        returndatacopy(0, 0, 32)
+        result := mload(0)
+      }
+      default { // anything else, should revert for safety
+        revert(0, 0)
+      }
+    }
+  }
+
+  function asmTransfer(IERC20 _token, address _to, uint256 _value) internal returns(bool) {
+    require(_token.isContract());
+    // solium-disable-next-line security/no-low-level-calls
+    require(_token.call(bytes4(keccak256("transfer(address,uint256)")), _to, _value));
+    return handleReturnBool();
+  }
+
+  function asmTransferFrom(IERC20 _token, address _from, address _to, uint256 _value) internal returns(bool) {
+    require(_token.isContract());
+    // solium-disable-next-line security/no-low-level-calls
+    require(_token.call(bytes4(keccak256("transferFrom(address,address,uint256)")), _from, _to, _value));
+    return handleReturnBool();
+  }
+
+  function asmApprove(IERC20 _token, address _spender, uint256 _value) internal returns(bool) {
+    require(_token.isContract());
+    // solium-disable-next-line security/no-low-level-calls
+    require(_token.call(bytes4(keccak256("approve(address,uint256)")), _spender, _value));
+    return handleReturnBool();
   }
 }


### PR DESCRIPTION
Fixes no issues in this repo

# 🚀 Description

Allows smart contracts to interact with bad ERC20 implementations, ie returning void from `transfer`, `transferFrom` or `approve`. Instead of revert introduced methods returns `bool`.

New methods:
- `asmTransfer`
- `asmTransferFrom`
- `asmApprove`

Info:
- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:fix`).

I'll do tests/docs/linter after the discussion.