### PR TITLE
Removed assertions from Escrow and SplitPayment.

### DIFF
--- a/contracts/payment/Escrow.sol
+++ b/contracts/payment/Escrow.sol
@@ -39,7 +39,6 @@ contract Escrow is Secondary {
   */
   function withdraw(address payee) public onlyPrimary {
     uint256 payment = _deposits[payee];
-    assert(address(this).balance >= payment);
 
     _deposits[payee] = 0;
 

--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -84,7 +84,6 @@ contract SplitPayment {
     );
 
     require(payment != 0);
-    assert(address(this).balance >= payment);
 
     _released[account] = _released[account].add(payment);
     _totalReleased = _totalReleased.add(payment);


### PR DESCRIPTION
Removing these until we have a criteria under which to add `assert` clauses. This will also bump coverage since `solidity-coverage` doesn't yet track these properly (see https://github.com/sc-forks/solidity-coverage/issues/269)