### PR TITLE
Dangling commas are now required.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
 
     // Code style
     "camelcase": ["error", {"properties": "always"}],
-    "comma-dangle": ["warn", "always-multiline"],
+    "comma-dangle": ["error", "always-multiline"],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "dot-notation": ["error", {"allowKeywords": true, "allowPattern": ""}],
     "eol-last": ["error", "always"],

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -46,7 +46,7 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
         purchaser: investor,
         beneficiary: investor,
         value: value,
-        amount: expectedTokenAmount
+        amount: expectedTokenAmount,
       });
     });
 

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -87,7 +87,7 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
             purchaser: investor,
             beneficiary: investor,
             value: value,
-            amount: expectedTokenAmount
+            amount: expectedTokenAmount,
           });
         });
 
@@ -111,7 +111,7 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
             purchaser: purchaser,
             beneficiary: investor,
             value: value,
-            amount: expectedTokenAmount
+            amount: expectedTokenAmount,
           });
         });
 

--- a/test/crowdsale/MintedCrowdsale.behavior.js
+++ b/test/crowdsale/MintedCrowdsale.behavior.js
@@ -25,7 +25,7 @@ function shouldBehaveLikeMintedCrowdsale ([_, investor, wallet, purchaser], rate
           purchaser: investor,
           beneficiary: investor,
           value: value,
-          amount: expectedTokenAmount
+          amount: expectedTokenAmount,
         });
       });
 

--- a/test/payment/Escrow.behavior.js
+++ b/test/payment/Escrow.behavior.js
@@ -34,7 +34,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
         const { logs } = await this.escrow.deposit(payee1, { from: primary, value: amount });
         expectEvent.inLogs(logs, 'Deposited', {
           payee: payee1,
-          weiAmount: amount
+          weiAmount: amount,
         });
       });
 
@@ -87,7 +87,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
         const { logs } = await this.escrow.withdraw(payee1, { from: primary });
         expectEvent.inLogs(logs, 'Withdrawn', {
           payee: payee1,
-          weiAmount: amount
+          weiAmount: amount,
         });
       });
     });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -65,7 +65,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
           expectEvent.inLogs(logs, 'Transfer', {
             from: owner,
             to: to,
-            value: amount
+            value: amount,
           });
         });
       });
@@ -93,7 +93,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
           expectEvent.inLogs(logs, 'Approval', {
             owner: owner,
             spender: spender,
-            value: amount
+            value: amount,
           });
         });
 
@@ -127,7 +127,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
           expectEvent.inLogs(logs, 'Approval', {
             owner: owner,
             spender: spender,
-            value: amount
+            value: amount,
           });
         });
 
@@ -197,7 +197,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
             expectEvent.inLogs(logs, 'Transfer', {
               from: owner,
               to: to,
-              value: amount
+              value: amount,
             });
           });
         });
@@ -272,7 +272,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
             expectEvent.inLogs(logs, 'Approval', {
               owner: owner,
               spender: spender,
-              value: 0
+              value: 0,
             });
           });
 
@@ -329,7 +329,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
           expectEvent.inLogs(logs, 'Approval', {
             owner: owner,
             spender: spender,
-            value: amount
+            value: amount,
           });
         });
 
@@ -363,7 +363,7 @@ contract('ERC20', function ([_, owner, recipient, anotherAccount]) {
           expectEvent.inLogs(logs, 'Approval', {
             owner: owner,
             spender: spender,
-            value: amount
+            value: amount,
           });
         });
 

--- a/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
@@ -32,7 +32,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
           expectEvent.inLogs(this.logs, 'Transfer', {
             from: owner,
             to: ZERO_ADDRESS,
-            value: amount
+            value: amount,
           });
         });
       }
@@ -78,7 +78,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
           expectEvent.inLogs(this.logs, 'Transfer', {
             from: owner,
             to: ZERO_ADDRESS,
-            value: amount
+            value: amount,
           });
         });
       }

--- a/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
@@ -38,7 +38,7 @@ function shouldBehaveLikeERC20Mintable (minter, [anyone]) {
             expectEvent.inLogs(this.logs, 'Transfer', {
               from: ZERO_ADDRESS,
               to: anyone,
-              value: amount
+              value: amount,
             });
           });
         }

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -92,7 +92,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'Transfer', {
               from: owner,
               to: this.toWhom,
-              tokenId: tokenId
+              tokenId: tokenId,
             });
           });
         } else {
@@ -100,7 +100,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'Transfer', {
               from: owner,
               to: this.toWhom,
-              tokenId: tokenId
+              tokenId: tokenId,
             });
           });
         }
@@ -165,7 +165,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'Transfer', {
               from: owner,
               to: owner,
-              tokenId: tokenId
+              tokenId: tokenId,
             });
           });
 
@@ -341,7 +341,7 @@ function shouldBehaveLikeERC721 (
           expectEvent.inLogs(logs, 'Approval', {
             owner: owner,
             approved: address,
-            tokenId: tokenId
+            tokenId: tokenId,
           });
         });
       };
@@ -451,7 +451,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'ApprovalForAll', {
               owner: owner,
               operator: operator,
-              approved: true
+              approved: true,
             });
           });
         });
@@ -473,7 +473,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'ApprovalForAll', {
               owner: owner,
               operator: operator,
-              approved: true
+              approved: true,
             });
           });
 
@@ -501,7 +501,7 @@ function shouldBehaveLikeERC721 (
             expectEvent.inLogs(logs, 'ApprovalForAll', {
               owner: owner,
               operator: operator,
-              approved: true
+              approved: true,
             });
           });
         });

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -45,7 +45,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
           expectEvent.inLogs(logs, 'Transfer', {
             from: ZERO_ADDRESS,
             to: newOwner,
-            tokenId: thirdTokenId
+            tokenId: thirdTokenId,
           });
         });
       });
@@ -90,7 +90,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
           expectEvent.inLogs(logs, 'Transfer', {
             from: owner,
             to: ZERO_ADDRESS,
-            tokenId: tokenId
+            tokenId: tokenId,
           });
         });
       });


### PR DESCRIPTION
As per our 'no linter warnings' rule.