### PR TITLE
Add SignatureBouncer test for when msg.data is too short

### DIFF
--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -64,9 +64,9 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
 
   }
 
-  function tooShortMsgData(bytes signature)
+  function tooShortMsgData()
     public
-    onlyValidSignatureAndData(signature)
+    onlyValidSignatureAndData("")
     view
   {
   }

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -63,4 +63,11 @@ contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
   {
 
   }
+
+  function tooShortMsgData(bytes signature)
+    public
+    onlyValidSignatureAndData(signature)
+    view
+  {
+  }
 }

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -128,6 +128,12 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
           )
         );
       });
+
+      it('does not allow msg.data shorter than _SIGNATURE_SIZE', async function () {
+        await assertRevert(
+          this.sigBouncer.tooShortMsgData('', { from: authorizedUser })
+        );
+      });
     });
   });
 

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -131,7 +131,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
 
       it('does not allow msg.data shorter than _SIGNATURE_SIZE', async function () {
         await assertRevert(
-          this.sigBouncer.tooShortMsgData('', { from: authorizedUser })
+          this.sigBouncer.tooShortMsgData({ from: authorizedUser })
         );
       });
     });

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -129,7 +129,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
         );
       });
 
-      it('does not allow msg.data shorter than _SIGNATURE_SIZE', async function () {
+      it('does not allow msg.data shorter than SIGNATURE_SIZE', async function () {
         await assertRevert(
           this.sigBouncer.tooShortMsgData({ from: authorizedUser })
         );


### PR DESCRIPTION
This should bring coverage from 99.873% to 100%. If not then the PR needs more work.