### PR TITLE
Separate ERC721Mintable

### DIFF
--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -6,13 +6,13 @@ import "../token/ERC721/ERC721MetadataMintable.sol";
 import "../token/ERC721/ERC721Burnable.sol";
 
 /**
- * @title ERC721Mock
+ * @title ERC721FullMock
  * This mock just provides a public mint and burn functions for testing purposes,
  * and a public setter for metadata URI
  */
-contract ERC721FullMock 
+contract ERC721FullMock
   is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
-  
+
   constructor(string name, string symbol) public
     ERC721Mintable()
     ERC721Full(name, symbol)

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -10,7 +10,9 @@ import "../token/ERC721/ERC721Burnable.sol";
  * This mock just provides a public mint and burn functions for testing purposes,
  * and a public setter for metadata URI
  */
-contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
+contract ERC721FullMock 
+  is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
+  
   constructor(string name, string symbol) public
     ERC721Mintable()
     ERC721Full(name, symbol)

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.24;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";
+import "../token/ERC721/ERC721MetadataMintable.sol";
 import "../token/ERC721/ERC721Burnable.sol";
 
 /**
@@ -9,7 +10,7 @@ import "../token/ERC721/ERC721Burnable.sol";
  * This mock just provides a public mint and burn functions for testing purposes,
  * and a public setter for metadata URI
  */
-contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721Burnable {
+contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
   constructor(string name, string symbol) public
     ERC721Mintable()
     ERC721Full(name, symbol)

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -2,13 +2,14 @@ pragma solidity ^0.4.24;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";
+import "../token/ERC721/ERC721MetadataMintable.sol";
 import "../token/ERC721/ERC721Burnable.sol";
 
 /**
  * @title ERC721MintableBurnableImpl
  */
 contract ERC721MintableBurnableImpl
-  is ERC721Full, ERC721Mintable, ERC721Burnable {
+  is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
 
   constructor()
     ERC721Mintable()

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -3,26 +3,30 @@ pragma solidity ^0.4.24;
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";
 
+
 /**
  * @title ERC721Mintable
  * @dev ERC721 minting logic
  */
-contract ERC721Mintable is ERC721, MinterRole {
+contract ERC721MetadataMintable is ERC721, ERC721Metadata, MinterRole {
   /**
    * @dev Function to mint tokens
    * @param to The address that will receive the minted tokens.
    * @param tokenId The token id to mint.
+   * @param tokenURI The token URI of the minted token.
    * @return A boolean that indicates if the operation was successful.
    */
-  function mint(
+  function mintWithTokenURI(
     address to,
-    uint256 tokenId
+    uint256 tokenId,
+    string tokenURI
   )
     public
     onlyMinter
     returns (bool)
   {
     _mint(to, tokenId);
+    _setTokenURI(tokenId, tokenURI);
     return true;
   }
 }

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -5,8 +5,8 @@ import "../../access/roles/MinterRole.sol";
 
 
 /**
- * @title ERC721Mintable
- * @dev ERC721 minting logic
+ * @title ERC721MetadataMintable
+ * @dev ERC721 minting logic with metadata
  */
 contract ERC721MetadataMintable is ERC721, ERC721Metadata, MinterRole {
   /**

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "./ERC721Metadata.sol";
+import "./ERC721.sol";
 import "../../access/roles/MinterRole.sol";
 
 /**

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -1,6 +1,5 @@
 const { assertRevert } = require('../../helpers/assertRevert');
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
-const { shouldBehaveLikeMintAndBurnERC721 } = require('./ERC721MintBurn.behavior');
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
 const BigNumber = web3.BigNumber;
@@ -221,7 +220,6 @@ contract('ERC721Full', function ([
   });
 
   shouldBehaveLikeERC721(creator, minter, accounts);
-  shouldBehaveLikeMintAndBurnERC721(creator, minter, accounts);
 
   shouldSupportInterfaces([
     'ERC165',

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -52,13 +52,13 @@ function shouldBehaveLikeMintAndBurnERC721 (
 
       describe('when the given owner address is the zero address', function () {
         it('reverts', async function () {
-          await assertRevert(this.token.mint(ZERO_ADDRESS, thirdTokenId));
+          await assertRevert(this.token.mint(ZERO_ADDRESS, thirdTokenId, { from: minter }));
         });
       });
 
       describe('when the given token ID was already tracked by this contract', function () {
         it('reverts', async function () {
-          await assertRevert(this.token.mint(owner, firstTokenId));
+          await assertRevert(this.token.mint(owner, firstTokenId, { from: minter }));
         });
       });
     });


### PR DESCRIPTION
We used to have only one `ERC721Mintable` that required to be plugged into an `ERC721Full`. This change allows making a more minimal `ERC721` mintable.