### PR TITLE
Made some inherit-only contracts internal.

### DIFF
--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -10,7 +10,7 @@ contract CapperRole {
 
   Roles.Role private cappers;
 
-  constructor() public {
+  constructor() internal {
     _addCapper(msg.sender);
   }
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -10,7 +10,7 @@ contract MinterRole {
 
   Roles.Role private minters;
 
-  constructor() public {
+  constructor() internal {
     _addMinter(msg.sender);
   }
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -10,7 +10,7 @@ contract PauserRole {
 
   Roles.Role private pausers;
 
-  constructor() public {
+  constructor() internal {
     _addPauser(msg.sender);
   }
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -10,7 +10,7 @@ contract SignerRole {
 
   Roles.Role private signers;
 
-  constructor() public {
+  constructor() internal {
     _addSigner(msg.sender);
   }
 

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -36,6 +36,8 @@ contract SignatureBouncer is SignerRole {
   // Signature size is 65 bytes (tightly packed v + r + s), but gets padded to 96 bytes
   uint256 private constant _SIGNATURE_SIZE = 96;
 
+  constructor() internal {}
+
   /**
    * @dev requires that a valid signature of a signer was provided
    */

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -25,7 +25,7 @@ contract ERC165 is IERC165 {
    * implement ERC165 itself
    */
   constructor()
-    public
+    internal
   {
     _registerInterface(_InterfaceId_ERC165);
   }

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -12,7 +12,7 @@ contract Pausable is PauserRole {
 
   bool private _paused;
 
-  constructor() public {
+  constructor() internal {
     _paused = false;
   }
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.24;
+
+import "../ownership/Ownable.sol";
+
+contract OwnableMock is Ownable {
+}

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -17,7 +17,7 @@ contract Ownable {
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
    */
-  constructor() public {
+  constructor() internal {
     _owner = msg.sender;
     emit OwnershipTransferred(address(0), _owner);
   }

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -10,7 +10,7 @@ contract Secondary {
   /**
    * @dev Sets the primary account to the one that is creating the Secondary contract.
    */
-  constructor() public {
+  constructor() internal {
     _primary = msg.sender;
   }
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -10,7 +10,7 @@ import "./escrow/Escrow.sol";
 contract PullPayment {
   Escrow private _escrow;
 
-  constructor() public {
+  constructor() internal {
     _escrow = new Escrow();
   }
 

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -11,7 +11,7 @@ contract ReentrancyGuard {
   /// @dev counter to allow mutex lock with only one SSTORE operation
   uint256 private _guardCounter;
 
-  constructor() public {
+  constructor() internal {
     // The counter starts at one to prevent changing it from zero to a non-zero
     // value, which is a more expensive operation.
     _guardCounter = 1;

--- a/test/ownership/Ownable.test.js
+++ b/test/ownership/Ownable.test.js
@@ -1,6 +1,6 @@
 const { shouldBehaveLikeOwnable } = require('./Ownable.behavior');
 
-const Ownable = artifacts.require('Ownable');
+const Ownable = artifacts.require('OwnableMock');
 
 contract('Ownable', function ([_, owner, ...otherAccounts]) {
   beforeEach(async function () {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1394.

We could also add this to some other abstract contracts (like `Crowdsale` children), but I think they're fine as it is for now.