### PR TITLE
Crowdsale.buyTokens is now nonReentrant.

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.24;
 import "../token/ERC20/IERC20.sol";
 import "../math/SafeMath.sol";
 import "../token/ERC20/SafeERC20.sol";
+import "../utils/ReentrancyGuard.sol";
 
 /**
  * @title Crowdsale
@@ -16,7 +17,7 @@ import "../token/ERC20/SafeERC20.sol";
  * the methods to add functionality. Consider using 'super' where appropriate to concatenate
  * behavior.
  */
-contract Crowdsale {
+contract Crowdsale is ReentrancyGuard {
   using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
@@ -110,7 +111,7 @@ contract Crowdsale {
    * @dev low level token purchase ***DO NOT OVERRIDE***
    * @param beneficiary Address performing the token purchase
    */
-  function buyTokens(address beneficiary) public payable {
+  function buyTokens(address beneficiary) public nonReentrant payable {
 
     uint256 weiAmount = msg.value;
     _preValidatePurchase(beneficiary, weiAmount);

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -109,6 +109,8 @@ contract Crowdsale is ReentrancyGuard {
 
   /**
    * @dev low level token purchase ***DO NOT OVERRIDE***
+   * This function has a non-reentrancy guard, so it shouldn't be called by
+   * another `nonReentrant` function.
    * @param beneficiary Address performing the token purchase
    */
   function buyTokens(address beneficiary) public nonReentrant payable {

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -24,8 +24,6 @@ contract ReentrancyGuard {
    * by making the `nonReentrant` function external, and make it call a
    * `private` function that does the actual work.
    */
-   * If you mark a function `nonReentrant`, you should also
-   * mark it `external`.
   modifier nonReentrant() {
     _guardCounter += 1;
     uint256 localCounter = _guardCounter;

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -19,12 +19,13 @@ contract ReentrancyGuard {
 
   /**
    * @dev Prevents a contract from calling itself, directly or indirectly.
-   * If you mark a function `nonReentrant`, you should also
-   * mark it `external`. Calling one `nonReentrant` function from
-   * another is not supported. Instead, you can implement a
-   * `private` function doing the actual work, and an `external`
-   * wrapper marked as `nonReentrant`.
+   * Calling a `nonReentrant` function from another `nonReentrant`
+   * function is not supported. It is possible to prevent this from happening
+   * by making the `nonReentrant` function external, and make it call a
+   * `private` function that does the actual work.
    */
+   * If you mark a function `nonReentrant`, you should also
+   * mark it `external`.
   modifier nonReentrant() {
     _guardCounter += 1;
     uint256 localCounter = _guardCounter;


### PR DESCRIPTION
This doesn't affect anything right now, but potentially could, with standards such as ERC677, and is hard to think about. Forbidding reentrancy altogether disallows all kinds of nasty behaviors.

Thanks @cwhinfrey and the Level K team for spotting this!