### PR TITLE
TimedCrowdsale: closing time must be strictly after opening time.

### DIFF
--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -29,7 +29,7 @@ contract TimedCrowdsale is Crowdsale {
   constructor(uint256 openingTime, uint256 closingTime) public {
     // solium-disable-next-line security/no-block-members
     require(openingTime >= block.timestamp);
-    require(closingTime >= openingTime);
+    require(closingTime > openingTime);
 
     _openingTime = openingTime;
     _closingTime = closingTime;

--- a/test/crowdsale/TimedCrowdsale.test.js
+++ b/test/crowdsale/TimedCrowdsale.test.js
@@ -29,15 +29,21 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
     this.token = await SimpleToken.new();
   });
 
-  it('rejects an opening time in the past', async function () {
+  it('reverts if the opening time is in the past', async function () {
     await shouldFail.reverting(TimedCrowdsaleImpl.new(
       (await time.latest()) - time.duration.days(1), this.closingTime, rate, wallet, this.token.address
     ));
   });
 
-  it('rejects a closing time before the opening time', async function () {
+  it('reverts if the closing time is before the opening time', async function () {
     await shouldFail.reverting(TimedCrowdsaleImpl.new(
       this.openingTime, this.openingTime - time.duration.seconds(1), rate, wallet, this.token.address
+    ));
+  });
+
+  it('reverts if the closing time equals the opening time', async function () {
+    await shouldFail.reverting(TimedCrowdsaleImpl.new(
+      this.openingTime, this.openingTime, rate, wallet, this.token.address
     ));
   });
 


### PR DESCRIPTION
A crowdsale that closes automatically doesn't make much sense, and it causes issues down the line when derived crowdsales divide by `duration = closing - opening`.