### PR TITLE
InitialRate must be strictly larger than finalRate.

### DIFF
--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -22,9 +22,13 @@ contract IncreasingPriceCrowdsale is TimedCrowdsale {
    */
   constructor(uint256 initialRate, uint256 finalRate) public {
     require(finalRate > 0);
-    require(initialRate >= finalRate);
+    require(initialRate > finalRate);
     _initialRate = initialRate;
     _finalRate = finalRate;
+  }
+
+  function rate() public view returns(uint256) {
+    revert();
   }
 
   /**

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -27,6 +27,10 @@ contract IncreasingPriceCrowdsale is TimedCrowdsale {
     _finalRate = finalRate;
   }
 
+  /**
+   * The base rate function is overridden to revert, since this crowdsale doens't use it, and
+   * all calls to it are a mistake.
+   */
   function rate() public view returns(uint256) {
     revert();
   }

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -65,7 +65,6 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
         (await this.crowdsale.finalRate()).should.be.bignumber.equal(finalRate);
       });
 
-
       it('reverts when the base Crowdsale\'s rate function is called', async function () {
         await shouldFail.reverting(this.crowdsale.rate());
       });

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -34,13 +34,19 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
       this.token = await SimpleToken.new();
     });
 
-    it('rejects a final rate larger than the initial rate', async function () {
+    it('reverts with a final rate larger than the initial rate', async function () {
       await shouldFail.reverting(IncreasingPriceCrowdsaleImpl.new(
         this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate.plus(1)
       ));
     });
 
-    it('rejects a final rate of zero', async function () {
+    it('reverts with a final equal to the initial rate', async function () {
+      await shouldFail.reverting(IncreasingPriceCrowdsaleImpl.new(
+        this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate
+      ));
+    });
+
+    it('reverts with a final rate of zero', async function () {
       await shouldFail.reverting(IncreasingPriceCrowdsaleImpl.new(
         this.startTime, this.closingTime, wallet, this.token.address, initialRate, 0
       ));
@@ -57,6 +63,10 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
       it('should have initial and final rate', async function () {
         (await this.crowdsale.initialRate()).should.be.bignumber.equal(initialRate);
         (await this.crowdsale.finalRate()).should.be.bignumber.equal(finalRate);
+      });
+
+      it('reverts when the base Crowdsale\'s rate function is called', async function () {
+        await shouldFail.reverting(this.crowdsale.rate());
       });
 
       it('at start', async function () {


### PR DESCRIPTION
There's no point in having a rate-changing crowdsale if both match.