### PR TITLE
IncPriceCrowdsale consistently returns 0 outside of the crowdsale window.

### DIFF
--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -47,6 +47,10 @@ contract IncreasingPriceCrowdsale is TimedCrowdsale {
    * @return The number of tokens a buyer gets per wei at a given time
    */
   function getCurrentRate() public view returns (uint256) {
+    if (!isOpen()) {
+      return 0;
+    }
+
     // solium-disable-next-line security/no-block-members
     uint256 elapsedTime = block.timestamp.sub(openingTime());
     uint256 timeRange = closingTime().sub(openingTime());

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -59,6 +59,15 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
         (await this.crowdsale.finalRate()).should.be.bignumber.equal(finalRate);
       });
 
+      it('returns a rate of 0 before the crowdsale starts', async function () {
+        (await this.crowdsale.getCurrentRate()).should.be.bignumber.equal(0);
+      });
+
+      it('returns a rate of 0 after the crowdsale ends', async function () {
+        await time.increaseTo(this.afterClosingTime);
+        (await this.crowdsale.getCurrentRate()).should.be.bignumber.equal(0);
+      });
+
       it('at start', async function () {
         await time.increaseTo(this.startTime);
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });


### PR DESCRIPTION
It used to revert when called before, and return the final rate when called after, this is more consistent (and hopefully clearer).