### PR TITLE
Made tokenURI external, as per the spec.

### DIFF
--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -54,7 +54,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
    * Throws if the token ID does not exist. May return an empty string.
    * @param tokenId uint256 ID of the token to query
    */
-  function tokenURI(uint256 tokenId) public view returns (string) {
+  function tokenURI(uint256 tokenId) external view returns (string) {
     require(_exists(tokenId));
     return _tokenURIs[tokenId];
   }

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -9,5 +9,5 @@ import "./IERC721.sol";
 contract IERC721Metadata is IERC721 {
   function name() external view returns (string);
   function symbol() external view returns (string);
-  function tokenURI(uint256 tokenId) public view returns (string);
+  function tokenURI(uint256 tokenId) external view returns (string);
 }


### PR DESCRIPTION
Not sure why it was public ¯\_(ツ)_/¯