### PR TITLE
Now setting the finalized flag early.

### DIFF
--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -34,10 +34,10 @@ contract FinalizableCrowdsale is TimedCrowdsale {
     require(!_finalized);
     require(hasClosed());
 
+    _finalized = true;
+
     _finalization();
     emit CrowdsaleFinalized();
-
-    _finalized = true;
   }
 
   /**
@@ -47,5 +47,4 @@ contract FinalizableCrowdsale is TimedCrowdsale {
    */
   function _finalization() internal {
   }
-
 }


### PR DESCRIPTION
Otherwise,  if `​_finalization()​` is overridden to make a call to an unknown address, a malicious actor could reenter `​finalize()​`. One case where this may happen is if the caller of `​finalize()​` is rewarded with a small ETH payment.