### PR TITLE
Fixed how allowance crowdsale checks remaining tokens.

### DIFF
--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -4,6 +4,7 @@ import "../Crowdsale.sol";
 import "../../token/ERC20/IERC20.sol";
 import "../../token/ERC20/SafeERC20.sol";
 import "../../math/SafeMath.sol";
+import "../../math/Math.sol";
 
 /**
  * @title AllowanceCrowdsale
@@ -36,7 +37,7 @@ contract AllowanceCrowdsale is Crowdsale {
    * @return Amount of tokens left in the allowance
    */
   function remainingTokens() public view returns (uint256) {
-    return token().allowance(_tokenWallet, this);
+    return Math.min(token().balanceOf(_tokenWallet), token().allowance(_tokenWallet, this));
   }
 
   /**

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -37,7 +37,10 @@ contract AllowanceCrowdsale is Crowdsale {
    * @return Amount of tokens left in the allowance
    */
   function remainingTokens() public view returns (uint256) {
-    return Math.min(token().balanceOf(_tokenWallet), token().allowance(_tokenWallet, this));
+    return Math.min(
+      token().balanceOf(_tokenWallet),
+      token().allowance(_tokenWallet, this)
+    );
   }
 
   /**

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -69,6 +69,17 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
       await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
       (await this.crowdsale.remainingTokens()).should.be.bignumber.equal(remainingAllowance);
     });
+
+    context('when the allowance is larger than the token amount', function () {
+      beforeEach(async function () {
+        const amount = await this.token.balanceOf(tokenWallet);
+        await this.token.approve(this.crowdsale.address, amount.plus(1), { from: tokenWallet });
+      });
+
+      it('should report the amount instead of the allowance', async function () {
+        (await this.crowdsale.remainingTokens()).should.be.bignumber.equal(await this.token.balanceOf(tokenWallet));
+      });
+    });
   });
 
   describe('when token wallet is different from token address', function () {


### PR DESCRIPTION
Pretty straightforward, I think. Note that this function is only used to query the state of the crowdsale: behavior remains the same as before (i.e. it reverts of there aren't enough tokens).