### PR TITLE
Add warning about trading tokens before refundable crowdsale goal is met

### DIFF
--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -8,6 +8,19 @@ import "../../payment/escrow/RefundEscrow.sol";
  * @title RefundableCrowdsale
  * @dev Extension of Crowdsale contract that adds a funding goal, and
  * the possibility of users getting a refund if goal is not met.
+ * WARNING: note that if you allow tokens to be traded before the goal 
+ * is met, then an attack is possible in which the attacker purchases 
+ * tokens from the crowdsale and when they sees that the goal is 
+ * unlikely to be met, they sell their tokens (possibly at a discount).
+ * The attacker will be refunded when the crowdsale is finalized, and
+ * the users that purchased from them will be left with worthless 
+ * tokens. There are many possible ways ot avoid this, like making the
+ * the crowdsale inherit from PostDeliveryCrowdsale, or imposing 
+ * restrictions on token trading until the crowdsale is finalized.
+ * This is being discussed in 
+ * https://github.com/OpenZeppelin/openzeppelin-solidity/issues/877
+ * This contract will be updated when we agree on a general solution
+ * for this problem.
  */
 contract RefundableCrowdsale is FinalizableCrowdsale {
   using SafeMath for uint256;

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -14,7 +14,7 @@ import "../../payment/escrow/RefundEscrow.sol";
  * unlikely to be met, they sell their tokens (possibly at a discount).
  * The attacker will be refunded when the crowdsale is finalized, and
  * the users that purchased from them will be left with worthless 
- * tokens. There are many possible ways ot avoid this, like making the
+ * tokens. There are many possible ways to avoid this, like making the
  * the crowdsale inherit from PostDeliveryCrowdsale, or imposing 
  * restrictions on token trading until the crowdsale is finalized.
  * This is being discussed in 


### PR DESCRIPTION
This attack was reported in https://github.com/OpenZeppelin/openzeppelin-solidity/issues/877