### PR TITLE
Add TokenRecover to recover any ERC20 token sent into the contract for error

### DIFF
--- a/contracts/access/roles/OperatorRole.sol
+++ b/contracts/access/roles/OperatorRole.sol
@@ -8,7 +8,7 @@ contract OperatorRole {
   event OperatorAdded(address indexed account);
   event OperatorRemoved(address indexed account);
 
-  Roles.Role private operators;
+  Roles.Role private _operators;
 
   constructor() internal {
     _addOperator(msg.sender);
@@ -20,7 +20,7 @@ contract OperatorRole {
   }
 
   function isOperator(address account) public view returns (bool) {
-    return operators.has(account);
+    return _operators.has(account);
   }
 
   function addOperator(address account) public onlyOperator {
@@ -32,12 +32,12 @@ contract OperatorRole {
   }
 
   function _addOperator(address account) internal {
-    operators.add(account);
+    _operators.add(account);
     emit OperatorAdded(account);
   }
 
   function _removeOperator(address account) internal {
-    operators.remove(account);
+    _operators.remove(account);
     emit OperatorRemoved(account);
   }
 }

--- a/contracts/access/roles/OperatorRole.sol
+++ b/contracts/access/roles/OperatorRole.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.24;
+
+import "../Roles.sol";
+
+contract OperatorRole {
+  using Roles for Roles.Role;
+
+  event OperatorAdded(address indexed account);
+  event OperatorRemoved(address indexed account);
+
+  Roles.Role private operators;
+
+  constructor() internal {
+    _addOperator(msg.sender);
+  }
+
+  modifier onlyOperator() {
+    require(isOperator(msg.sender));
+    _;
+  }
+
+  function isOperator(address account) public view returns (bool) {
+    return operators.has(account);
+  }
+
+  function addOperator(address account) public onlyOperator {
+    _addOperator(account);
+  }
+
+  function renounceOperator() public {
+    _removeOperator(msg.sender);
+  }
+
+  function _addOperator(address account) internal {
+    operators.add(account);
+    emit OperatorAdded(account);
+  }
+
+  function _removeOperator(address account) internal {
+    operators.remove(account);
+    emit OperatorRemoved(account);
+  }
+}

--- a/contracts/mocks/OperatorRoleMock.sol
+++ b/contracts/mocks/OperatorRoleMock.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.24;
+
+import "../access/roles/OperatorRole.sol";
+
+contract OperatorRoleMock is OperatorRole {
+  function removeOperator(address account) public {
+    _removeOperator(account);
+  }
+
+  function onlyOperatorMock() public view onlyOperator {
+  }
+
+  // Causes a compilation error if super._removeOperator is not internal
+  function _removeOperator(address account) internal {
+    super._removeOperator(account);
+  }
+}

--- a/contracts/mocks/TokenRecoverMock.sol
+++ b/contracts/mocks/TokenRecoverMock.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+import "../token/ERC20/TokenRecover.sol";
+import "./OperatorRoleMock.sol";
+
+contract TokenRecoverMock is TokenRecover, OperatorRoleMock {
+}

--- a/contracts/token/ERC20/TokenRecover.sol
+++ b/contracts/token/ERC20/TokenRecover.sol
@@ -5,7 +5,7 @@ import "../../access/roles/OperatorRole.sol";
 
 /**
  * @title TokenRecover
- * @author Vittorio Minacori (@vittominacori)
+ * @author Vittorio Minacori (https://github.com/vittominacori)
  * @dev Allow to recover any ERC20 token sent into the contract for error.
  * Do not use if your contract is a token holder because of `operator` can move tokens bypassing your logic.
  */

--- a/contracts/token/ERC20/TokenRecover.sol
+++ b/contracts/token/ERC20/TokenRecover.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.4.24;
+
+import "./IERC20.sol";
+import "../../access/roles/OperatorRole.sol";
+
+/**
+ * @title TokenRecover
+ * @author Vittorio Minacori (@vittominacori)
+ * @dev Allow to recover any ERC20 token sent into the contract for error.
+ * Do not use if your contract is a token holder because of `operator` can move tokens bypassing your logic.
+ */
+contract TokenRecover is OperatorRole {
+
+  /**
+   * @dev Recover requested ERC20 token and send them to provided address.
+   * @param tokenAddress The token contract address to recover.
+   * @param receiverAddress The receiver address to send the tokens to.
+   * @param amount Number of tokens to be sent.
+   */
+  function recoverERC20(
+    address tokenAddress,
+    address receiverAddress,
+    uint256 amount
+  )
+    public
+    onlyOperator
+  {
+    require(tokenAddress != address(0));
+    IERC20(tokenAddress).transfer(receiverAddress, amount);
+  }
+}

--- a/test/access/roles/OperatorRole.test.js
+++ b/test/access/roles/OperatorRole.test.js
@@ -1,0 +1,11 @@
+const { shouldBehaveLikePublicRole } = require('../../access/roles/PublicRole.behavior');
+const OperatorRoleMock = artifacts.require('OperatorRoleMock');
+
+contract('OperatorRole', function ([_, operator, otherOperator, ...otherAccounts]) {
+  beforeEach(async function () {
+    this.contract = await OperatorRoleMock.new({ from: operator });
+    await this.contract.addOperator(otherOperator, { from: operator });
+  });
+
+  shouldBehaveLikePublicRole(operator, otherOperator, otherAccounts, 'operator');
+});

--- a/test/token/ERC20/TokenRecover.test.js
+++ b/test/token/ERC20/TokenRecover.test.js
@@ -1,0 +1,64 @@
+const shouldFail = require('../../helpers/shouldFail');
+const { ZERO_ADDRESS } = require('../../helpers/constants');
+
+const BigNumber = web3.BigNumber;
+
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+const { shouldBehaveLikePublicRole } = require('../../access/roles/PublicRole.behavior');
+
+const ERC20Mock = artifacts.require('ERC20Mock');
+const TokenRecoverMock = artifacts.require('TokenRecoverMock');
+
+contract('TokenRecover', function ([operator, otherOperator, receiver, ...otherAccounts]) {
+  beforeEach(async function () {
+    this.tokenRecover = await TokenRecoverMock.new({ from: operator });
+  });
+
+  describe('operator role', function () {
+    beforeEach(async function () {
+      this.contract = this.tokenRecover;
+      await this.contract.addOperator(otherOperator, { from: operator });
+    });
+
+    shouldBehaveLikePublicRole(operator, otherOperator, otherAccounts, 'operator');
+  });
+
+  describe('recover ERC20', function () {
+    const amount = 100;
+
+    beforeEach(async function () {
+      this.anotherERC20 = await ERC20Mock.new(this.tokenRecover.address, amount, { from: operator });
+    });
+
+    describe('when operator is calling', function () {
+      it('should transfer tokens to receiver', async function () {
+        (await this.anotherERC20.balanceOf(this.tokenRecover.address)).should.be.bignumber.equal(amount);
+        (await this.anotherERC20.balanceOf(receiver)).should.be.bignumber.equal(0);
+
+        await this.tokenRecover.recoverERC20(this.anotherERC20.address, receiver, amount, { from: operator });
+
+        (await this.anotherERC20.balanceOf(this.tokenRecover.address)).should.be.bignumber.equal(0);
+        (await this.anotherERC20.balanceOf(receiver)).should.be.bignumber.equal(amount);
+      });
+    });
+
+    describe('when token address is zero', function () {
+      it('reverts', async function () {
+        await shouldFail.reverting(
+          this.tokenRecover.recoverERC20(ZERO_ADDRESS, receiver, 0, { from: operator })
+        );
+      });
+    });
+
+    describe('when other accounts are calling', function () {
+      it('reverts', async function () {
+        await shouldFail.reverting(
+          this.tokenRecover.recoverERC20(this.anotherERC20.address, receiver, amount, { from: otherAccounts[0] })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
**TokenRecover** allows accounts with `operator` role to recover any ERC20 token sent into the contract for error.

There are lots of tokens lost forever into Smart Contracts (see [OMG](https://etherscan.io/address/0xd26114cd6ee289accf82350c8d8487fedb8a0c07) token balances).   
Each Ethereum contract is a potential token trap for ERC20 tokens. They can't be recovered so it means money losses for end users.

The `recoverERC20` function recover requested ERC20 token and send them to provided address.

NOTE: Do not use if your contract is a token holder because of `operator` can move tokens bypassing your logic.

