### PR TITLE
Update Secondary.sol

### DIFF
--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -40,6 +40,7 @@ contract Secondary {
    */
   function transferPrimary(address recipient) public onlyPrimary {
     require(recipient != address(0));
+    require(recipient != address(this));
     _primary = recipient;
     emit PrimaryTransferred(_primary);
   }


### PR DESCRIPTION
avoid recursive lockup by preventing _primary from being set to the current Secondary contract address

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented, and
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`).
-->
