### PR TITLE
Create SafeMath32.sol

### DIFF
--- a/contracts/math/SafeMath32.sol
+++ b/contracts/math/SafeMath32.sol
@@ -1,0 +1,65 @@
+pragma solidity ^0.4.24;
+
+/**
+ * @title SafeMath32
+ * @dev Math operations for 32-bit unsigned integers with safety checks that revert on error
+ */
+library SafeMath32 {
+
+  /**
+  * @dev Multiplies two numbers, reverts on overflow.
+  */
+  function mul(uint32 a, uint32 b) internal pure returns (uint32) {
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+    if (a == 0) {
+      return 0;
+    }
+
+    uint32 c = a * b;
+    require(c / a == b);
+
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers truncating the quotient, reverts on division by zero.
+  */
+  function div(uint32 a, uint32 b) internal pure returns (uint32) {
+    require(b > 0); // Solidity only automatically asserts when dividing by 0
+    uint32 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+    return c;
+  }
+
+  /**
+  * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint32 a, uint32 b) internal pure returns (uint32) {
+    require(b <= a);
+    uint32 c = a - b;
+
+    return c;
+  }
+
+  /**
+  * @dev Adds two numbers, reverts on overflow.
+  */
+  function add(uint32 a, uint32 b) internal pure returns (uint32) {
+    uint32 c = a + b;
+    require(c >= a);
+
+    return c;
+  }
+
+  /**
+  * @dev Divides two numbers and returns the remainder (unsigned integer modulo),
+  * reverts when dividing by zero.
+  */
+  function mod(uint32 a, uint32 b) internal pure returns (uint32) {
+    require(b != 0);
+    return a % b;
+  }
+}

--- a/contracts/mocks/SafeMath32Mock.sol
+++ b/contracts/mocks/SafeMath32Mock.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.24;
+
+import "../math/SafeMath32.sol";
+
+contract SafeMath32Mock {
+
+  function mul(uint32 a, uint32 b) public pure returns (uint32) {
+    return SafeMath32.mul(a, b);
+  }
+
+  function div(uint32 a, uint32 b) public pure returns (uint32) {
+    return SafeMath32.div(a, b);
+  }
+
+  function sub(uint32 a, uint32 b) public pure returns (uint32) {
+    return SafeMath32.sub(a, b);
+  }
+
+  function add(uint32 a, uint32 b) public pure returns (uint32) {
+    return SafeMath32.add(a, b);
+  }
+
+  function mod(uint32 a, uint32 b) public pure returns (uint32) {
+    return SafeMath32.mod(a, b);
+  }
+}

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -3,4 +3,5 @@ const BigNumber = web3.BigNumber;
 module.exports = {
   ZERO_ADDRESS: '0x0000000000000000000000000000000000000000',
   MAX_UINT256: new BigNumber(2).pow(256).minus(1),
+  MAX_UINT32: new BigNumber(2).pow(32).minus(1),
 };

--- a/test/math/SafeMath32.test.js
+++ b/test/math/SafeMath32.test.js
@@ -1,0 +1,125 @@
+const shouldFail = require('../helpers/shouldFail');
+const { MAX_UINT32 } = require('../helpers/constants');
+
+const BigNumber = web3.BigNumber;
+const SafeMath32Mock = artifacts.require('SafeMath32Mock');
+
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('SafeMath32', function () {
+  beforeEach(async function () {
+    this.safeMath = await SafeMath32Mock.new();
+  });
+
+  describe('add', function () {
+    it('adds correctly', async function () {
+      const a = new BigNumber(5678);
+      const b = new BigNumber(1234);
+
+      (await this.safeMath.add(a, b)).should.be.bignumber.equal(a.plus(b));
+    });
+
+    it('throws a revert error on addition overflow', async function () {
+      const a = MAX_UINT32;
+      const b = new BigNumber(1);
+
+      await shouldFail.reverting(this.safeMath.add(a, b));
+    });
+  });
+
+  describe('sub', function () {
+    it('subtracts correctly', async function () {
+      const a = new BigNumber(5678);
+      const b = new BigNumber(1234);
+
+      (await this.safeMath.sub(a, b)).should.be.bignumber.equal(a.minus(b));
+    });
+
+    it('throws a revert error if subtraction result would be negative', async function () {
+      const a = new BigNumber(1234);
+      const b = new BigNumber(5678);
+
+      await shouldFail.reverting(this.safeMath.sub(a, b));
+    });
+  });
+
+  describe('mul', function () {
+    it('multiplies correctly', async function () {
+      const a = new BigNumber(1234);
+      const b = new BigNumber(5678);
+
+      (await this.safeMath.mul(a, b)).should.be.bignumber.equal(a.times(b));
+    });
+
+    it('handles a zero product correctly', async function () {
+      const a = new BigNumber(0);
+      const b = new BigNumber(5678);
+
+      (await this.safeMath.mul(a, b)).should.be.bignumber.equal(a.times(b));
+    });
+
+    it('throws a revert error on multiplication overflow', async function () {
+      const a = MAX_UINT32;
+      const b = new BigNumber(2);
+
+      await shouldFail.reverting(this.safeMath.mul(a, b));
+    });
+  });
+
+  describe('div', function () {
+    it('divides correctly', async function () {
+      const a = new BigNumber(5678);
+      const b = new BigNumber(5678);
+
+      (await this.safeMath.div(a, b)).should.be.bignumber.equal(a.div(b));
+    });
+
+    it('throws a revert error on zero division', async function () {
+      const a = new BigNumber(5678);
+      const b = new BigNumber(0);
+
+      await shouldFail.reverting(this.safeMath.div(a, b));
+    });
+  });
+
+  describe('mod', function () {
+    describe('modulos correctly', async function () {
+      it('when the dividend is smaller than the divisor', async function () {
+        const a = new BigNumber(284);
+        const b = new BigNumber(5678);
+
+        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+      });
+
+      it('when the dividend is equal to the divisor', async function () {
+        const a = new BigNumber(5678);
+        const b = new BigNumber(5678);
+
+        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+      });
+
+      it('when the dividend is larger than the divisor', async function () {
+        const a = new BigNumber(7000);
+        const b = new BigNumber(5678);
+
+        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+      });
+
+      it('when the dividend is a multiple of the divisor', async function () {
+        const a = new BigNumber(17034); // 17034 == 5678 * 3
+        const b = new BigNumber(5678);
+
+        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+      });
+    });
+
+    it('reverts with a 0 divisor', async function () {
+      const a = new BigNumber(5678);
+      const b = new BigNumber(0);
+
+      await shouldFail.reverting(this.safeMath.mod(a, b));
+    });
+  });
+});


### PR DESCRIPTION
This PR creates a library that serves the same functions as SafeMath, but for `uint32`s instead of `uint256`s.  Now, those of us doing math with uint32s can do so safely!
Only variable types, the contract name, and the description on line 5 have changed from SafeMath.sol. 
