### PR TITLE
Fix isOwnable view method behavior

### DIFF
--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -33,15 +33,15 @@ contract Ownable {
    * @dev Throws if called by any account other than the owner.
    */
   modifier onlyOwner() {
-    require(isOwner());
+    require(isOwner(msg.sender));
     _;
   }
 
   /**
    * @return true if `msg.sender` is the owner of the contract.
    */
-  function isOwner() public view returns(bool) {
-    return msg.sender == _owner;
+  function isOwner(address who) public view returns(bool) {
+    return who == _owner;
   }
 
   /**

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -12,12 +12,12 @@ function shouldBehaveLikeOwnable (owner, [anyone]) {
     });
 
     it('changes owner after transfer', async function () {
-      (await this.ownable.isOwner({ from: anyone })).should.be.equal(false);
+      (await this.ownable.isOwner(anyone)).should.be.equal(false);
       const { logs } = await this.ownable.transferOwnership(anyone, { from: owner });
       expectEvent.inLogs(logs, 'OwnershipTransferred');
 
       (await this.ownable.owner()).should.equal(anyone);
-      (await this.ownable.isOwner({ from: anyone })).should.be.equal(true);
+      (await this.ownable.isOwner(anyone)).should.be.equal(true);
     });
 
     it('should prevent non-owners from transfering', async function () {


### PR DESCRIPTION
I am afraid of using `msg.*` inside of public `view`/`pure` methods as well as use modifiers. For me it seems method `isOwnable(address)` is more reasonable than `isOwnable()`.