### PR TITLE
export shouldFail.shouldFailWithMessage

### DIFF
--- a/contracts/mocks/Reverter.sol
+++ b/contracts/mocks/Reverter.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.24;
+
+contract Reverter {
+    bool public toggle = true;
+
+    function requiresTrue(bool param) public pure returns (bool) {
+        require(param == true, "Passed argument must be true");
+        return true;
+    }
+
+    function requiresGas() public returns (bool) {
+        toggle = !toggle;
+    }
+}

--- a/test/helpers/shouldFail.js
+++ b/test/helpers/shouldFail.js
@@ -25,6 +25,7 @@ async function outOfGas (promise) {
 }
 
 module.exports = {
+  withMessage: shouldFailWithMessage,
   reverting,
   throwing,
   outOfGas,

--- a/test/helpers/test/shouldFail.test.js
+++ b/test/helpers/test/shouldFail.test.js
@@ -1,17 +1,17 @@
 const shouldFail = require('../shouldFail');
-const RequireWithReason = artifacts.require('Reverter');
+const Reverter = artifacts.require('Reverter');
 
 const should = require('chai').should();
 
-describe.only('shouldFail', function() {
+describe('shouldFail', function() {
     beforeEach(async function () {
         this.reverter = await Reverter.new();
     });
-    // describe('withMessage');
-    // describe('reverting');
-    // describe('throwing');
-    describe('outOfGas', function() {
 
-    });
+    describe('withMessage', function() {
+        it('Excepts VM revert message to include revert reason', function() {
+            shouldFail.withMessage(this.reverter.requiresTrue(false), 'Passed argument must be true')
+        })
+    })
 })
 

--- a/test/helpers/test/shouldFail.test.js
+++ b/test/helpers/test/shouldFail.test.js
@@ -1,0 +1,17 @@
+const shouldFail = require('../shouldFail');
+const RequireWithReason = artifacts.require('Reverter');
+
+const should = require('chai').should();
+
+describe.only('shouldFail', function() {
+    beforeEach(async function () {
+        this.reverter = await Reverter.new();
+    });
+    // describe('withMessage');
+    // describe('reverting');
+    // describe('throwing');
+    describe('outOfGas', function() {
+
+    });
+})
+


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #1502

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented, and
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`).
-->

This is a harmless, one-liner change. Basically, it lets `shouldFail` module export the awesome `shouldFailWithMessage` function so that it could be used by 3rd party developers. 