### PR TITLE
ether and shouldFail tests

### DIFF
--- a/contracts/mocks/Failer.sol
+++ b/contracts/mocks/Failer.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.24;
+
+contract Failer {
+    uint256[] private array;
+
+    function dontFail() public pure {
+    }
+
+    function failWithRevert() public pure {
+        revert();
+    }
+
+    function failWithThrow() public pure {
+        assert(false);
+    }
+
+    function failWithOutOfGas() public {
+        for (uint256 i = 0; i < 2**200; ++i) {
+            array.push(i);
+        }
+    }
+}

--- a/test/helpers/shouldFail.js
+++ b/test/helpers/shouldFail.js
@@ -5,11 +5,13 @@ async function shouldFailWithMessage (promise, message) {
   try {
     await promise;
   } catch (error) {
-    error.message.should.include(message, 'Wrong failure type');
+    if (message) {
+      error.message.should.include(message, `Wrong failure type, expected '${message}'`);
+    }
     return;
   }
 
-  should.fail(`Expected '${message}' failure not received`);
+  should.fail('Expected failure not received');
 }
 
 async function reverting (promise) {
@@ -24,8 +26,12 @@ async function outOfGas (promise) {
   await shouldFailWithMessage(promise, 'out of gas');
 }
 
-module.exports = {
-  reverting,
-  throwing,
-  outOfGas,
-};
+async function shouldFail (promise) {
+  await shouldFailWithMessage(promise);
+}
+
+shouldFail.reverting = reverting;
+shouldFail.throwing = throwing;
+shouldFail.outOfGas = outOfGas;
+
+module.exports = shouldFail;

--- a/test/helpers/test/ether.test.js
+++ b/test/helpers/test/ether.test.js
@@ -1,0 +1,16 @@
+const { ether } = require('../ether');
+
+const BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+describe('ether', function () {
+  it('returns a BigNumber', function () {
+    ether(1, 'ether').should.be.bignumber.equal(new BigNumber(1000000000000000000));
+  });
+
+  it('works with negative amounts', function () {
+    ether(-1, 'ether').should.be.bignumber.equal(new BigNumber(-1000000000000000000));
+  });
+});

--- a/test/helpers/test/shouldFail.test.js
+++ b/test/helpers/test/shouldFail.test.js
@@ -35,7 +35,7 @@ describe('shouldFail', function () {
     });
 
     it('accepts an out of gas', async function () {
-      await shouldFail(this.failer.failWithOutOfGas());
+      await shouldFail(this.failer.failWithOutOfGas({ gas: 2000000 }));
     });
   });
 
@@ -53,7 +53,7 @@ describe('shouldFail', function () {
     });
 
     it('rejects an outOfGas', async function () {
-      await assertFailure(shouldFail.reverting(this.failer.failWithOutOfGas()));
+      await assertFailure(shouldFail.reverting(this.failer.failWithOutOfGas({ gas: 2000000 })));
     });
   });
 
@@ -71,7 +71,7 @@ describe('shouldFail', function () {
     });
 
     it('rejects an outOfGas', async function () {
-      await assertFailure(shouldFail.throwing(this.failer.failWithOutOfGas()));
+      await assertFailure(shouldFail.throwing(this.failer.failWithOutOfGas({ gas: 2000000 })));
     });
   });
 
@@ -81,7 +81,7 @@ describe('shouldFail', function () {
     });
 
     it('accepts an out of gas', async function () {
-      await shouldFail.outOfGas(this.failer.failWithOutOfGas());
+      await shouldFail.outOfGas(this.failer.failWithOutOfGas({ gas: 2000000 }));
     });
 
     it('rejects a revert', async function () {

--- a/test/helpers/test/shouldFail.test.js
+++ b/test/helpers/test/shouldFail.test.js
@@ -22,7 +22,7 @@ describe('shouldFail', function () {
   });
 
   describe('shouldFail', function () {
-    it('throws if no failure occurs', async function () {
+    it('rejects if no failure occurs', async function () {
       await assertFailure(shouldFail(this.failer.dontFail()));
     });
 
@@ -40,7 +40,7 @@ describe('shouldFail', function () {
   });
 
   describe('reverting', function () {
-    it('throws if no failure occurs', async function () {
+    it('rejects if no failure occurs', async function () {
       await assertFailure(shouldFail.reverting(this.failer.dontFail()));
     });
 
@@ -48,17 +48,17 @@ describe('shouldFail', function () {
       await shouldFail.reverting(this.failer.failWithRevert());
     });
 
-    it('throws with a throw', async function () {
+    it('rejects a throw', async function () {
       await assertFailure(shouldFail.reverting(this.failer.failWithThrow()));
     });
 
-    it('throws with an outOfGas', async function () {
+    it('rejects an outOfGas', async function () {
       await assertFailure(shouldFail.reverting(this.failer.failWithOutOfGas()));
     });
   });
 
   describe('throwing', function () {
-    it('throws if no failure occurs', async function () {
+    it('rejects if no failure occurs', async function () {
       await assertFailure(shouldFail.throwing(this.failer.dontFail()));
     });
 
@@ -66,17 +66,17 @@ describe('shouldFail', function () {
       await shouldFail.throwing(this.failer.failWithThrow());
     });
 
-    it('throws with a throw', async function () {
+    it('rejects a throw', async function () {
       await assertFailure(shouldFail.throwing(this.failer.failWithRevert()));
     });
 
-    it('throws with an outOfGas', async function () {
+    it('rejects an outOfGas', async function () {
       await assertFailure(shouldFail.throwing(this.failer.failWithOutOfGas()));
     });
   });
 
   describe('outOfGas', function () {
-    it('throws if no failure occurs', async function () {
+    it('rejects if no failure occurs', async function () {
       await assertFailure(shouldFail.outOfGas(this.failer.dontFail()));
     });
 
@@ -84,11 +84,11 @@ describe('shouldFail', function () {
       await shouldFail.outOfGas(this.failer.failWithOutOfGas());
     });
 
-    it('throws with a revert', async function () {
+    it('rejects a revert', async function () {
       await assertFailure(shouldFail.outOfGas(this.failer.failWithRevert()));
     });
 
-    it('throws with a throw', async function () {
+    it('rejects a throw', async function () {
       await assertFailure(shouldFail.outOfGas(this.failer.failWithThrow()));
     });
   });

--- a/test/helpers/test/shouldFail.test.js
+++ b/test/helpers/test/shouldFail.test.js
@@ -1,0 +1,95 @@
+const shouldFail = require('../shouldFail');
+
+const BigNumber = web3.BigNumber;
+const should = require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+const Failer = artifacts.require('Failer');
+
+async function assertFailure (promise) {
+  try {
+    await promise;
+  } catch (error) {
+    return;
+  }
+  should.fail();
+}
+
+describe('shouldFail', function () {
+  beforeEach(async function () {
+    this.failer = await Failer.new();
+  });
+
+  describe('shouldFail', function () {
+    it('throws if no failure occurs', async function () {
+      await assertFailure(shouldFail(this.failer.dontFail()));
+    });
+
+    it('accepts a revert', async function () {
+      await shouldFail(this.failer.failWithRevert());
+    });
+
+    it('accepts a throw', async function () {
+      await shouldFail(this.failer.failWithThrow());
+    });
+
+    it('accepts an out of gas', async function () {
+      await shouldFail(this.failer.failWithOutOfGas());
+    });
+  });
+
+  describe('reverting', function () {
+    it('throws if no failure occurs', async function () {
+      await assertFailure(shouldFail.reverting(this.failer.dontFail()));
+    });
+
+    it('accepts a revert', async function () {
+      await shouldFail.reverting(this.failer.failWithRevert());
+    });
+
+    it('throws with a throw', async function () {
+      await assertFailure(shouldFail.reverting(this.failer.failWithThrow()));
+    });
+
+    it('throws with an outOfGas', async function () {
+      await assertFailure(shouldFail.reverting(this.failer.failWithOutOfGas()));
+    });
+  });
+
+  describe('throwing', function () {
+    it('throws if no failure occurs', async function () {
+      await assertFailure(shouldFail.throwing(this.failer.dontFail()));
+    });
+
+    it('accepts a throw', async function () {
+      await shouldFail.throwing(this.failer.failWithThrow());
+    });
+
+    it('throws with a throw', async function () {
+      await assertFailure(shouldFail.throwing(this.failer.failWithRevert()));
+    });
+
+    it('throws with an outOfGas', async function () {
+      await assertFailure(shouldFail.throwing(this.failer.failWithOutOfGas()));
+    });
+  });
+
+  describe('outOfGas', function () {
+    it('throws if no failure occurs', async function () {
+      await assertFailure(shouldFail.outOfGas(this.failer.dontFail()));
+    });
+
+    it('accepts an out of gas', async function () {
+      await shouldFail.outOfGas(this.failer.failWithOutOfGas());
+    });
+
+    it('throws with a revert', async function () {
+      await assertFailure(shouldFail.outOfGas(this.failer.failWithRevert()));
+    });
+
+    it('throws with a throw', async function () {
+      await assertFailure(shouldFail.outOfGas(this.failer.failWithThrow()));
+    });
+  });
+});


### PR DESCRIPTION
I also created a new `shouldFail` function that doesn't expect any message (i.e. it can be used for any kind of rejection).

Fixes https://github.com/OpenZeppelin/openzeppelin-solidity/issues/938