### PR TITLE
balanceDifference tests and application

### DIFF
--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -1,7 +1,7 @@
 const expectEvent = require('../helpers/expectEvent');
 const { ether } = require('../helpers/ether');
 const shouldFail = require('../helpers/shouldFail');
-const { ethGetBalance } = require('../helpers/web3');
+const { balanceDifference } = require('../helpers/balanceDifference');
 const { ZERO_ADDRESS } = require('../helpers/constants');
 
 const BigNumber = web3.BigNumber;
@@ -56,10 +56,9 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
     });
 
     it('should forward funds to wallet', async function () {
-      const pre = await ethGetBalance(wallet);
-      await this.crowdsale.sendTransaction({ value, from: investor });
-      const post = await ethGetBalance(wallet);
-      post.minus(pre).should.be.bignumber.equal(value);
+      (await balanceDifference(wallet, () =>
+        this.crowdsale.sendTransaction({ value, from: investor }))
+      ).should.be.bignumber.equal(value);
     });
   });
 

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -1,7 +1,7 @@
 const expectEvent = require('../helpers/expectEvent');
 const shouldFail = require('../helpers/shouldFail');
+const { balanceDifference } = require('../helpers/balanceDifference');
 const { ether } = require('../helpers/ether');
-const { ethGetBalance } = require('../helpers/web3');
 const { ZERO_ADDRESS } = require('../helpers/constants');
 
 const BigNumber = web3.BigNumber;
@@ -97,10 +97,9 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
         });
 
         it('should forward funds to wallet', async function () {
-          const pre = await ethGetBalance(wallet);
-          await this.crowdsale.sendTransaction({ value, from: investor });
-          const post = await ethGetBalance(wallet);
-          post.minus(pre).should.be.bignumber.equal(value);
+          (await balanceDifference(wallet, () =>
+            this.crowdsale.sendTransaction({ value, from: investor }))
+          ).should.be.bignumber.equal(value);
         });
       });
 
@@ -121,10 +120,9 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
         });
 
         it('should forward funds to wallet', async function () {
-          const pre = await ethGetBalance(wallet);
-          await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-          const post = await ethGetBalance(wallet);
-          post.minus(pre).should.be.bignumber.equal(value);
+          (await balanceDifference(wallet, () =>
+            this.crowdsale.buyTokens(investor, { value, from: purchaser }))
+          ).should.be.bignumber.equal(value);
         });
       });
     });

--- a/test/crowdsale/MintedCrowdsale.behavior.js
+++ b/test/crowdsale/MintedCrowdsale.behavior.js
@@ -1,5 +1,5 @@
 const expectEvent = require('../helpers/expectEvent');
-const { ethGetBalance } = require('../helpers/web3');
+const { balanceDifference } = require('../helpers/expectEvent');
 
 const BigNumber = web3.BigNumber;
 
@@ -35,10 +35,9 @@ function shouldBehaveLikeMintedCrowdsale ([_, investor, wallet, purchaser], rate
       });
 
       it('should forward funds to wallet', async function () {
-        const pre = await ethGetBalance(wallet);
-        await this.crowdsale.sendTransaction({ value, from: investor });
-        const post = await ethGetBalance(wallet);
-        post.minus(pre).should.be.bignumber.equal(value);
+        (await balanceDifference(wallet, () =>
+          this.crowdsale.sendTransaction({ value, from: investor }))
+        ).should.be.bignumber.equal(value);
       });
     });
   });

--- a/test/crowdsale/MintedCrowdsale.behavior.js
+++ b/test/crowdsale/MintedCrowdsale.behavior.js
@@ -1,5 +1,5 @@
 const expectEvent = require('../helpers/expectEvent');
-const { balanceDifference } = require('../helpers/expectEvent');
+const { balanceDifference } = require('../helpers/balanceDifference');
 
 const BigNumber = web3.BigNumber;
 

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -1,5 +1,6 @@
 const { ether } = require('../helpers/ether');
 const { advanceBlock } = require('../helpers/advanceToBlock');
+const { balanceDifference } = require('../helpers/balanceDifference');
 const shouldFail = require('../helpers/shouldFail');
 const time = require('../helpers/time');
 const { ethGetBalance } = require('../helpers/web3');
@@ -75,10 +76,9 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, anyon
           });
 
           it('refunds', async function () {
-            const pre = await ethGetBalance(investor);
-            await this.crowdsale.claimRefund(investor, { gasPrice: 0 });
-            const post = await ethGetBalance(investor);
-            post.minus(pre).should.be.bignumber.equal(lessThanGoal);
+            (await balanceDifference(investor, () =>
+              this.crowdsale.claimRefund(investor, { gasPrice: 0 }))
+            ).should.be.bignumber.equal(lessThanGoal);
           });
         });
       });

--- a/test/helpers/balanceDifference.js
+++ b/test/helpers/balanceDifference.js
@@ -1,6 +1,6 @@
-async function balanceDifference (account, promise) {
+async function balanceDifference (account, promiseFunc) {
   const balanceBefore = web3.eth.getBalance(account);
-  await promise();
+  await promiseFunc();
   const balanceAfter = web3.eth.getBalance(account);
   return balanceAfter.minus(balanceBefore);
 }

--- a/test/helpers/test/balanceDifference.test.js
+++ b/test/helpers/test/balanceDifference.test.js
@@ -1,0 +1,20 @@
+const { balanceDifference } = require('../balanceDifference');
+const { sendEther } = require('../sendTransaction');
+const { ether } = require('../ether');
+
+const BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('balanceDifference', function ([sender, receiver]) {
+  it('returns balance increments', async function () {
+    (await balanceDifference(receiver, () => sendEther(sender, receiver, ether(1))))
+      .should.be.bignumber.equal(ether(1));
+  });
+
+  it('returns balance decrements', async function () {
+    (await balanceDifference(sender, () => sendEther(sender, receiver, ether(1))))
+      .should.be.bignumber.equal(ether(-1));
+  });
+});

--- a/test/helpers/test/balanceDifference.test.js
+++ b/test/helpers/test/balanceDifference.test.js
@@ -9,12 +9,14 @@ require('chai')
 
 contract('balanceDifference', function ([sender, receiver]) {
   it('returns balance increments', async function () {
-    (await balanceDifference(receiver, () => sendEther(sender, receiver, ether(1))))
-      .should.be.bignumber.equal(ether(1));
+    (await balanceDifference(receiver, () =>
+      sendEther(sender, receiver, ether(1)))
+    ).should.be.bignumber.equal(ether(1));
   });
 
   it('returns balance decrements', async function () {
-    (await balanceDifference(sender, () => sendEther(sender, receiver, ether(1))))
-      .should.be.bignumber.equal(ether(-1));
+    (await balanceDifference(sender, () =>
+      sendEther(sender, receiver, ether(1)))
+    ).should.be.bignumber.equal(ether(-1));
   });
 });

--- a/test/payment/PullPayment.test.js
+++ b/test/payment/PullPayment.test.js
@@ -1,4 +1,4 @@
-const { ethGetBalance } = require('../helpers/web3');
+const { balanceDifference } = require('../helpers/balanceDifference');
 const { ether } = require('../helpers/ether');
 
 const BigNumber = web3.BigNumber;
@@ -37,16 +37,13 @@ contract('PullPayment', function ([_, payer, payee1, payee2]) {
   });
 
   it('can withdraw payment', async function () {
-    const initialBalance = await ethGetBalance(payee1);
+    (await balanceDifference(payee1, async () => {
+      await this.contract.callTransfer(payee1, amount, { from: payer });
+      (await this.contract.payments(payee1)).should.be.bignumber.equal(amount);
 
-    await this.contract.callTransfer(payee1, amount, { from: payer });
+      await this.contract.withdrawPayments(payee1);
+    })).should.be.bignumber.equal(amount);
 
-    (await this.contract.payments(payee1)).should.be.bignumber.equal(amount);
-
-    await this.contract.withdrawPayments(payee1);
     (await this.contract.payments(payee1)).should.be.bignumber.equal(0);
-
-    const balance = await ethGetBalance(payee1);
-    Math.abs(balance - initialBalance - amount).should.be.lt(1e16);
   });
 });

--- a/test/payment/escrow/Escrow.behavior.js
+++ b/test/payment/escrow/Escrow.behavior.js
@@ -1,6 +1,7 @@
 const expectEvent = require('../../helpers/expectEvent');
 const shouldFail = require('../../helpers/shouldFail');
 const { ethGetBalance } = require('../../helpers/web3');
+const { balanceDifference } = require('../../helpers/balanceDifference');
 const { ether } = require('../../helpers/ether');
 
 const BigNumber = web3.BigNumber;
@@ -61,17 +62,13 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
 
     describe('withdrawals', async function () {
       it('can withdraw payments', async function () {
-        const payeeInitialBalance = await ethGetBalance(payee1);
-
-        await this.escrow.deposit(payee1, { from: primary, value: amount });
-        await this.escrow.withdraw(payee1, { from: primary });
+        (await balanceDifference(payee1, async () => {
+          await this.escrow.deposit(payee1, { from: primary, value: amount });
+          await this.escrow.withdraw(payee1, { from: primary });
+        })).should.be.bignumber.equal(amount);
 
         (await ethGetBalance(this.escrow.address)).should.be.bignumber.equal(0);
-
         (await this.escrow.depositsOf(payee1)).should.be.bignumber.equal(0);
-
-        const payeeFinalBalance = await ethGetBalance(payee1);
-        payeeFinalBalance.sub(payeeInitialBalance).should.be.bignumber.equal(amount);
       });
 
       it('can do an empty withdrawal', async function () {

--- a/test/payment/escrow/RefundEscrow.test.js
+++ b/test/payment/escrow/RefundEscrow.test.js
@@ -1,6 +1,6 @@
 const shouldFail = require('../../helpers/shouldFail');
 const expectEvent = require('../../helpers/expectEvent');
-const { ethGetBalance } = require('../../helpers/web3');
+const { balanceDifference } = require('../../helpers/balanceDifference');
 const { ether } = require('../../helpers/ether');
 const { ZERO_ADDRESS } = require('../../helpers/constants');
 
@@ -73,11 +73,9 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       });
 
       it('allows beneficiary withdrawal', async function () {
-        const beneficiaryInitialBalance = await ethGetBalance(beneficiary);
-        await this.escrow.beneficiaryWithdraw();
-        const beneficiaryFinalBalance = await ethGetBalance(beneficiary);
-
-        beneficiaryFinalBalance.sub(beneficiaryInitialBalance).should.be.bignumber.equal(amount * refundees.length);
+        (await balanceDifference(beneficiary, () =>
+          this.escrow.beneficiaryWithdraw()
+        )).should.be.bignumber.equal(amount * refundees.length);
       });
 
       it('prevents entering the refund state', async function () {
@@ -109,11 +107,9 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
 
       it('refunds refundees', async function () {
         for (const refundee of [refundee1, refundee2]) {
-          const refundeeInitialBalance = await ethGetBalance(refundee);
-          await this.escrow.withdraw(refundee, { from: primary });
-          const refundeeFinalBalance = await ethGetBalance(refundee);
-
-          refundeeFinalBalance.sub(refundeeInitialBalance).should.be.bignumber.equal(amount);
+          (await balanceDifference(refundee, () =>
+            this.escrow.withdraw(refundee, { from: primary }))
+          ).should.be.bignumber.equal(amount);
         }
       });
 


### PR DESCRIPTION
`PaymentSplitter` still uses `ethGetBalance`, but the whole test file is sort of messy, it may need a more thorough refactor eventually.