### PR TITLE
updating ERC20Detailed to inherit from ERC20, not IERC20.

### DIFF
--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "./IERC20.sol";
+import "./ERC20.sol";
 
 /**
  * @title ERC20Detailed token
@@ -8,7 +8,7 @@ import "./IERC20.sol";
  * All the operations are done using the smallest and indivisible token unit,
  * just as on Ethereum all the operations are done in wei.
  */
-contract ERC20Detailed is IERC20 {
+contract ERC20Detailed is ERC20 {
     string private _name;
     string private _symbol;
     uint8 private _decimals;


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #1536

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

Changing ERC20Detailed to inherit from ERC20 instead of IERC20 to better match the other ERC20X contracts and to allow a token to inherit only ERC20Detailed instead of both ERC20Detailed and ERC20.