### PR TITLE
Deprecated ERC721._burn(address, uint256)

### DIFF
--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -12,6 +12,6 @@ contract ERC721Mock is ERC721 {
     }
 
     function burn(uint256 tokenId) public {
-        _burn(ownerOf(tokenId), tokenId);
+        _burn(tokenId);
     }
 }

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -13,7 +13,7 @@ contract ERC721PausableMock is ERC721Pausable, PauserRoleMock {
     }
 
     function burn(uint256 tokenId) public {
-        super._burn(ownerOf(tokenId), tokenId);
+        super._burn(tokenId);
     }
 
     function exists(uint256 tokenId) public view returns (bool) {

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -198,7 +198,7 @@ contract ERC721 is ERC165, IERC721 {
      * @dev Internal function to mint a new token
      * Reverts if the given token ID already exists
      * @param to The address that will own the minted token
-     * @param tokenId uint256 ID of the token to be minted by the msg.sender
+     * @param tokenId uint256 ID of the token to be minted
      */
     function _mint(address to, uint256 tokenId) internal {
         require(to != address(0));
@@ -209,12 +209,22 @@ contract ERC721 is ERC165, IERC721 {
     /**
      * @dev Internal function to burn a specific token
      * Reverts if the token does not exist
-     * @param tokenId uint256 ID of the token being burned by the msg.sender
+     * Deprecated, use _burn(uint256) instead.
+     * @param tokenId uint256 ID of the token being burned
      */
     function _burn(address owner, uint256 tokenId) internal {
         _clearApproval(tokenId);
         _removeTokenFrom(owner, tokenId);
         emit Transfer(owner, address(0), tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token
+     * Reverts if the token does not exist
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(uint256 tokenId) internal {
+        _burn(ownerOf(tokenId), tokenId);
     }
 
     /**

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -210,6 +210,7 @@ contract ERC721 is ERC165, IERC721 {
      * @dev Internal function to burn a specific token
      * Reverts if the token does not exist
      * Deprecated, use _burn(uint256) instead.
+     * @param owner owner of the token to burn
      * @param tokenId uint256 ID of the token being burned
      */
     function _burn(address owner, uint256 tokenId) internal {

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -13,6 +13,6 @@ contract ERC721Burnable is ERC721 {
      */
     function burn(uint256 tokenId) public {
         require(_isApprovedOrOwner(msg.sender, tokenId));
-        _burn(ownerOf(tokenId), tokenId);
+        _burn(tokenId);
     }
 }

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -117,7 +117,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
      * @dev Internal function to mint a new token
      * Reverts if the given token ID already exists
      * @param to address the beneficiary that will own the minted token
-     * @param tokenId uint256 ID of the token to be minted by the msg.sender
+     * @param tokenId uint256 ID of the token to be minted
      */
     function _mint(address to, uint256 tokenId) internal {
         super._mint(to, tokenId);
@@ -129,8 +129,9 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     /**
      * @dev Internal function to burn a specific token
      * Reverts if the token does not exist
+     * Deprecated, use _burn(uint256) instead
      * @param owner owner of the token to burn
-     * @param tokenId uint256 ID of the token being burned by the msg.sender
+     * @param tokenId uint256 ID of the token being burned
      */
     function _burn(address owner, uint256 tokenId) internal {
         super._burn(owner, tokenId);
@@ -147,10 +148,10 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
         _allTokensIndex[tokenId] = 0;
         _allTokensIndex[lastToken] = tokenIndex;
     }
-    
+
     /**
      * @dev Gets the list of token IDs of the requested owner
-     * @param owner address owning the tokens 
+     * @param owner address owning the tokens
      * @return uint256[] List of token IDs owned by the requested address
      */
     function _tokensOfOwner(address owner) internal view returns (uint256[] storage) {

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -73,6 +73,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     /**
      * @dev Internal function to burn a specific token
      * Reverts if the token does not exist
+     * Deprecated, use _burn(uint256) instead
      * @param owner owner of the token to burn
      * @param tokenId uint256 ID of the token being burned by the msg.sender
      */


### PR DESCRIPTION
The old interface made no sense, since the address could only be the owner of the token. This PR adds a saner alternative, keeping the underlying behavior.