### PR TITLE
WIP: ERC20 funded Crowdsale

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -112,7 +112,7 @@ contract Crowdsale is ReentrancyGuard {
      * @param beneficiary Recipient of the token purchase
      */
     function buyTokens(address beneficiary) public nonReentrant payable {
-        uint256 weiAmount = msg.value;
+        uint256 weiAmount = _weiAmount();
         _preValidatePurchase(beneficiary, weiAmount);
 
         // calculate token amount to be created
@@ -197,5 +197,12 @@ contract Crowdsale is ReentrancyGuard {
      */
     function _forwardFunds() internal {
         _wallet.transfer(msg.value);
+    }
+
+    /**
+     * @dev Determines the value (in Wei) included with a purchase.
+     */
+    function _weiAmount() internal view returns (uint256) {
+        return msg.value;
     }
 }

--- a/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
+++ b/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
@@ -41,33 +41,17 @@ contract ERC20FundedCrowdsale is Crowdsale {
     }
 
     /**
-     * @dev Validates the incoming purchase by ensuring no wei is sent with the transaction, and number of `fundingToken`s
-     * sent with the transaction is greater than 0.
-     * @param beneficiary Address that will receive `token`s from this purchase
-     * @param weiAmount Guaranteed to be 0
-     */
-    function _preValidatePurchase(address beneficiary, uint256 weiAmount) internal view {
-        require(beneficiary != address(0));
-        require(weiAmount == 0);
-
-        require(fundingToken().allowance(msg.sender, address(this)) > 0);
-    }
-
-    /**
-     * @dev Convert number of `fundingToken`s to number of `token`s.
-     * @param weiAmount Guaranteed to be 0
-     * @return Number of `token`s that will be received from this purchase
-     */
-    function _getTokenAmount(uint256 weiAmount) internal view returns (uint256) {
-        return fundingToken().allowance(msg.sender, address(this)).mul(rate());
-    }
-
-    /**
      * @dev Forwards `fundingToken`s to `wallet`.
      */
     function _forwardFunds() internal {
-        uint256 allowance = fundingToken().allowance(msg.sender, address(this));
-        fundingToken().safeTransferFrom(msg.sender, wallet(), allowance);
+        fundingToken().safeTransferFrom(msg.sender, wallet(), _weiAmount());
+    }
+
+    /**
+     * @dev Determines the value (in `fundingToken`) included with a purchase.
+     */
+    function _weiAmount() internal view returns (uint256) {
+        return fundingToken().allowance(msg.sender, address(this));
     }
 
 }

--- a/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
+++ b/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
@@ -34,13 +34,6 @@ contract ERC20FundedCrowdsale is Crowdsale {
     }
 
     /**
-     * @return The number of `fundingToken`s raised (NOT WEI).
-     */
-    function weiRaised() public view returns (uint256) {
-        return fundingToken().balanceOf(address(this));
-    }
-
-    /**
      * @dev Forwards `fundingToken`s to `wallet`.
      */
     function _forwardFunds() internal {

--- a/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
+++ b/contracts/crowdsale/distribution/ERC20FundedCrowdsale.sol
@@ -1,0 +1,73 @@
+pragma solidity ^0.4.24;
+
+import "../Crowdsale.sol";
+import "../../token/ERC20/IERC20.sol";
+import "../../token/ERC20/SafeERC20.sol";
+import "../../math/SafeMath.sol";
+
+/**
+ * @title ERC20FundedCrowdsale
+ * @dev Crowdsale that raises funds in an ERC20 token (instead of Ether).
+ * IMPORTANT: `weiRaised` indicates the number of `fundingToken`s raised (not Ether)
+ *
+ * Developed by blockimmo AG (https://blockimmo.ch/)
+ */
+contract ERC20FundedCrowdsale is Crowdsale {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    IERC20 private _fundingToken;  // ERC20 token funds will be raised in
+
+    /**
+     * @param fundingToken IERC20 Address of the token funds will be raised in (i.e. Dai Stablecoin, Crypto Franc (XCHF), etc...).
+     */
+    constructor (IERC20 fundingToken) internal {
+        require(fundingToken != address(0));
+        _fundingToken = fundingToken;
+    }
+
+    /**
+     * @return The token funds are being raised in.
+     */
+    function fundingToken() public view returns (IERC20) {
+        return _fundingToken;
+    }
+
+    /**
+     * @return The number of `fundingToken`s raised (NOT WEI).
+     */
+    function weiRaised() public view returns (uint256) {
+        return fundingToken().balanceOf(address(this));
+    }
+
+    /**
+     * @dev Validates the incoming purchase by ensuring no wei is sent with the transaction, and number of `fundingToken`s
+     * sent with the transaction is greater than 0.
+     * @param beneficiary Address that will receive `token`s from this purchase
+     * @param weiAmount Guaranteed to be 0
+     */
+    function _preValidatePurchase(address beneficiary, uint256 weiAmount) internal view {
+        require(beneficiary != address(0));
+        require(weiAmount == 0);
+
+        require(fundingToken().allowance(msg.sender, address(this)) > 0);
+    }
+
+    /**
+     * @dev Convert number of `fundingToken`s to number of `token`s.
+     * @param weiAmount Guaranteed to be 0
+     * @return Number of `token`s that will be received from this purchase
+     */
+    function _getTokenAmount(uint256 weiAmount) internal view returns (uint256) {
+        return fundingToken().allowance(msg.sender, address(this)).mul(rate());
+    }
+
+    /**
+     * @dev Forwards `fundingToken`s to `wallet`.
+     */
+    function _forwardFunds() internal {
+        uint256 allowance = fundingToken().allowance(msg.sender, address(this));
+        fundingToken().safeTransferFrom(msg.sender, wallet(), allowance);
+    }
+
+}

--- a/contracts/mocks/ERC20FundedCrowdsaleMock.sol
+++ b/contracts/mocks/ERC20FundedCrowdsaleMock.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.24;
+
+import "../token/ERC20/IERC20.sol";
+import "../crowdsale/distribution/ERC20FundedCrowdsale.sol";
+
+contract ERC20FundedCrowdsaleMock is ERC20FundedCrowdsale {
+    constructor (
+        uint256 rate,
+        address wallet,
+        IERC20 token,
+        IERC20 fundingToken
+    )
+        public
+        Crowdsale(rate, wallet, token)
+        ERC20FundedCrowdsale(fundingToken)
+    {}
+}

--- a/test/crowdsale/ERC20FundedCrowdsale.test.js
+++ b/test/crowdsale/ERC20FundedCrowdsale.test.js
@@ -1,0 +1,121 @@
+const expectEvent = require('../helpers/expectEvent');
+const shouldFail = require('../helpers/shouldFail');
+const { balanceDifference } = require('../helpers/balanceDifference');
+const { ether } = require('../helpers/ether');
+const { ZERO_ADDRESS } = require('../helpers/constants');
+
+const { BigNumber } = require('../helpers/setup');
+
+const ERC20FundedCrowdsale = artifacts.require('ERC20FundedCrowdsaleMock');
+const SimpleToken = artifacts.require('SimpleToken');
+const ERC20Mock = artifacts.require('ERC20Mock');
+
+contract('ERC20FundedCrowdsale', function ([_, investor, wallet, purchaser]) {
+  const rate = new BigNumber(1);
+  const value = ether(42);
+  const tokenSupply = new BigNumber('1e22');
+  const expectedTokenAmount = rate.mul(value);
+
+  context('with token', async function () {
+    beforeEach(async function () {
+      this.token = await SimpleToken.new();
+    });
+
+    it('requires a non-null funding token', async function () {
+      await shouldFail.reverting(
+        ERC20FundedCrowdsale.new(rate, wallet, this.token.address, ZERO_ADDRESS)
+      );
+    });
+
+    context('once deployed', async function () {
+      beforeEach(async function () {
+        this.fundingToken = await ERC20Mock.new(purchaser, tokenSupply);
+
+        this.crowdsale = await ERC20FundedCrowdsale.new(rate, wallet, this.token.address, this.fundingToken.address);
+        await this.token.transfer(this.crowdsale.address, tokenSupply);
+
+        await this.fundingToken.approve(this.crowdsale.address, value, { from: purchaser });
+      });
+
+      describe('accepting payments', function () {
+        describe('bare payments', function () {
+          it('should accept payments', async function () {
+            await this.crowdsale.sendTransaction({ from: purchaser });
+          });
+
+          it('reverts on zero-valued payments', async function () {
+            await shouldFail.reverting(
+              this.crowdsale.send(0, { from: investor })
+            );
+          });
+        });
+
+        describe('buyTokens', function () {
+          it('should accept payments', async function () {
+            await this.crowdsale.buyTokens(investor, { from: purchaser });
+          });
+
+          it('reverts on zero-valued payments', async function () {
+            await shouldFail.reverting(
+              this.crowdsale.buyTokens(investor, { from: investor })
+            );
+          });
+
+          it('requires a non-null beneficiary', async function () {
+            await shouldFail.reverting(
+              this.crowdsale.buyTokens(ZERO_ADDRESS, { from: purchaser })
+            );
+          });
+        });
+      });
+
+      describe('high-level purchase', function () {
+        it('should log purchase', async function () {
+          const { logs } = await this.crowdsale.sendTransaction({ from: purchaser });
+          expectEvent.inLogs(logs, 'TokensPurchased', {
+            purchaser,
+            beneficiary: purchaser,
+            value: 0,
+            amount: expectedTokenAmount,
+          });
+        });
+
+        it('should assign tokens to sender', async function () {
+          await this.crowdsale.sendTransaction({ from: purchaser });
+          (await this.token.balanceOf(purchaser)).should.be.bignumber.equal(expectedTokenAmount);
+        });
+
+        it('should forward funds to wallet', async function () {
+          (await balanceDifference(wallet, () =>
+            this.crowdsale.sendTransaction({ from: purchaser }))
+          ).should.be.bignumber.equal(0);
+          (await this.fundingToken.balanceOf(wallet)).should.be.bignumber.equal(value);
+        });
+      });
+
+      describe('low-level purchase', function () {
+        it('should log purchase', async function () {
+          const { logs } = await this.crowdsale.buyTokens(investor, { from: purchaser });
+          expectEvent.inLogs(logs, 'TokensPurchased', {
+            purchaser: purchaser,
+            beneficiary: investor,
+            value: 0,
+            amount: expectedTokenAmount,
+          });
+        });
+
+        it('should assign tokens to beneficiary', async function () {
+          await this.crowdsale.buyTokens(investor, { from: purchaser });
+          (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
+        });
+
+        it('should forward funds to wallet', async function () {
+          (await balanceDifference(wallet, () =>
+            this.crowdsale.buyTokens(investor, { from: purchaser }))
+          ).should.be.bignumber.equal(0);
+          (await this.fundingToken.balanceOf(wallet)).should.be.bignumber.equal(value);
+        });
+      });
+    });
+  });
+});

--- a/test/crowdsale/ERC20FundedCrowdsale.test.js
+++ b/test/crowdsale/ERC20FundedCrowdsale.test.js
@@ -41,6 +41,7 @@ contract('ERC20FundedCrowdsale', function ([_, investor, wallet, purchaser]) {
         describe('bare payments', function () {
           it('should accept payments', async function () {
             await this.crowdsale.sendTransaction({ from: purchaser });
+            (await this.crowdsale.weiRaised()).should.be.bignumber.equal(value);
           });
 
           it('reverts on zero-valued payments', async function () {
@@ -53,6 +54,7 @@ contract('ERC20FundedCrowdsale', function ([_, investor, wallet, purchaser]) {
         describe('buyTokens', function () {
           it('should accept payments', async function () {
             await this.crowdsale.buyTokens(investor, { from: purchaser });
+            (await this.crowdsale.weiRaised()).should.be.bignumber.equal(value);
           });
 
           it('reverts on zero-valued payments', async function () {

--- a/test/crowdsale/ERC20FundedCrowdsale.test.js
+++ b/test/crowdsale/ERC20FundedCrowdsale.test.js
@@ -75,7 +75,7 @@ contract('ERC20FundedCrowdsale', function ([_, investor, wallet, purchaser]) {
           expectEvent.inLogs(logs, 'TokensPurchased', {
             purchaser,
             beneficiary: purchaser,
-            value: 0,
+            value,
             amount: expectedTokenAmount,
           });
         });
@@ -99,7 +99,7 @@ contract('ERC20FundedCrowdsale', function ([_, investor, wallet, purchaser]) {
           expectEvent.inLogs(logs, 'TokensPurchased', {
             purchaser: purchaser,
             beneficiary: investor,
-            value: 0,
+            value,
             amount: expectedTokenAmount,
           });
         });


### PR DESCRIPTION
### Why we made this PR
At [blockimmo](https://blockimmo.ch/) we tokenize real estate and enable these (security) tokens to be sold in the primary market via an `OpenZeppelin` based [TokenSale](https://gitlab.com/blockimmo-ch/blockimmo-contracts/blob/master/contracts/TokenSale.sol) that we've implemented.

Ether's volatility is turning out to be a major roadblock in listing real properties on our platform. A single percentage point can be the difference between a successful and bad investment in the real estate investment space, and therefore we need a way to offer both sellers and investors a stable means to conduct these transactions. **This seems to be the case for most assets / securities, in addition to real estate.**

Therefore we are working on a `Crowdsale` that raises funds in a stable token such as [Dai](https://makerdao.com/) or [Crypto Frank (XCHF)](https://www.swisscryptotokens.ch/). This offers both seller(s) and investor(s) stability.

### Technical details / changes
This `Crowdsale` is very similar to the existing `OpenZeppelin` `Crowdsale`s, except:

- Purchasing tokens now consists of two transactions on the investor's side.
  1. The investor must first `approve()` the `Crowdsale` to transfer the number of tokens they'd like to invest on their behalf. 
  2. The investor may then call the `Crowdsale`'s `buyTokens()` method, which will pull the number of tokens they approved in (1) with `transferFrom` to execute the purchase.
- The `weiRaised` and `weiAmount` variable names are kept (to play nicely with the base `Crowdsale` smart contract that we extend here), but don't make sense in this case.. This probably needs to be improved.

### Work in progress
I want to get some feedback on this PR before spending more time on it. Documentation can be improved, and all extended `Crowdsale`s like `RefundableCrowdsale` can be adapted to support ERC20 powered sales. But first want to get a round of feedback

- The [first commit](https://github.com/OpenZeppelin/openzeppelin-solidity/commit/d25ea73b40ca6de96ee1c2a9fb97cdf011e2d00) in this PR implements this without touching the base `Crowdsale`
- The [second commit](https://github.com/OpenZeppelin/openzeppelin-solidity/commit/f554021c2c399c2ebfd5138ec3d3fb7f18f37445) makes a minor change to the base `Crowdsale` that makes `ERC20FundedCrowdsale` simpler / less code, and play nicely with extensions like `CappedCrowdsale` as their is very little deviation from base

### Open Questions
This requires two transactions on the investor's side. Ideally, purchasing tokens via `ERC20FundedCrowdsale` would remain one transaction. Is there a simple way to do this that I'm missing?

Seems like it would be simple enough to add a method to `ERC20.sol` that allows a token holder to sign a transfer on their behalf (instead of approving an `allowance` with a transaction). And then this signature hash could just be provided to `buyTokens` as a parameter, and executed in a single transaction. But maybe there is a simpler way that doesn't require a change to `ERC20.sol`?