### PR TITLE
Release v2.1.0 solc 0.5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 # truffle
 .node-xmlhttprequest-*
+
+# Temporary directory for 0.5.x compilation
+solc-0.5

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Roles

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Roles

--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelistedRole.sol
+++ b/contracts/access/roles/WhitelistedRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 import "./WhitelisterRole.sol";

--- a/contracts/access/roles/WhitelistedRole.sol
+++ b/contracts/access/roles/WhitelistedRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 import "./WhitelisterRole.sol";

--- a/contracts/access/roles/WhitelisterRole.sol
+++ b/contracts/access/roles/WhitelisterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelisterRole.sol
+++ b/contracts/access/roles/WhitelisterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Roles.sol";
 

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../math/SafeMath.sol";
@@ -25,7 +25,7 @@ contract Crowdsale is ReentrancyGuard {
     IERC20 private _token;
 
     // Address where funds are collected
-    address private _wallet;
+    address payable private _wallet;
 
     // How many token units a buyer gets per wei.
     // The rate is the conversion between wei and the smallest and indivisible token unit.
@@ -53,10 +53,10 @@ contract Crowdsale is ReentrancyGuard {
      * @param wallet Address where collected funds will be forwarded to
      * @param token Address of the token being sold
      */
-    constructor (uint256 rate, address wallet, IERC20 token) public {
+    constructor (uint256 rate, address payable wallet, IERC20 token) public {
         require(rate > 0);
         require(wallet != address(0));
-        require(token != address(0));
+        require(address(token) != address(0));
 
         _rate = rate;
         _wallet = wallet;
@@ -87,7 +87,7 @@ contract Crowdsale is ReentrancyGuard {
     /**
      * @return the address where funds are collected.
      */
-    function wallet() public view returns (address) {
+    function wallet() public view returns (address payable) {
         return _wallet;
     }
 

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "../validation/TimedCrowdsale.sol";

--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "../validation/TimedCrowdsale.sol";

--- a/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "./FinalizableCrowdsale.sol";

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "./FinalizableCrowdsale.sol";
@@ -44,7 +44,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
      * @dev Investors can claim refunds here if crowdsale is unsuccessful
      * @param refundee Whose refund will be claimed.
      */
-    function claimRefund(address refundee) public {
+    function claimRefund(address payable refundee) public {
         require(finalized());
         require(!goalReached());
 

--- a/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./RefundableCrowdsale.sol";
 import "./PostDeliveryCrowdsale.sol";

--- a/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./RefundableCrowdsale.sol";
 import "./PostDeliveryCrowdsale.sol";

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/IERC20.sol";
@@ -37,7 +37,7 @@ contract AllowanceCrowdsale is Crowdsale {
      * @return Amount of tokens left in the allowance
      */
     function remainingTokens() public view returns (uint256) {
-        return Math.min(token().balanceOf(_tokenWallet), token().allowance(_tokenWallet, this));
+        return Math.min(token().balanceOf(_tokenWallet), token().allowance(_tokenWallet, address(this)));
     }
 
     /**

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/IERC20.sol";

--- a/contracts/crowdsale/emission/MintedCrowdsale.sol
+++ b/contracts/crowdsale/emission/MintedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/ERC20Mintable.sol";

--- a/contracts/crowdsale/emission/MintedCrowdsale.sol
+++ b/contracts/crowdsale/emission/MintedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/ERC20Mintable.sol";

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/PausableCrowdsale.sol
+++ b/contracts/crowdsale/validation/PausableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.1;
 
 import "../Crowdsale.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/crowdsale/validation/PausableCrowdsale.sol
+++ b/contracts/crowdsale/validation/PausableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../Crowdsale.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/WhitelistCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 import "../Crowdsale.sol";
 import "../../access/roles/WhitelistedRole.sol";
 

--- a/contracts/crowdsale/validation/WhitelistCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 import "../Crowdsale.sol";
 import "../../access/roles/WhitelistedRole.sol";
 

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Elliptic curve signature operations

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Elliptic curve signature operations
@@ -13,7 +13,7 @@ library ECDSA {
      * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
      * @param signature bytes signature, the signature is generated using web3.eth.sign()
      */
-    function recover(bytes32 hash, bytes signature) internal pure returns (address) {
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title MerkleProof

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title MerkleProof
@@ -13,7 +13,7 @@ library MerkleProof {
      * @param root Merkle root
      * @param leaf Leaf of Merkle tree
      */
-    function verify(bytes32[] proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
         bytes32 computedHash = leaf;
 
         for (uint256 i = 0; i < proof.length; i++) {

--- a/contracts/drafts/Counter.sol
+++ b/contracts/drafts/Counter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Counter

--- a/contracts/drafts/Counter.sol
+++ b/contracts/drafts/Counter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Counter

--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../token/ERC20/IERC20.sol";
 

--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../token/ERC20/IERC20.sol";
 
@@ -9,17 +9,17 @@ import "../../token/ERC20/IERC20.sol";
  * @dev TODO - update https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/IERC721.sol#L17 when 1046 is finalized
  */
 contract ERC20TokenMetadata is IERC20 {
-    function tokenURI() external view returns (string);
+    function tokenURI() external view returns (string memory);
 }
 
 contract ERC20WithMetadata is ERC20TokenMetadata {
     string private _tokenURI;
 
-    constructor (string tokenURI) public {
+    constructor (string memory tokenURI) public {
         _tokenURI = tokenURI;
     }
 
-    function tokenURI() external view returns (string) {
+    function tokenURI() external view returns (string memory) {
         return _tokenURI;
     }
 }

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/ERC20Mintable.sol";

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/ERC20Mintable.sol";
@@ -44,7 +44,7 @@ contract ERC20Migrator {
      * @param legacyToken address of the old token contract
      */
     constructor (IERC20 legacyToken) public {
-        require(legacyToken != address(0));
+        require(address(legacyToken) != address(0));
         _legacyToken = legacyToken;
     }
 
@@ -68,9 +68,9 @@ contract ERC20Migrator {
      * @param newToken the token that will be minted
      */
     function beginMigration(ERC20Mintable newToken) public {
-        require(_newToken == address(0));
-        require(newToken != address(0));
-        require(newToken.isMinter(this));
+        require(address(_newToken) == address(0));
+        require(address(newToken) != address(0));
+        require(newToken.isMinter(address(this)));
 
         _newToken = newToken;
     }
@@ -82,7 +82,7 @@ contract ERC20Migrator {
      * @param amount amount of tokens to be migrated
      */
     function migrate(address account, uint256 amount) public {
-        _legacyToken.safeTransferFrom(account, this, amount);
+        _legacyToken.safeTransferFrom(account, address(this), amount);
         _newToken.mint(account, amount);
     }
 
@@ -93,7 +93,7 @@ contract ERC20Migrator {
      */
     function migrateAll(address account) public {
         uint256 balance = _legacyToken.balanceOf(account);
-        uint256 allowance = _legacyToken.allowance(account, this);
+        uint256 allowance = _legacyToken.allowance(account, address(this));
         uint256 amount = Math.min(balance, allowance);
         migrate(account, amount);
     }

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/SignerRole.sol";
 import "../cryptography/ECDSA.sol";
@@ -48,7 +48,7 @@ contract SignatureBouncer is SignerRole {
     /**
      * @dev requires that a valid signature of a signer was provided
      */
-    modifier onlyValidSignature(bytes signature) {
+    modifier onlyValidSignature(bytes memory signature) {
         require(_isValidSignature(msg.sender, signature));
         _;
     }
@@ -56,7 +56,7 @@ contract SignatureBouncer is SignerRole {
     /**
      * @dev requires that a valid signature with a specifed method of a signer was provided
      */
-    modifier onlyValidSignatureAndMethod(bytes signature) {
+    modifier onlyValidSignatureAndMethod(bytes memory signature) {
         require(_isValidSignatureAndMethod(msg.sender, signature));
         _;
     }
@@ -64,7 +64,7 @@ contract SignatureBouncer is SignerRole {
     /**
      * @dev requires that a valid signature with a specifed method and params of a signer was provided
      */
-    modifier onlyValidSignatureAndData(bytes signature) {
+    modifier onlyValidSignatureAndData(bytes memory signature) {
         require(_isValidSignatureAndData(msg.sender, signature));
         _;
     }
@@ -73,7 +73,7 @@ contract SignatureBouncer is SignerRole {
      * @dev is the signature of `this + sender` from a signer?
      * @return bool
      */
-    function _isValidSignature(address account, bytes signature) internal view returns (bool) {
+    function _isValidSignature(address account, bytes memory signature) internal view returns (bool) {
         return _isValidDataHash(keccak256(abi.encodePacked(address(this), account)), signature);
     }
 
@@ -81,7 +81,7 @@ contract SignatureBouncer is SignerRole {
      * @dev is the signature of `this + sender + methodId` from a signer?
      * @return bool
      */
-    function _isValidSignatureAndMethod(address account, bytes signature) internal view returns (bool) {
+    function _isValidSignatureAndMethod(address account, bytes memory signature) internal view returns (bool) {
         bytes memory data = new bytes(_METHOD_ID_SIZE);
         for (uint i = 0; i < data.length; i++) {
             data[i] = msg.data[i];
@@ -94,7 +94,7 @@ contract SignatureBouncer is SignerRole {
         * @notice the signature parameter of the method being validated must be the "last" parameter
         * @return bool
         */
-    function _isValidSignatureAndData(address account, bytes signature) internal view returns (bool) {
+    function _isValidSignatureAndData(address account, bytes memory signature) internal view returns (bool) {
         require(msg.data.length > _SIGNATURE_SIZE);
 
         bytes memory data = new bytes(msg.data.length - _SIGNATURE_SIZE);
@@ -110,7 +110,7 @@ contract SignatureBouncer is SignerRole {
      * and then recover the signature and check it against the signer role
      * @return bool
      */
-    function _isValidDataHash(bytes32 hash, bytes signature) internal view returns (bool) {
+    function _isValidDataHash(bytes32 hash, bytes memory signature) internal view returns (bool) {
         address signer = hash.toEthSignedMessageHash().recover(signature);
 
         return signer != address(0) && isSigner(signer);

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/SignerRole.sol";
 import "../cryptography/ECDSA.sol";

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,6 +1,6 @@
 /* solium-disable security/no-block-members */
 
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/SafeERC20.sol";
 import "../ownership/Ownable.sol";

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,6 +1,6 @@
 /* solium-disable security/no-block-members */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/SafeERC20.sol";
 import "../ownership/Ownable.sol";
@@ -112,11 +112,11 @@ contract TokenVesting is Ownable {
 
         require(unreleased > 0);
 
-        _released[token] = _released[token].add(unreleased);
+        _released[address(token)] = _released[address(token)].add(unreleased);
 
         token.safeTransfer(_beneficiary, unreleased);
 
-        emit TokensReleased(token, unreleased);
+        emit TokensReleased(address(token), unreleased);
     }
 
     /**
@@ -126,18 +126,18 @@ contract TokenVesting is Ownable {
      */
     function revoke(IERC20 token) public onlyOwner {
         require(_revocable);
-        require(!_revoked[token]);
+        require(!_revoked[address(token)]);
 
         uint256 balance = token.balanceOf(address(this));
 
         uint256 unreleased = _releasableAmount(token);
         uint256 refund = balance.sub(unreleased);
 
-        _revoked[token] = true;
+        _revoked[address(token)] = true;
 
         token.safeTransfer(owner(), refund);
 
-        emit TokenVestingRevoked(token);
+        emit TokenVestingRevoked(address(token));
     }
 
     /**
@@ -145,7 +145,7 @@ contract TokenVesting is Ownable {
      * @param token ERC20 token which is being vested
      */
     function _releasableAmount(IERC20 token) private view returns (uint256) {
-        return _vestedAmount(token).sub(_released[token]);
+        return _vestedAmount(token).sub(_released[address(token)]);
     }
 
     /**
@@ -154,11 +154,11 @@ contract TokenVesting is Ownable {
      */
     function _vestedAmount(IERC20 token) private view returns (uint256) {
         uint256 currentBalance = token.balanceOf(address(this));
-        uint256 totalBalance = currentBalance.add(_released[token]);
+        uint256 totalBalance = currentBalance.add(_released[address(token)]);
 
         if (block.timestamp < _cliff) {
             return 0;
-        } else if (block.timestamp >= _start.add(_duration) || _revoked[token]) {
+        } else if (block.timestamp >= _start.add(_duration) || _revoked[address(token)]) {
             return totalBalance;
         } else {
             return totalBalance.mul(block.timestamp.sub(_start)).div(_duration);

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../crowdsale/validation/CappedCrowdsale.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../crowdsale/validation/CappedCrowdsale.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";
@@ -38,7 +38,7 @@ contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale, MintedCrowdsal
         uint256 openingTime,
         uint256 closingTime,
         uint256 rate,
-        address wallet,
+        address payable wallet,
         uint256 cap,
         ERC20Mintable token,
         uint256 goal

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";
@@ -10,12 +10,13 @@ import "../token/ERC20/ERC20Detailed.sol";
  * `ERC20` functions.
  */
 contract SimpleToken is ERC20, ERC20Detailed {
-    uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(decimals()));
+    uint8 public constant DECIMALS = 18;
+    uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(DECIMALS));
 
     /**
      * @dev Constructor that gives msg.sender all of existing tokens.
      */
-    constructor () public ERC20Detailed("SimpleToken", "SIM", 18) {
+    constructor () public ERC20Detailed("SimpleToken", "SIM", DECIMALS) {
         _mint(msg.sender, INITIAL_SUPPLY);
     }
 }

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC165.sol";
 

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC165.sol";
 

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title ERC165Checker
@@ -49,7 +49,7 @@ library ERC165Checker {
      * interfaceIds list, false otherwise
      * @dev Interface identification is specified in ERC-165.
      */
-    function _supportsAllInterfaces(address account, bytes4[] interfaceIds) internal view returns (bool) {
+    function _supportsAllInterfaces(address account, bytes4[] memory interfaceIds) internal view returns (bool) {
         // query support of ERC165 itself
         if (!_supportsERC165(account)) {
             return false;

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title ERC165Checker

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title IERC165

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title IERC165

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Math

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Math

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title SafeMath

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title SafeMath

--- a/contracts/mocks/Acknowledger.sol
+++ b/contracts/mocks/Acknowledger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract Acknowledger {
     event AcknowledgeFoo(uint256 a);

--- a/contracts/mocks/Acknowledger.sol
+++ b/contracts/mocks/Acknowledger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 contract Acknowledger {
     event AcknowledgeFoo(uint256 a);

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../utils/Address.sol";
 

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../utils/Address.sol";
 

--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/emission/AllowanceCrowdsale.sol";
 
 contract AllowanceCrowdsaleImpl is AllowanceCrowdsale {
-    constructor (uint256 rate, address wallet, IERC20 token, address tokenWallet)
+    constructor (uint256 rate, address payable wallet, IERC20 token, address tokenWallet)
         public
         Crowdsale(rate, wallet, token)
         AllowanceCrowdsale(tokenWallet)

--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/emission/AllowanceCrowdsale.sol";

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../utils/Arrays.sol";
 
@@ -7,7 +7,7 @@ contract ArraysImpl {
 
     uint256[] private array;
 
-    constructor (uint256[] _array) public {
+    constructor (uint256[] memory _array) public {
         array = _array;
     }
 

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../utils/Arrays.sol";
 

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/CappedCrowdsale.sol";

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/CappedCrowdsale.sol";
 
 contract CappedCrowdsaleImpl is CappedCrowdsale {
-    constructor (uint256 rate, address wallet, IERC20 token, uint256 cap)
+    constructor (uint256 rate, address payable wallet, IERC20 token, uint256 cap)
         public
         Crowdsale(rate, wallet, token)
         CappedCrowdsale(cap)

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/CapperRole.sol";
 

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/CapperRole.sol";
 

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../payment/escrow/ConditionalEscrow.sol";
 

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../payment/escrow/ConditionalEscrow.sol";
 

--- a/contracts/mocks/CounterImpl.sol
+++ b/contracts/mocks/CounterImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../drafts/Counter.sol";
 

--- a/contracts/mocks/CounterImpl.sol
+++ b/contracts/mocks/CounterImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../drafts/Counter.sol";
 
@@ -10,7 +10,7 @@ contract CounterImpl {
     // use whatever key you want to track your counters
     mapping(string => Counter.Counter) private _counters;
 
-    function doThing(string key) public returns (uint256) {
+    function doThing(string memory key) public returns (uint256) {
         theId = _counters[key].next();
         return theId;
     }

--- a/contracts/mocks/CrowdsaleMock.sol
+++ b/contracts/mocks/CrowdsaleMock.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../crowdsale/Crowdsale.sol";
 
 contract CrowdsaleMock is Crowdsale {
-    constructor (uint256 rate, address wallet, IERC20 token) public Crowdsale(rate, wallet, token) {}
+    constructor (uint256 rate, address payable wallet, IERC20 token) public Crowdsale(rate, wallet, token) {}
 }

--- a/contracts/mocks/CrowdsaleMock.sol
+++ b/contracts/mocks/CrowdsaleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../crowdsale/Crowdsale.sol";
 

--- a/contracts/mocks/DetailedERC20Mock.sol
+++ b/contracts/mocks/DetailedERC20Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/mocks/DetailedERC20Mock.sol
+++ b/contracts/mocks/DetailedERC20Mock.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";
 
 contract ERC20DetailedMock is ERC20, ERC20Detailed {
-    constructor (string name, string symbol, uint8 decimals) ERC20Detailed(name, symbol, decimals) public {}
+    constructor (string memory name, string memory symbol, uint8 decimals) ERC20Detailed(name, symbol, decimals) public {}
 }

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../cryptography/ECDSA.sol";
 
 contract ECDSAMock {
     using ECDSA for bytes32;
 
-    function recover(bytes32 hash, bytes signature) public pure returns (address) {
+    function recover(bytes32 hash, bytes memory signature) public pure returns (address) {
         return hash.recover(signature);
     }
 

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../cryptography/ECDSA.sol";
 

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../introspection/IERC165.sol";
 
@@ -47,7 +47,7 @@ contract SupportsInterfaceWithLookupMock is IERC165 {
 }
 
 contract ERC165InterfacesSupported is SupportsInterfaceWithLookupMock {
-    constructor (bytes4[] interfaceIds) public {
+    constructor (bytes4[] memory interfaceIds) public {
         for (uint256 i = 0; i < interfaceIds.length; i++) {
             _registerInterface(interfaceIds[i]);
         }

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,3 +1,3 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 contract ERC165NotSupported {}

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,3 +1,3 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract ERC165NotSupported {}

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../introspection/ERC165Checker.sol";
 
@@ -13,7 +13,7 @@ contract ERC165CheckerMock {
         return account._supportsInterface(interfaceId);
     }
 
-    function supportsAllInterfaces(address account, bytes4[] interfaceIds) public view returns (bool) {
+    function supportsAllInterfaces(address account, bytes4[] memory interfaceIds) public view returns (bool) {
         return account._supportsAllInterfaces(interfaceIds);
     }
 }

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../introspection/ERC165Checker.sol";
 

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../introspection/ERC165.sol";
 

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../introspection/ERC165.sol";
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20Burnable.sol";
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20Burnable.sol";
 

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "./MinterRoleMock.sol";

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "./MinterRoleMock.sol";

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";
 
 contract ERC20WithMetadataMock is ERC20, ERC20WithMetadata {
-    constructor (string tokenURI) public ERC20WithMetadata(tokenURI) {}
+    constructor (string memory tokenURI) public ERC20WithMetadata(tokenURI) {}
 }

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";
@@ -11,7 +11,7 @@ import "../token/ERC721/ERC721Burnable.sol";
  * checking token existence, removal of a token from an address
  */
 contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, ERC721Burnable {
-    constructor (string name, string symbol) public ERC721Mintable() ERC721Full(name, symbol) {}
+    constructor (string memory name, string memory symbol) public ERC721Mintable() ERC721Full(name, symbol) {}
 
     function exists(uint256 tokenId) public view returns (bool) {
         return _exists(tokenId);
@@ -21,7 +21,7 @@ contract ERC721FullMock is ERC721Full, ERC721Mintable, ERC721MetadataMintable, E
         return _tokensOfOwner(owner);
     }
 
-    function setTokenURI(uint256 tokenId, string uri) public {
+    function setTokenURI(uint256 tokenId, string memory uri) public {
         _setTokenURI(tokenId, uri);
     }
 }

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC721/ERC721Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC721/ERC721Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC721/IERC721Receiver.sol";
 
@@ -13,7 +13,7 @@ contract ERC721ReceiverMock is IERC721Receiver {
         _reverts = reverts;
     }
 
-    function onERC721Received(address operator, address from, uint256 tokenId, bytes data) public returns (bytes4) {
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes memory data) public returns (bytes4) {
         require(!_reverts);
         emit Received(operator, from, tokenId, data, gasleft());
         return _retval;

--- a/contracts/mocks/EventEmitter.sol
+++ b/contracts/mocks/EventEmitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 contract EventEmitter {
     event Argumentless();

--- a/contracts/mocks/EventEmitter.sol
+++ b/contracts/mocks/EventEmitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract EventEmitter {
     event Argumentless();
@@ -11,7 +11,7 @@ contract EventEmitter {
     event String(string value);
     event LongUintBooleanString(uint256 uintValue, bool booleanValue, string stringValue);
 
-    constructor (uint8 uintValue, bool booleanValue, string stringValue) public {
+    constructor (uint8 uintValue, bool booleanValue, string memory stringValue) public {
         emit ShortUint(uintValue);
         emit Boolean(booleanValue);
         emit String(stringValue);
@@ -45,11 +45,11 @@ contract EventEmitter {
         emit Boolean(value);
     }
 
-    function emitString(string value) public {
+    function emitString(string memory value) public {
         emit String(value);
     }
 
-    function emitLongUintBooleanString(uint256 uintValue, bool booleanValue, string stringValue) public {
+    function emitLongUintBooleanString(uint256 uintValue, bool booleanValue, string memory stringValue) public {
         emit LongUintBooleanString(uintValue, booleanValue, stringValue);
     }
 
@@ -58,7 +58,7 @@ contract EventEmitter {
         emit Boolean(boolValue);
     }
 
-    function emitStringAndEmitIndirectly(string value, IndirectEventEmitter emitter) public {
+    function emitStringAndEmitIndirectly(string memory value, IndirectEventEmitter emitter) public {
         emit String(value);
         emitter.emitStringIndirectly(value);
     }
@@ -67,7 +67,7 @@ contract EventEmitter {
 contract IndirectEventEmitter {
     event IndirectString(string value);
 
-    function emitStringIndirectly(string value) public {
+    function emitStringIndirectly(string memory value) public {
         emit IndirectString(value);
     }
 }

--- a/contracts/mocks/Failer.sol
+++ b/contracts/mocks/Failer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 contract Failer {
     uint256[] private array;

--- a/contracts/mocks/Failer.sol
+++ b/contracts/mocks/Failer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract Failer {
     uint256[] private array;

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/FinalizableCrowdsale.sol";
 
 contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
 
-    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address wallet, IERC20 token)
+    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address payable wallet, IERC20 token)
         public
         Crowdsale(rate, wallet, token)
         TimedCrowdsale(openingTime, closingTime)

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/FinalizableCrowdsale.sol";

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../crowdsale/price/IncreasingPriceCrowdsale.sol";
 import "../math/SafeMath.sol";
@@ -7,7 +7,7 @@ contract IncreasingPriceCrowdsaleImpl is IncreasingPriceCrowdsale {
     constructor (
         uint256 openingTime,
         uint256 closingTime,
-        address wallet,
+        address payable wallet,
         IERC20 token,
         uint256 initialRate,
         uint256 finalRate

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../crowdsale/price/IncreasingPriceCrowdsale.sol";
 import "../math/SafeMath.sol";

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/IndividuallyCappedCrowdsale.sol";

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/IndividuallyCappedCrowdsale.sol";
 import "./CapperRoleMock.sol";
 
 contract IndividuallyCappedCrowdsaleImpl is IndividuallyCappedCrowdsale, CapperRoleMock {
-    constructor (uint256 rate, address wallet, IERC20 token) public Crowdsale(rate, wallet, token)
+    constructor (uint256 rate, address payable wallet, IERC20 token) public Crowdsale(rate, wallet, token)
     {}
 }

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../math/Math.sol";
 

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../math/Math.sol";
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";
 
 contract MerkleProofWrapper {
-    function verify(bytes32[] proof, bytes32 root, bytes32 leaf) public pure returns (bool) {
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) public pure returns (bool) {
         return MerkleProof.verify(proof, root, leaf);
     }
 }

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/emission/MintedCrowdsale.sol";

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/emission/MintedCrowdsale.sol";
 
 contract MintedCrowdsaleImpl is MintedCrowdsale {
-    constructor (uint256 rate, address wallet, ERC20Mintable token) public Crowdsale(rate, wallet, token) {}
+    constructor (uint256 rate, address payable wallet, ERC20Mintable token) public Crowdsale(rate, wallet, token) {}
 }

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/MinterRole.sol";
 

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/MinterRole.sol";
 

--- a/contracts/mocks/OwnableInterfaceId.sol
+++ b/contracts/mocks/OwnableInterfaceId.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/OwnableInterfaceId.sol
+++ b/contracts/mocks/OwnableInterfaceId.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/PausableCrowdsaleImpl.sol
+++ b/contracts/mocks/PausableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/ERC20.sol";
 import "../crowdsale/validation/PausableCrowdsale.sol";

--- a/contracts/mocks/PausableCrowdsaleImpl.sol
+++ b/contracts/mocks/PausableCrowdsaleImpl.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/ERC20.sol";
 import "../crowdsale/validation/PausableCrowdsale.sol";
 
 contract PausableCrowdsaleImpl is PausableCrowdsale {
-    constructor (uint256 _rate, address _wallet, ERC20 _token) public Crowdsale(_rate, _wallet, _token) {
+    constructor (uint256 _rate, address payable _wallet, ERC20 _token) public Crowdsale(_rate, _wallet, _token) {
     }
 }

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../lifecycle/Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../lifecycle/Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/PostDeliveryCrowdsale.sol";
 
 contract PostDeliveryCrowdsaleImpl is PostDeliveryCrowdsale {
-    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address wallet, IERC20 token)
+    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address payable wallet, IERC20 token)
         public
         TimedCrowdsale(openingTime, closingTime)
         Crowdsale(rate, wallet, token)

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/PostDeliveryCrowdsale.sol";

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../payment/PullPayment.sol";
 

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../payment/PullPayment.sol";
 

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,10 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract ReentrancyAttack {
 
     function callSender(bytes4 data) public {
         // solium-disable-next-line security/no-low-level-calls
-        require(msg.sender.call(abi.encodeWithSelector(data)));
+        (bool success,) = msg.sender.call(abi.encodeWithSelector(data));
+        require(success);
     }
 
 }

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 contract ReentrancyAttack {
 

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";
@@ -25,8 +25,8 @@ contract ReentrancyMock is ReentrancyGuard {
         if (n > 0) {
             count();
             // solium-disable-next-line security/no-low-level-calls
-            bool result = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
-            require(result == true);
+            (bool success,) = address(this).call(abi.encodeWithSignature("countThisRecursive(uint256)", n - 1));
+            require(success);
         }
     }
 

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";
@@ -8,7 +8,7 @@ contract RefundableCrowdsaleImpl is RefundableCrowdsale {
         uint256 openingTime,
         uint256 closingTime,
         uint256 rate,
-        address wallet,
+        address payable wallet,
         IERC20 token,
         uint256 goal
     )

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol";
@@ -8,7 +8,7 @@ contract RefundablePostDeliveryCrowdsaleImpl is RefundablePostDeliveryCrowdsale 
         uint256 openingTime,
         uint256 closingTime,
         uint256 rate,
-        address wallet,
+        address payable wallet,
         IERC20 token,
         uint256 goal
     )

--- a/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol";

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/Roles.sol";
 

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/Roles.sol";
 

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/SafeERC20.sol";

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/SafeERC20.sol";
@@ -54,8 +54,8 @@ contract SafeERC20Helper {
     IERC20 private _succeeding;
 
     constructor () public {
-        _failing = IERC20(new ERC20FailingMock());
-        _succeeding = IERC20(new ERC20SucceedingMock());
+        _failing = IERC20(address(new ERC20FailingMock()));
+        _succeeding = IERC20(address(new ERC20SucceedingMock()));
     }
 
     // Using _failing
@@ -103,7 +103,7 @@ contract SafeERC20Helper {
     }
 
     function setAllowance(uint256 allowance_) public {
-        ERC20SucceedingMock(_succeeding).setAllowance(allowance_);
+        ERC20SucceedingMock(address(_succeeding)).setAllowance(allowance_);
     }
 
     function allowance() public view returns (uint256) {

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 
 import "../math/SafeMath.sol";

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 
 import "../math/SafeMath.sol";

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../ownership/Secondary.sol";
 

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../ownership/Secondary.sol";
 

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -1,28 +1,28 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";
 
 contract SignatureBouncerMock is SignatureBouncer, SignerRoleMock {
-    function checkValidSignature(address account, bytes signature) public view returns (bool) {
+    function checkValidSignature(address account, bytes memory signature) public view returns (bool) {
         return _isValidSignature(account, signature);
     }
 
-    function onlyWithValidSignature(bytes signature) public onlyValidSignature(signature) view {}
+    function onlyWithValidSignature(bytes memory signature) public onlyValidSignature(signature) view {}
 
-    function checkValidSignatureAndMethod(address account, bytes signature) public view returns (bool) {
+    function checkValidSignatureAndMethod(address account, bytes memory signature) public view returns (bool) {
         return _isValidSignatureAndMethod(account, signature);
     }
 
-    function onlyWithValidSignatureAndMethod(bytes signature) public onlyValidSignatureAndMethod(signature) view {}
+    function onlyWithValidSignatureAndMethod(bytes memory signature) public onlyValidSignatureAndMethod(signature) view {}
 
-    function checkValidSignatureAndData(address account, bytes, uint, bytes signature) public view returns (bool) {
+    function checkValidSignatureAndData(address account, bytes memory, uint, bytes memory signature) public view returns (bool) {
         return _isValidSignatureAndData(account, signature);
     }
 
-    function onlyWithValidSignatureAndData(uint, bytes signature) public onlyValidSignatureAndData(signature) view {}
+    function onlyWithValidSignatureAndData(uint, bytes memory signature) public onlyValidSignatureAndData(signature) view {}
 
-    function theWrongMethod(bytes) public pure {}
+    function theWrongMethod(bytes memory) public pure {}
 
     function tooShortMsgData() public onlyValidSignatureAndData("") view {}
 }

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/SignerRole.sol";
 

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/SignerRole.sol";
 

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/TimedCrowdsale.sol";
 
 contract TimedCrowdsaleImpl is TimedCrowdsale {
-    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address wallet, IERC20 token)
+    constructor (uint256 openingTime, uint256 closingTime, uint256 rate, address payable wallet, IERC20 token)
         public
         Crowdsale(rate, wallet, token)
         TimedCrowdsale(openingTime, closingTime)

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/TimedCrowdsale.sol";

--- a/contracts/mocks/WhitelistCrowdsaleImpl.sol
+++ b/contracts/mocks/WhitelistCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/WhitelistCrowdsale.sol";
@@ -6,5 +6,5 @@ import "../crowdsale/Crowdsale.sol";
 
 
 contract WhitelistCrowdsaleImpl is Crowdsale, WhitelistCrowdsale {
-    constructor (uint256 _rate, address _wallet, IERC20 _token) Crowdsale(_rate, _wallet, _token) public {}
+    constructor (uint256 _rate, address payable _wallet, IERC20 _token) Crowdsale(_rate, _wallet, _token) public {}
 }

--- a/contracts/mocks/WhitelistCrowdsaleImpl.sol
+++ b/contracts/mocks/WhitelistCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/WhitelistCrowdsale.sol";

--- a/contracts/mocks/WhitelistedRoleMock.sol
+++ b/contracts/mocks/WhitelistedRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/WhitelistedRole.sol";
 

--- a/contracts/mocks/WhitelistedRoleMock.sol
+++ b/contracts/mocks/WhitelistedRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/WhitelistedRole.sol";
 

--- a/contracts/mocks/WhitelisterRoleMock.sol
+++ b/contracts/mocks/WhitelisterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../access/roles/WhitelisterRole.sol";
 

--- a/contracts/mocks/WhitelisterRoleMock.sol
+++ b/contracts/mocks/WhitelisterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../access/roles/WhitelisterRole.sol";
 

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Ownable

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Ownable

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Secondary

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Secondary

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../math/SafeMath.sol";
 
@@ -24,7 +24,7 @@ contract PaymentSplitter {
     /**
      * @dev Constructor
      */
-    constructor (address[] payees, uint256[] shares) public payable {
+    constructor (address[] memory payees, uint256[] memory shares) public payable {
         require(payees.length == shares.length);
         require(payees.length > 0);
 
@@ -79,7 +79,7 @@ contract PaymentSplitter {
      * @dev Release one of the payee's proportional payment.
      * @param account Whose payments will be released.
      */
-    function release(address account) public {
+    function release(address payable account) public {
         require(_shares[account] > 0);
 
         uint256 totalReceived = address(this).balance.add(_totalReleased);

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./escrow/Escrow.sol";
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./escrow/Escrow.sol";
 
@@ -18,7 +18,7 @@ contract PullPayment {
     * @dev Withdraw accumulated balance.
     * @param payee Whose balance will be withdrawn.
     */
-    function withdrawPayments(address payee) public {
+    function withdrawPayments(address payable payee) public {
         _escrow.withdraw(payee);
     }
 

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./Escrow.sol";
 
@@ -15,7 +15,7 @@ contract ConditionalEscrow is Escrow {
     */
     function withdrawalAllowed(address payee) public view returns (bool);
 
-    function withdraw(address payee) public {
+    function withdraw(address payable payee) public {
         require(withdrawalAllowed(payee));
         super.withdraw(payee);
     }

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./Escrow.sol";
 

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../math/SafeMath.sol";
 import "../../ownership/Secondary.sol";
@@ -42,7 +42,7 @@ contract Escrow is Secondary {
     * @dev Withdraw accumulated balance for a payee.
     * @param payee The address whose funds will be withdrawn and transferred to.
     */
-    function withdraw(address payee) public onlyPrimary {
+    function withdraw(address payable payee) public onlyPrimary {
         uint256 payment = _deposits[payee];
 
         _deposits[payee] = 0;

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../math/SafeMath.sol";
 import "../../ownership/Secondary.sol";

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ConditionalEscrow.sol";
 
@@ -20,13 +20,13 @@ contract RefundEscrow is ConditionalEscrow {
     event RefundsEnabled();
 
     State private _state;
-    address private _beneficiary;
+    address payable private _beneficiary;
 
     /**
      * @dev Constructor.
      * @param beneficiary The beneficiary of the deposits.
      */
-    constructor (address beneficiary) public {
+    constructor (address payable beneficiary) public {
         require(beneficiary != address(0));
         _beneficiary = beneficiary;
         _state = State.Active;

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ConditionalEscrow.sol";
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC20Mintable.sol";
 

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC20Mintable.sol";
 

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC20.sol";
 
@@ -13,7 +13,7 @@ contract ERC20Detailed is IERC20 {
     string private _symbol;
     uint8 private _decimals;
 
-    constructor (string name, string symbol, uint8 decimals) public {
+    constructor (string memory name, string memory symbol, uint8 decimals) public {
         _name = name;
         _symbol = symbol;
         _decimals = decimals;
@@ -22,14 +22,14 @@ contract ERC20Detailed is IERC20 {
     /**
      * @return the name of the token.
      */
-    function name() public view returns (string) {
+    function name() public view returns (string memory) {
         return _name;
     }
 
     /**
      * @return the symbol of the token.
      */
-    function symbol() public view returns (string) {
+    function symbol() public view returns (string memory) {
         return _symbol;
     }
 

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC20.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC20.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC20.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC20.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title ERC20 interface

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title ERC20 interface

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./SafeERC20.sol";
 

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./SafeERC20.sol";
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721.sol";
 import "./IERC721Receiver.sol";

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721.sol";
 import "./IERC721Receiver.sol";
@@ -163,7 +163,7 @@ contract ERC721 is ERC165, IERC721 {
      * @param tokenId uint256 ID of the token to be transferred
      * @param _data bytes data to send along with a safe transfer check
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes _data) public {
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory _data) public {
         transferFrom(from, to, tokenId);
         // solium-disable-next-line arg-overflow
         require(_checkOnERC721Received(from, to, tokenId, _data));
@@ -227,7 +227,7 @@ contract ERC721 is ERC165, IERC721 {
 
         emit Transfer(owner, address(0), tokenId);
     }
-    
+
     /**
      * @dev Internal function to burn a specific token
      * Reverts if the token does not exist
@@ -267,7 +267,7 @@ contract ERC721 is ERC165, IERC721 {
      * @param _data bytes optional data to send along with the call
      * @return whether the call correctly returned the expected magic value
      */
-    function _checkOnERC721Received(address from, address to, uint256 tokenId, bytes _data) internal returns (bool) {
+    function _checkOnERC721Received(address from, address to, uint256 tokenId, bytes memory _data) internal returns (bool) {
         if (!to.isContract()) {
             return true;
         }

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721.sol";
 

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721.sol";
 

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721Enumerable.sol";
 import "./ERC721.sol";

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721Enumerable.sol";
 import "./ERC721.sol";

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721.sol";
 import "./ERC721Enumerable.sol";

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721.sol";
 import "./ERC721Enumerable.sol";
@@ -11,5 +11,5 @@ import "./ERC721Metadata.sol";
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Full is ERC721, ERC721Enumerable, ERC721Metadata {
-    constructor (string name, string symbol) ERC721Metadata(name, symbol) public {}
+    constructor (string memory name, string memory symbol) ERC721Metadata(name, symbol) public {}
 }

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721Receiver.sol";
 

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721Receiver.sol";
 
 contract ERC721Holder is IERC721Receiver {
-    function onERC721Received(address, address, uint256, bytes) public returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes memory) public returns (bytes4) {
         return this.onERC721Received.selector;
     }
 }

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721.sol";
 import "./IERC721Metadata.sol";
@@ -25,7 +25,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     /**
      * @dev Constructor function
      */
-    constructor (string name, string symbol) public {
+    constructor (string memory name, string memory symbol) public {
         _name = name;
         _symbol = symbol;
 
@@ -37,7 +37,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      * @dev Gets the token name
      * @return string representing the token name
      */
-    function name() external view returns (string) {
+    function name() external view returns (string memory) {
         return _name;
     }
 
@@ -45,7 +45,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      * @dev Gets the token symbol
      * @return string representing the token symbol
      */
-    function symbol() external view returns (string) {
+    function symbol() external view returns (string memory) {
         return _symbol;
     }
 
@@ -54,7 +54,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      * Throws if the token ID does not exist. May return an empty string.
      * @param tokenId uint256 ID of the token to query
      */
-    function tokenURI(uint256 tokenId) external view returns (string) {
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
         require(_exists(tokenId));
         return _tokenURIs[tokenId];
     }
@@ -65,7 +65,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      * @param tokenId uint256 ID of the token to set its URI
      * @param uri string URI to assign
      */
-    function _setTokenURI(uint256 tokenId, string uri) internal {
+    function _setTokenURI(uint256 tokenId, string memory uri) internal {
         require(_exists(tokenId));
         _tokenURIs[tokenId] = uri;
     }

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721.sol";
 import "./IERC721Metadata.sol";

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";
@@ -16,7 +16,7 @@ contract ERC721MetadataMintable is ERC721, ERC721Metadata, MinterRole {
      * @param tokenURI The token URI of the minted token.
      * @return A boolean that indicates if the operation was successful.
      */
-    function mintWithTokenURI(address to, uint256 tokenId, string tokenURI) public onlyMinter returns (bool) {
+    function mintWithTokenURI(address to, uint256 tokenId, string memory tokenURI) public onlyMinter returns (bool) {
         _mint(to, tokenId);
         _setTokenURI(tokenId, tokenURI);
         return true;

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC721.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./ERC721.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../../introspection/IERC165.sol";
 
@@ -23,5 +23,5 @@ contract IERC721 is IERC165 {
     function transferFrom(address from, address to, uint256 tokenId) public;
     function safeTransferFrom(address from, address to, uint256 tokenId) public;
 
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) public;
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public;
 }

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Full.sol
+++ b/contracts/token/ERC721/IERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721.sol";
 import "./IERC721Enumerable.sol";

--- a/contracts/token/ERC721/IERC721Full.sol
+++ b/contracts/token/ERC721/IERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721.sol";
 import "./IERC721Enumerable.sol";

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./IERC721.sol";
 
@@ -7,7 +7,7 @@ import "./IERC721.sol";
  * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract IERC721Metadata is IERC721 {
-    function name() external view returns (string);
-    function symbol() external view returns (string);
-    function tokenURI(uint256 tokenId) external view returns (string);
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function tokenURI(uint256 tokenId) external view returns (string memory);
 }

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title ERC721 token receiver interface

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title ERC721 token receiver interface
@@ -20,5 +20,5 @@ contract IERC721Receiver {
      * @param data Additional data with no specified format
      * @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
      */
-    function onERC721Received(address operator, address from, uint256 tokenId, bytes data) public returns (bytes4);
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes memory data) public returns (bytes4);
 }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * Utility library of inline functions on addresses

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * Utility library of inline functions on addresses

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "../math/Math.sol";
 

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 import "../math/Math.sol";
 

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 /**
  * @title Helps contracts guard against reentrancy attacks.

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.5.0;
 
 /**
  * @title Helps contracts guard against reentrancy attacks.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "npm run lint:js && npm run lint:sol",
     "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",
     "console": "truffle console",
+    "compile": "scripts/compile.sh",
     "coverage": "scripts/coverage.sh",
     "version": "scripts/version.js",
     "build": "scripts/build.sh",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test"
   ],
   "scripts": {
-    "test": "scripts/test.sh",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint:sol": "solium -d .",
@@ -16,10 +15,11 @@
     "lint": "npm run lint:js && npm run lint:sol",
     "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",
     "console": "truffle console",
+    "build": "scripts/build.sh",
     "compile": "scripts/compile.sh",
     "coverage": "scripts/coverage.sh",
     "version": "scripts/version.js",
-    "build": "scripts/build.sh",
+    "test": "npm run compile && scripts/test.sh",
     "prepack": "npm run build"
   },
   "repository": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ do
 done < contracts/.npmignore
 
 # Compile everything else.
-node_modules/.bin/truffle compile
+npm run compile
 
 # Return ignored files to their place.
 mv "$tmp_dir/"* contracts/

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Configure to exit script as soon as a command fails.
+set -o errexit
+
+SOLC_05_DIR=solc-0.5
+
+# Delete any previous build artifacts
+rm -rf build/
+
+# Create a subproject where 0.5.x compilation will take place
+mkdir -p $SOLC_05_DIR
+
+cd $SOLC_05_DIR
+npm init --yes
+npm install --save-dev truffle@5.0.0
+
+rm -rf contracts
+ln -s ../contracts contracts
+
+# Delete any previous build artifacts
+rm -rf build/
+
+# Compile
+echo "
+module.exports = {
+  compilers: {
+    solc: {
+      version: \"0.4.24\",
+    },
+  },
+};
+" > truffle-config.js
+
+npx truffle compile
+
+# Modify the paths in the artifacts to make it look as if they were built in the root
+find build -name "*.json" -exec sed -i "s/\/$SOLC_05_DIR//g" {} +
+
+# Copy them back into the root
+cd ..
+cp -r $SOLC_05_DIR/build build

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,7 +26,7 @@ echo "
 module.exports = {
   compilers: {
     solc: {
-      version: \"0.5.1\",
+      version: \"0.5.0\",
     },
   },
 };

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,7 +26,7 @@ echo "
 module.exports = {
   compilers: {
     solc: {
-      version: \"0.4.24\",
+      version: \"0.5.1\",
     },
   },
 };


### PR DESCRIPTION
This updates all contracts, in their 2.1.0-rc.1 state, to compile using Solidity v0.5.0.

The test suite has not been modified and still uses truffle 4 - compilation is made in a temporary sub-project that uses truffle 5, and artifacts are then retrieved into the root project (see `scripts/compile.sh`). The coverage build seems to both compile and test on its own, so it probably won't work.

Closes https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1510 (thanks for the help!)
Closes https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1498
