### PR TITLE
Remove linux-specific mktemp usage

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,8 @@ set -o errexit
 rm -rf build
 
 # Create a temporary directory to place ignored files (e.g. examples).
-tmp_dir="$(mktemp -dp.)"
+tmp_dir="ignored_contracts"
+mkdir "$tmp_dir"
 
 # Move the ignored files to the temporary directory.
 while IFS="" read -r ignored


### PR DESCRIPTION
The `-d` option of `mktemp` does not seem to be cross-platform. I replace it with a fixed directory name. The script will fail if the directory already exists.