### PR TITLE
Update ReentrancyGuard for EIP 1283

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -7,14 +7,7 @@ pragma solidity ^0.4.24;
  * mark it `external`.
  */
 contract ReentrancyGuard {
-    /// @dev counter to allow mutex lock with only one SSTORE operation
     uint256 private _guardCounter;
-
-    constructor () internal {
-        // The counter starts at one to prevent changing it from zero to a non-zero
-        // value, which is a more expensive operation.
-        _guardCounter = 1;
-    }
 
     /**
      * @dev Prevents a contract from calling itself, directly or indirectly.
@@ -24,9 +17,9 @@ contract ReentrancyGuard {
      * `private` function that does the actual work.
      */
     modifier nonReentrant() {
-        _guardCounter += 1;
-        uint256 localCounter = _guardCounter;
+        require(_guardCounter == 0);
+        _guardCounter = 1;
         _;
-        require(localCounter == _guardCounter);
+        _guardCounter = 0;
     }
 }


### PR DESCRIPTION
Per https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1283.md, the old way of doing reentrancy will soon be more efficient (~400 gas). Uses uint256 instead of bool since the native word size of the EVM is 256 bits and this will probably be the most gas-optimized solution regardless of how many rounds of optimization are used.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
