### PR TITLE
Update solidity pragma to ^0.5.0

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 /**
  * @title Roles


### PR DESCRIPTION
Can the pragma on this be upgraded to solidity ^0.5.0 to be usable with Truffle 5.0.1? It seems to compile ok in remix using ^0.5.0

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
