### PR TITLE
Fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2.2.0 (unreleased)
 
+### Improvements:
+ * Silenced most Solidity warnings.
+
+### Bugfixes:
+
+### Breaking changes:
+
 ## 2.1.1 (2019-04-01)
  * Version bump to avoid conflict in the npm registry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 2.2.0 (unreleased)
 
 ### Improvements:
- * Silenced most Solidity warnings.
+ * Upgraded the minimum compiler version to v0.5.2: this removes many Solidity warnings that were false positives.
+ * Fixed variable shadowing issues.
 
 ### Bugfixes:
 

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Roles

--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelistAdminRole.sol
+++ b/contracts/access/roles/WhitelistAdminRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelistedRole.sol
+++ b/contracts/access/roles/WhitelistedRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Roles.sol";
 import "./WhitelistAdminRole.sol";

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "../validation/TimedCrowdsale.sol";

--- a/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "./FinalizableCrowdsale.sol";

--- a/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./RefundableCrowdsale.sol";
 import "./PostDeliveryCrowdsale.sol";

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/IERC20.sol";

--- a/contracts/crowdsale/emission/MintedCrowdsale.sol
+++ b/contracts/crowdsale/emission/MintedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/ERC20Mintable.sol";

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/PausableCrowdsale.sol
+++ b/contracts/crowdsale/validation/PausableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../Crowdsale.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/WhitelistCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 import "../Crowdsale.sol";
 import "../../access/roles/WhitelistedRole.sol";
 

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Elliptic curve signature operations

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title MerkleProof

--- a/contracts/drafts/Counter.sol
+++ b/contracts/drafts/Counter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Counter

--- a/contracts/drafts/Counters.sol
+++ b/contracts/drafts/Counters.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.2;
 
 /**
- * @title Counter
+ * @title Counters
  * @author Matt Condon (@shrugs)
  * @dev Provides an incrementing uint256 id acquired by the `Counter#next` getter.
  * Use this for issuing ERC721 ids or keeping track of request ids, anything you want, really.
  *
- * Include with `using Counter for Counter.Counter;`
+ * Include with `using Counters` for Counters.Counter;`
  * @notice Does not allow an Id of 0, which is popularly used to signify a null state in solidity.
  * Does not protect from overflows, but if you have 2^256 ids, you have other problems.
  * (But actually, it's generally impossible to increment a counter this many times, energy wise
  * so it's not something you have to worry about.)
  */
-library Counter {
+library Counters {
     struct Counter {
         uint256 current; // default: 0
     }

--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../token/ERC20/IERC20.sol";
 

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/ERC20Mintable.sol";

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -65,14 +65,14 @@ contract ERC20Migrator {
     /**
      * @dev Begins the migration by setting which is the new token that will be
      * minted. This contract must be a minter for the new token.
-     * @param newToken the token that will be minted
+     * @param newToken_ the token that will be minted
      */
-    function beginMigration(ERC20Mintable newToken) public {
+    function beginMigration(ERC20Mintable newToken_) public {
         require(address(_newToken) == address(0));
-        require(address(newToken) != address(0));
-        require(newToken.isMinter(address(this)));
+        require(address(newToken_) != address(0));
+        require(newToken_.isMinter(address(this)));
 
-        _newToken = newToken;
+        _newToken = newToken_;
     }
 
     /**

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/SignerRole.sol";
 import "../cryptography/ECDSA.sol";

--- a/contracts/drafts/SignedSafeMath.sol
+++ b/contracts/drafts/SignedSafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title SignedSafeMath

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/SafeERC20.sol";
 import "../ownership/Ownable.sol";

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../crowdsale/validation/CappedCrowdsale.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC165.sol";
 

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title ERC165Checker

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title IERC165

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Math

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title SafeMath

--- a/contracts/mocks/Acknowledger.sol
+++ b/contracts/mocks/Acknowledger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 contract Acknowledger {
     event AcknowledgeFoo(uint256 a);

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../utils/Address.sol";
 

--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/emission/AllowanceCrowdsale.sol";

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../utils/Arrays.sol";
 

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/CappedCrowdsale.sol";

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/CapperRole.sol";
 

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../payment/escrow/ConditionalEscrow.sol";
 

--- a/contracts/mocks/CounterImpl.sol
+++ b/contracts/mocks/CounterImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../drafts/Counter.sol";
 

--- a/contracts/mocks/CountersImpl.sol
+++ b/contracts/mocks/CountersImpl.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.2;
 
 import "../drafts/Counters.sol";
 
-contract CounterImpl {
+contract CountersImpl {
     using Counters for Counters.Counter;
 
     uint256 public theId;

--- a/contracts/mocks/CountersImpl.sol
+++ b/contracts/mocks/CountersImpl.sol
@@ -1,14 +1,14 @@
 pragma solidity ^0.5.2;
 
-import "../drafts/Counter.sol";
+import "../drafts/Counters.sol";
 
 contract CounterImpl {
-    using Counter for Counter.Counter;
+    using Counters for Counters.Counter;
 
     uint256 public theId;
 
     // use whatever key you want to track your counters
-    mapping(string => Counter.Counter) private _counters;
+    mapping(string => Counters.Counter) private _counters;
 
     function doThing(string memory key) public returns (uint256) {
         theId = _counters[key].next();

--- a/contracts/mocks/CrowdsaleMock.sol
+++ b/contracts/mocks/CrowdsaleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../crowdsale/Crowdsale.sol";
 

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../cryptography/ECDSA.sol";
 

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 contract ERC165NotSupported {
     // solhint-disable-previous-line no-empty-blocks

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../introspection/ERC165Checker.sol";
 

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../introspection/ERC165.sol";
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20Burnable.sol";
 

--- a/contracts/mocks/ERC20DetailedMock.sol
+++ b/contracts/mocks/ERC20DetailedMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "./MinterRoleMock.sol";

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/TokenMetadata.sol";

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC721/ERC721Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/EventEmitter.sol
+++ b/contracts/mocks/EventEmitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 contract EventEmitter {
     event Argumentless();

--- a/contracts/mocks/Failer.sol
+++ b/contracts/mocks/Failer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 contract Failer {
     uint256[] private array;

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/FinalizableCrowdsale.sol";

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../crowdsale/price/IncreasingPriceCrowdsale.sol";
 import "../math/SafeMath.sol";

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/IndividuallyCappedCrowdsale.sol";

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../math/Math.sol";
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";
 

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/emission/MintedCrowdsale.sol";

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/MinterRole.sol";
 

--- a/contracts/mocks/OwnableInterfaceId.sol
+++ b/contracts/mocks/OwnableInterfaceId.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/PausableCrowdsaleImpl.sol
+++ b/contracts/mocks/PausableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
 import "../crowdsale/validation/PausableCrowdsale.sol";

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../lifecycle/Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/PostDeliveryCrowdsale.sol";

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../payment/PullPayment.sol";
 

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 contract ReentrancyAttack {
     function callSender(bytes4 data) public {

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol";

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/Roles.sol";
 

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/SafeERC20.sol";

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -6,19 +6,27 @@ import "../token/ERC20/SafeERC20.sol";
 contract ERC20FailingMock {
     uint256 private _allowance;
 
+    // IERC20's functions are not pure, but these mock implementations are: to prevent Solidity from issuing warnings,
+    // we write to a dummy state variable.
+    uint256 private _dummy;
+
     function transfer(address, uint256) public returns (bool) {
+        _dummy = 0;
         return false;
     }
 
     function transferFrom(address, address, uint256) public returns (bool) {
+        _dummy = 0;
         return false;
     }
 
     function approve(address, uint256) public returns (bool) {
+        _dummy = 0;
         return false;
     }
 
     function allowance(address, address) public view returns (uint256) {
+        require(_dummy == 0);
         return 0;
     }
 }
@@ -26,15 +34,22 @@ contract ERC20FailingMock {
 contract ERC20SucceedingMock {
     uint256 private _allowance;
 
+    // IERC20's functions are not pure, but these mock implementations are: to prevent Solidity from issuing warnings,
+    // we write to a dummy state variable.
+    uint256 private _dummy;
+
     function transfer(address, uint256) public returns (bool) {
+        _dummy = 0;
         return true;
     }
 
     function transferFrom(address, address, uint256) public returns (bool) {
+        _dummy = 0;
         return true;
     }
 
     function approve(address, uint256) public returns (bool) {
+        _dummy = 0;
         return true;
     }
 

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../ownership/Secondary.sol";
 

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";

--- a/contracts/mocks/SignedSafeMathMock.sol
+++ b/contracts/mocks/SignedSafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../drafts/SignedSafeMath.sol";
 

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/SignerRole.sol";
 

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/TimedCrowdsale.sol";

--- a/contracts/mocks/WhitelistAdminRoleMock.sol
+++ b/contracts/mocks/WhitelistAdminRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/WhitelistAdminRole.sol";
 

--- a/contracts/mocks/WhitelistCrowdsaleImpl.sol
+++ b/contracts/mocks/WhitelistCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/WhitelistCrowdsale.sol";

--- a/contracts/mocks/WhitelistedRoleMock.sol
+++ b/contracts/mocks/WhitelistedRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../access/roles/WhitelistedRole.sol";
 

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Ownable

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Secondary

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./escrow/Escrow.sol";
 

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./Escrow.sol";
 

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../math/SafeMath.sol";
 import "../../ownership/Secondary.sol";

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ConditionalEscrow.sol";
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC20Mintable.sol";
 

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC20.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC20.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title ERC20 interface

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./SafeERC20.sol";
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721.sol";
 import "./IERC721Receiver.sol";

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721.sol";
 

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721Enumerable.sol";
 import "./ERC721.sol";

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721.sol";
 import "./ERC721Enumerable.sol";

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721Receiver.sol";
 

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721.sol";
 import "./IERC721Metadata.sol";

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./ERC721.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Full.sol
+++ b/contracts/token/ERC721/IERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721.sol";
 import "./IERC721Enumerable.sol";

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title ERC721 token receiver interface

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * Utility library of inline functions on addresses

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 import "../math/Math.sol";
 

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
 
 /**
  * @title Helps contracts guard against reentrancy attacks.

--- a/test/drafts/Counters.test.js
+++ b/test/drafts/Counters.test.js
@@ -1,14 +1,14 @@
 const { BN } = require('openzeppelin-test-helpers');
 
-const CounterImpl = artifacts.require('CounterImpl');
+const CountersImpl = artifacts.require('CountersImpl');
 
 const EXPECTED = [new BN(1), new BN(2), new BN(3), new BN(4)];
 const KEY1 = web3.utils.sha3('key1');
 const KEY2 = web3.utils.sha3('key2');
 
-contract('Counter', function ([_, owner]) {
+contract('Counters', function ([_, owner]) {
   beforeEach(async function () {
-    this.mock = await CounterImpl.new({ from: owner });
+    this.mock = await CountersImpl.new({ from: owner });
   });
 
   context('custom key', async function () {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ module.exports = {
 
   compilers: {
     solc: {
-      version: '0.5.0',
+      version: '0.5.2',
     },
   },
 };


### PR DESCRIPTION
Part of https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1346

With this PR, there is only one warning remaining, which we can't get rid of yet (unless we add a dummy state variable read, but while this may be fine for a mock, I don't think it is for actual production code):
```
Crowdsale.sol:138:5: Warning: Function state mutability can be restricted to pure
    function _preValidatePurchase(address beneficiary, uint256 weiAmount) internal view {
    ^ (Relevant source part starts here and spans across multiple lines).
```

It's probably best to review each commit separately.

Regarding the changes:
 * Solidity removed warnings on functions with empty body in https://github.com/ethereum/solidity/pull/5630, which is part of 0.5.2. This, coupled with the newly added recommendation to [use the latest compiler version](https://github.com/ethereum/solidity/pull/5757) is IMO enough to switch to 0.5.2, considering it should be a drop-in replacement for 0.5.0.
 * There is precedent for an argument to end with an underscore if it matches a public function in `PaymentSplitter#_addPayee`
 * A library that works with data structures being named in plural is consistent with `Roles` (which works on a `Role`) and `Arrays` (which works on an array)



