### PR TITLE
Add ERC20 _setTokenURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugfixes:
 
 ### Breaking changes:
+ * `TokenMetadata` (in drafts) has been renamed to `ERC20Metadata`.
 
 ## 2.1.2 (2019-17-01)
  * Removed most of the test suite from the npm package, except `PublicRole.behavior.js`, which may be useful to users testing their own `Roles`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features:
  * `ERC20`: added internal `_approve(address owner, address spender, uint256 value)`, allowing derived contracts to set the allowance of arbitrary accounts.
+ * `ERC20Metadata`: added internal `_setTokenURI(string memory tokenURI)`.
 
 ### Improvements:
  * Upgraded the minimum compiler version to v0.5.2: this removes many Solidity warnings that were false positives.

--- a/contracts/drafts/ERC1046/ERC20Metadata.sol
+++ b/contracts/drafts/ERC1046/ERC20Metadata.sol
@@ -7,22 +7,18 @@ import "../../token/ERC20/IERC20.sol";
  * @dev See https://eips.ethereum.org/EIPS/eip-1046
  * @dev tokenURI must respond with a URI that implements https://eips.ethereum.org/EIPS/eip-1047
  */
-contract ERC20TokenMetadata is IERC20 {
-    function tokenURI() external view returns (string memory);
-}
-
-contract ERC20WithMetadata is ERC20TokenMetadata {
+contract ERC20Metadata {
     string private _tokenURI;
 
-    constructor (string memory tokenURI) public {
-        _setTokenURI(tokenURI)
-    }
-
-    function _setTokenURI(string memory tokenURI) internal {
-        _tokenURI = tokenURI;
+    constructor (string memory tokenURI_) public {
+        _setTokenURI(tokenURI_);
     }
 
     function tokenURI() external view returns (string memory) {
         return _tokenURI;
+    }
+
+    function _setTokenURI(string memory tokenURI_) internal {
+        _tokenURI = tokenURI_;
     }
 }

--- a/contracts/drafts/ERC1046/TokenMetadata.sol
+++ b/contracts/drafts/ERC1046/TokenMetadata.sol
@@ -15,6 +15,10 @@ contract ERC20WithMetadata is ERC20TokenMetadata {
     string private _tokenURI;
 
     constructor (string memory tokenURI) public {
+        _setTokenURI(tokenURI)
+    }
+
+    function _setTokenURI(string memory tokenURI) internal {
         _tokenURI = tokenURI;
     }
 

--- a/contracts/mocks/ERC20MetadataMock.sol
+++ b/contracts/mocks/ERC20MetadataMock.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.2;
 
 import "../token/ERC20/ERC20.sol";
-import "../drafts/ERC1046/TokenMetadata.sol";
+import "../drafts/ERC1046/ERC20Metadata.sol";
 
-contract ERC20WithMetadataMock is ERC20, ERC20WithMetadata {
-    constructor (string memory tokenURI) public ERC20WithMetadata(tokenURI) {
+contract ERC20MetadataMock is ERC20, ERC20Metadata {
+    constructor (string memory tokenURI) public ERC20Metadata(tokenURI) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/contracts/mocks/ERC20WithMetadataMock.sol
+++ b/contracts/mocks/ERC20WithMetadataMock.sol
@@ -7,4 +7,8 @@ contract ERC20WithMetadataMock is ERC20, ERC20WithMetadata {
     constructor (string memory tokenURI) public ERC20WithMetadata(tokenURI) {
         // solhint-disable-previous-line no-empty-blocks
     }
+
+    function setTokenURI(string memory tokenURI) public {
+        _setTokenURI(tokenURI);
+    }
 }

--- a/test/drafts/ERC1046/ERC20Metadata.test.js
+++ b/test/drafts/ERC1046/ERC20Metadata.test.js
@@ -1,10 +1,10 @@
 require('openzeppelin-test-helpers');
 
-const ERC20WithMetadataMock = artifacts.require('ERC20WithMetadataMock');
+const ERC20MetadataMock = artifacts.require('ERC20MetadataMock');
 
 const metadataURI = 'https://example.com';
 
-describe('ERC20WithMetadata', function () {
+describe('ERC20Metadata', function () {
   beforeEach(async function () {
     this.token = await ERC20WithMetadataMock.new(metadataURI);
   });

--- a/test/drafts/ERC1046/ERC20Metadata.test.js
+++ b/test/drafts/ERC1046/ERC20Metadata.test.js
@@ -6,7 +6,7 @@ const metadataURI = 'https://example.com';
 
 describe('ERC20Metadata', function () {
   beforeEach(async function () {
-    this.token = await ERC20WithMetadataMock.new(metadataURI);
+    this.token = await ERC20MetadataMock.new(metadataURI);
   });
 
   it('responds with the metadata', async function () {

--- a/test/drafts/ERC1046/TokenMetadata.test.js
+++ b/test/drafts/ERC1046/TokenMetadata.test.js
@@ -12,4 +12,12 @@ describe('ERC20WithMetadata', function () {
   it('responds with the metadata', async function () {
     (await this.token.tokenURI()).should.equal(metadataURI);
   });
+
+  describe('setTokenURI', function () {
+    it('changes the original URI', async function () {
+      const newMetadataURI = 'https://betterexample.com';
+      await this.token.setTokenURI(newMetadataURI);
+      (await this.token.tokenURI()).should.equal(newMetadataURI);
+    });
+  });
 });


### PR DESCRIPTION
I also renamed the contract, since it used to be spit in two for no apparent reason.

Fixes https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1612