### PR TITLE
Seperating cap setting functionality into seperate function for modularity within ERC20Capped.sol

### DIFF
--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -10,8 +10,7 @@ contract ERC20Capped is ERC20Mintable {
     uint256 private _cap;
 
     constructor (uint256 cap) public {
-        require(cap > 0);
-        _cap = cap;
+        _setCap(cap);
     }
 
     /**
@@ -19,6 +18,11 @@ contract ERC20Capped is ERC20Mintable {
      */
     function cap() public view returns (uint256) {
         return _cap;
+    }
+
+    function _setCap(uint256 cap) private {
+        require(cap > 0);
+        _cap = cap;        
     }
 
     function _mint(address account, uint256 value) internal {


### PR DESCRIPTION
Hello,

I wanted to suggest a very minor change in the "ERC20Capped.sol" contract. I thought it would be nice for modularity to break out the lines responsible for setting the cap into a seperate function "_setCap", then calling the function from within the constructor.

I hope I managed to follow all the guidelines well. Thank you!
Luiserebii