### PR TITLE
Feature/erc20 erc165 #1073

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## 2.2.0 (unreleased)
 
 ### New features:
+ * `ERC20`, `ERC20Burnable`, `ERC20Detailed`: added ERC165 implementations
  * `ERC20`: added internal `_approve(address owner, address spender, uint256 value)`, allowing derived contracts to set the allowance of arbitrary accounts.
  * `ERC20Metadata`: added internal `_setTokenURI(string memory tokenURI)`.
 
 ### Improvements:
+ * `ERC20`: `name()`, `symbol()`, `decimals()` made external instead of public
  * Upgraded the minimum compiler version to v0.5.2: this removes many Solidity warnings that were false positives.
  * `Counter`'s API has been improved, and is now used by `ERC721` (though it is still in `drafts`).
  * `ERC721`'s transfers are now more gas efficient due to removal of unnecessary `SafeMath` calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
  * `ERC20Metadata`: added internal `_setTokenURI(string memory tokenURI)`.
 
 ### Improvements:
- * `ERC20`: `name()`, `symbol()`, `decimals()` made external instead of public
  * Upgraded the minimum compiler version to v0.5.2: this removes many Solidity warnings that were false positives.
  * `Counter`'s API has been improved, and is now used by `ERC721` (though it is still in `drafts`).
  * `ERC721`'s transfers are now more gas efficient due to removal of unnecessary `SafeMath` calls.

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -39,7 +39,7 @@ contract ERC20 is ERC165, IERC20 {
     constructor()
     public
     {
-      _registerInterface(_INTERFACE_ID_ERC20);
+        _registerInterface(_INTERFACE_ID_ERC20);
     }
 
     /**

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";
+import "../../introspection/ERC165.sol";
 
 /**
  * @title Standard ERC20 token
@@ -15,7 +16,7 @@ import "../../math/SafeMath.sol";
  * all accounts just by listening to said events. Note that this isn't required by the specification, and other
  * compliant implementations may not do it.
  */
-contract ERC20 is IERC20 {
+contract ERC20 is ERC165, IERC20 {
     using SafeMath for uint256;
 
     mapping (address => uint256) private _balances;
@@ -24,9 +25,26 @@ contract ERC20 is IERC20 {
 
     uint256 private _totalSupply;
 
-    /**
-     * @dev Total number of tokens in existence
-     */
+  bytes4 private constant _INTERFACE_ID_ERC20 = 0x36372b07;
+  /*
+   * 0x80ac58cd ===
+   *     bytes4(keccak256('transfer(address,uint256)')) ^
+   *     bytes4(keccak256('approve(address,uint256)')) ^
+   *     bytes4(keccak256('transferFrom(address,address,uint256)')) ^
+   *     bytes4(keccak256('totalSupply()')) ^
+   *     bytes4(keccak256('balanceOf(address)')) ^
+   *     bytes4(keccak256('allowance(address,address)'))
+   */
+
+  constructor()
+  public
+  {
+    _registerInterface(_INTERFACE_ID_ERC20);
+  }
+
+  /**
+   * @dev Total number of tokens in existence
+   */
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
     }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -25,26 +25,26 @@ contract ERC20 is ERC165, IERC20 {
 
     uint256 private _totalSupply;
 
-  bytes4 private constant _INTERFACE_ID_ERC20 = 0x36372b07;
-  /*
-   * 0x80ac58cd ===
-   *     bytes4(keccak256('transfer(address,uint256)')) ^
-   *     bytes4(keccak256('approve(address,uint256)')) ^
-   *     bytes4(keccak256('transferFrom(address,address,uint256)')) ^
-   *     bytes4(keccak256('totalSupply()')) ^
-   *     bytes4(keccak256('balanceOf(address)')) ^
-   *     bytes4(keccak256('allowance(address,address)'))
-   */
+    bytes4 private constant _INTERFACE_ID_ERC20 = 0x36372b07;
+    /*
+     * 0x36372b07 ===
+     *     bytes4(keccak256('transfer(address,uint256)')) ^
+     *     bytes4(keccak256('approve(address,uint256)')) ^
+     *     bytes4(keccak256('transferFrom(address,address,uint256)')) ^
+     *     bytes4(keccak256('totalSupply()')) ^
+     *     bytes4(keccak256('balanceOf(address)')) ^
+     *     bytes4(keccak256('allowance(address,address)'))
+     */
 
-  constructor()
-  public
-  {
-    _registerInterface(_INTERFACE_ID_ERC20);
-  }
+    constructor()
+    public
+    {
+      _registerInterface(_INTERFACE_ID_ERC20);
+    }
 
-  /**
-   * @dev Total number of tokens in existence
-   */
+    /**
+     * @dev Total number of tokens in existence
+     */
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
     }

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,12 +1,24 @@
 pragma solidity ^0.5.2;
 
 import "./ERC20.sol";
+import "../../introspection/ERC165.sol";
 
 /**
  * @title Burnable Token
  * @dev Token that can be irreversibly burned (destroyed).
  */
-contract ERC20Burnable is ERC20 {
+contract ERC20Burnable is ERC165, ERC20 {
+    bytes4 private constant _INTERFACE_ID_ERC20_BURNABLE = 0x3b5a0bf8;
+    /*
+     * 0xa219a025 ===
+     *     bytes4(keccak256('burn(uint256)') ^
+     *     bytes4(keccak256('burnFrom(address,uint256)'))
+     */
+
+    constructor () public {
+      _registerInterface(_INTERFACE_ID_ERC20_BURNABLE);
+    }
+
     /**
      * @dev Burns a specific amount of tokens.
      * @param value The amount of token to be burned.

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -10,13 +10,13 @@ import "../../introspection/ERC165.sol";
 contract ERC20Burnable is ERC165, ERC20 {
     bytes4 private constant _INTERFACE_ID_ERC20_BURNABLE = 0x3b5a0bf8;
     /*
-     * 0xa219a025 ===
+     * 0x3b5a0bf8 ===
      *     bytes4(keccak256('burn(uint256)') ^
      *     bytes4(keccak256('burnFrom(address,uint256)'))
      */
 
     constructor () public {
-      _registerInterface(_INTERFACE_ID_ERC20_BURNABLE);
+        _registerInterface(_INTERFACE_ID_ERC20_BURNABLE);
     }
 
     /**

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -32,21 +32,21 @@ contract ERC20Detailed is ERC165, IERC20 {
     /**
      * @return the name of the token.
      */
-    function name() external view returns (string memory) {
+    function name() public view returns (string memory) {
         return _name;
     }
 
     /**
      * @return the symbol of the token.
      */
-    function symbol() external view returns (string memory) {
+    function symbol() public view returns (string memory) {
         return _symbol;
     }
 
     /**
      * @return the number of decimals of the token.
      */
-    function decimals() external view returns (uint8) {
+    function decimals() public view returns (uint8) {
         return _decimals;
     }
 }

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -19,7 +19,7 @@ contract ERC20Detailed is ERC165, IERC20 {
      * 0xa219a025 ===
      *     bytes4(keccak256('name()') ^
      *     bytes4(keccak256('symbol()')) ^
-     *     bytes4(keccak256('decimals)'))
+     *     bytes4(keccak256('decimals()'))
      */
 
     constructor (string memory name, string memory symbol, uint8 decimals) public {

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -17,7 +17,7 @@ contract ERC20Detailed is ERC165, IERC20 {
     bytes4 private constant _INTERFACE_ID_ERC20_DETAILED = 0xa219a025;
     /*
      * 0xa219a025 ===
-     *     bytes4(keccak256('name()) ^
+     *     bytes4(keccak256('name()') ^
      *     bytes4(keccak256('symbol()')) ^
      *     bytes4(keccak256('decimals)'))
      */

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.2;
 
 import "./IERC20.sol";
+import "../../introspection/ERC165.sol";
 
 /**
  * @title ERC20Detailed token
@@ -8,15 +9,24 @@ import "./IERC20.sol";
  * All the operations are done using the smallest and indivisible token unit,
  * just as on Ethereum all the operations are done in wei.
  */
-contract ERC20Detailed is IERC20 {
+contract ERC20Detailed is ERC165, IERC20 {
     string private _name;
     string private _symbol;
     uint8 private _decimals;
+
+    bytes4 private constant _INTERFACE_ID_ERC20_DETAILED = 0xa219a025;
+    /*
+     * 0xa219a025 ===
+     *     bytes4(keccak256('name()) ^
+     *     bytes4(keccak256('symbol()')) ^
+     *     bytes4(keccak256('decimals)'))
+     */
 
     constructor (string memory name, string memory symbol, uint8 decimals) public {
         _name = name;
         _symbol = symbol;
         _decimals = decimals;
+        _registerInterface(_INTERFACE_ID_ERC20_DETAILED);
     }
 
     /**

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -32,21 +32,21 @@ contract ERC20Detailed is ERC165, IERC20 {
     /**
      * @return the name of the token.
      */
-    function name() public view returns (string memory) {
+    function name() external view returns (string memory) {
         return _name;
     }
 
     /**
      * @return the symbol of the token.
      */
-    function symbol() public view returns (string memory) {
+    function symbol() external view returns (string memory) {
         return _symbol;
     }
 
     /**
      * @return the number of decimals of the token.
      */
-    function decimals() public view returns (uint8) {
+    function decimals() external view returns (uint8) {
         return _decimals;
     }
 }

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -10,18 +10,17 @@ const INTERFACE_IDS = {
     'transferFrom(address,address,uint256)',
     'totalSupply()',
     'balanceOf(address)',
-    'allowance(address,address)'
+    'allowance(address,address)',
   ]),
   ERC20Burnable: makeInterfaceId([
     'burn(uint256)',
-    'burnFrom(address,uint256)'
-    ]),
+    'burnFrom(address,uint256)',
+  ]),
   ERC20Detailed: makeInterfaceId([
     'name()',
     'symbol()',
-    'decimals()'
+    'decimals()',
   ]),
-  // TODO ERC20 ERC20Burnable, SafeERC20
   ERC721: makeInterfaceId([
     'balanceOf(address)',
     'ownerOf(uint256)',

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -12,6 +12,10 @@ const INTERFACE_IDS = {
     'balanceOf(address)',
     'allowance(address,address)'
   ]),
+  ERC20Burnable: makeInterfaceId([
+    'burn(uint256)',
+    'burnFrom(address,uint256)'
+    ]),
   ERC20Detailed: makeInterfaceId([
     'name()',
     'symbol()',

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -4,6 +4,15 @@ const INTERFACE_IDS = {
   ERC165: makeInterfaceId([
     'supportsInterface(bytes4)',
   ]),
+  ERC20: makeInterfaceId([
+    'transfer(address,uint256)',
+    'approve(address,uint256)',
+    'transferFrom(address,address,uint256)',
+    'totalSupply()',
+    'balanceOf(address)',
+    'allowance(address,address)'
+  ]),
+  // TODO ERC20 burnable, mintable etc.
   ERC721: makeInterfaceId([
     'balanceOf(address)',
     'ownerOf(uint256)',

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -12,7 +12,12 @@ const INTERFACE_IDS = {
     'balanceOf(address)',
     'allowance(address,address)'
   ]),
-  // TODO ERC20 burnable, mintable etc.
+  ERC20Detailed: makeInterfaceId([
+    'name()',
+    'symbol()',
+    'decimals()'
+  ]),
+  // TODO ERC20 ERC20Burnable, SafeERC20
   ERC721: makeInterfaceId([
     'balanceOf(address)',
     'ownerOf(uint256)',

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -4,7 +4,6 @@ const { ZERO_ADDRESS } = constants;
 const ERC20Mock = artifacts.require('ERC20Mock');
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
-
 contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
   const initialSupply = new BN(100);
   beforeEach(async function () {
@@ -564,6 +563,6 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
   shouldSupportInterfaces([
     'ERC165',
-    'ERC20'
-  ])
+    'ERC20',
+  ]);
 });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -2,6 +2,8 @@ const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-he
 const { ZERO_ADDRESS } = constants;
 
 const ERC20Mock = artifacts.require('ERC20Mock');
+const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
+
 
 contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
   const initialSupply = new BN(100);
@@ -559,4 +561,9 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
       });
     });
   }
+
+  shouldSupportInterfaces([
+    'ERC165',
+    'ERC20'
+  ])
 });

--- a/test/token/ERC20/ERC20Burnable.test.js
+++ b/test/token/ERC20/ERC20Burnable.test.js
@@ -1,20 +1,20 @@
-const {BN} = require('openzeppelin-test-helpers');
+const { BN } = require('openzeppelin-test-helpers');
 
-const {shouldBehaveLikeERC20Burnable} = require('./behaviors/ERC20Burnable.behavior');
+const { shouldBehaveLikeERC20Burnable } = require('./behaviors/ERC20Burnable.behavior');
 const ERC20BurnableMock = artifacts.require('ERC20BurnableMock');
-const {shouldSupportInterfaces} = require('../../introspection/SupportsInterface.behavior');
+const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
 contract('ERC20Burnable', function ([_, owner, ...otherAccounts]) {
   const initialBalance = new BN(1000);
 
   beforeEach(async function () {
-    this.token = await ERC20BurnableMock.new(owner, initialBalance, {from: owner});
+    this.token = await ERC20BurnableMock.new(owner, initialBalance, { from: owner });
   });
 
   shouldBehaveLikeERC20Burnable(owner, initialBalance, otherAccounts);
 
   shouldSupportInterfaces([
     'ERC165',
-    'ERC20Burnable'
-  ])
+    'ERC20Burnable',
+  ]);
 });

--- a/test/token/ERC20/ERC20Burnable.test.js
+++ b/test/token/ERC20/ERC20Burnable.test.js
@@ -1,14 +1,20 @@
-const { BN } = require('openzeppelin-test-helpers');
+const {BN} = require('openzeppelin-test-helpers');
 
-const { shouldBehaveLikeERC20Burnable } = require('./behaviors/ERC20Burnable.behavior');
+const {shouldBehaveLikeERC20Burnable} = require('./behaviors/ERC20Burnable.behavior');
 const ERC20BurnableMock = artifacts.require('ERC20BurnableMock');
+const {shouldSupportInterfaces} = require('../../introspection/SupportsInterface.behavior');
 
 contract('ERC20Burnable', function ([_, owner, ...otherAccounts]) {
   const initialBalance = new BN(1000);
 
   beforeEach(async function () {
-    this.token = await ERC20BurnableMock.new(owner, initialBalance, { from: owner });
+    this.token = await ERC20BurnableMock.new(owner, initialBalance, {from: owner});
   });
 
   shouldBehaveLikeERC20Burnable(owner, initialBalance, otherAccounts);
+
+  shouldSupportInterfaces([
+    'ERC165',
+    'ERC20Burnable'
+  ])
 });

--- a/test/token/ERC20/ERC20Detailed.test.js
+++ b/test/token/ERC20/ERC20Detailed.test.js
@@ -1,6 +1,7 @@
 const { BN } = require('openzeppelin-test-helpers');
 
 const ERC20DetailedMock = artifacts.require('ERC20DetailedMock');
+const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
 contract('ERC20Detailed', function () {
   const _name = 'My Detailed ERC20';
@@ -8,18 +9,23 @@ contract('ERC20Detailed', function () {
   const _decimals = new BN(18);
 
   beforeEach(async function () {
-    this.detailedERC20 = await ERC20DetailedMock.new(_name, _symbol, _decimals);
+    this.token = await ERC20DetailedMock.new(_name, _symbol, _decimals);
   });
 
   it('has a name', async function () {
-    (await this.detailedERC20.name()).should.be.equal(_name);
+    (await this.token.name()).should.be.equal(_name);
   });
 
   it('has a symbol', async function () {
-    (await this.detailedERC20.symbol()).should.be.equal(_symbol);
+    (await this.token.symbol()).should.be.equal(_symbol);
   });
 
   it('has an amount of decimals', async function () {
-    (await this.detailedERC20.decimals()).should.be.bignumber.equal(_decimals);
+    (await this.token.decimals()).should.be.bignumber.equal(_decimals);
   });
+
+  shouldSupportInterfaces([
+    'ERC165',
+    'ERC20Detailed'
+  ])
 });

--- a/test/token/ERC20/ERC20Detailed.test.js
+++ b/test/token/ERC20/ERC20Detailed.test.js
@@ -26,6 +26,6 @@ contract('ERC20Detailed', function () {
 
   shouldSupportInterfaces([
     'ERC165',
-    'ERC20Detailed'
-  ])
+    'ERC20Detailed',
+  ]);
 });


### PR DESCRIPTION
 ERC20 made ERC165-compliant (Fixes #1073)

This PR mimics 259b9da and uses test helpers introduced there in a similar manner. 

* fix: ERC20Detailed's name(), symbol(), decimals() made external instead of public

* feat: add ERC165 to ERC20Burnable

* feat: add ERC165 to ERC20Detailed

* feat: add ERC165 to ERC20

Added ERC165 implementation to ERC20, as well as Burnable and Detailed flavors, 
didn't touch Capped, Mintable etc., because their functionality is mostly accessible to contract owners.
