### PR TITLE
add _setName and _setSymbol to ERC721Metadata

### DIFF
--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -26,8 +26,8 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      * @dev Constructor function
      */
     constructor (string memory name, string memory symbol) public {
-        _name = name;
-        _symbol = symbol;
+        _setName(name);
+        _setSymbol(symbol);
 
         // register the supported interfaces to conform to ERC721 via ERC165
         _registerInterface(_INTERFACE_ID_ERC721_METADATA);
@@ -57,6 +57,22 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     function tokenURI(uint256 tokenId) external view returns (string memory) {
         require(_exists(tokenId));
         return _tokenURIs[tokenId];
+    }
+
+    /**
+     * @dev Internal function to set the name
+     * @param name string name to assign
+     */
+    function _setName(string memory name) internal {
+        _name = name;
+    }
+
+    /**
+     * @dev Internal function to set the symbol
+     * @param symbol string symbol to assign
+     */
+    function _setSymbol(string memory symbol) internal {
+        _symbol = symbol;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,7 +3538,7 @@
         "req-cwd": "^1.0.1",
         "shelljs": "^0.7.4",
         "sol-explore": "^1.6.2",
-        "solidity-parser-sc": "github:maxsam4/solidity-parser#solidity-0.5",
+        "solidity-parser-sc": "github:maxsam4/solidity-parser#8c93bc23aeb55e6c858ab4f79ef8cf8966034444",
         "tree-kill": "^1.2.0",
         "web3": "^0.20.6"
       }
@@ -3934,7 +3934,7 @@
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

Fixes #1632 

<!-- 2. Describe the changes introduced in this pull request. -->

Adds _setName and _setSymbol so child contracts can change them

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->

No new tests necessary since the constructor uses the new internal functions
