### PR TITLE
Use assembly in SafeMath

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -9,49 +9,46 @@ library SafeMath {
      * @dev Multiplies two unsigned integers, reverts on overflow.
      */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
-        // benefit is lost if 'b' is also tested.
-        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
-        if (a == 0) {
-            return 0;
+        assembly {
+            switch a
+            case 0 {
+                r := 0
+            }
+            default {
+                r := mul(a, b)
+                if not(eq(div(r, a), b)) { revert(0, 0) }
+            }
         }
-
-        uint256 c = a * b;
-        require(c / a == b);
-
-        return c;
     }
 
     /**
      * @dev Integer division of two unsigned integers truncating the quotient, reverts on division by zero.
      */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity only automatically asserts when dividing by 0
-        require(b > 0);
-        uint256 c = a / b;
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-
-        return c;
+        assembly {
+            if iszero(b) { revert(0, 0) }
+            r := div(a, b)
+        }
     }
 
     /**
      * @dev Subtracts two unsigned integers, reverts on overflow (i.e. if subtrahend is greater than minuend).
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b <= a);
-        uint256 c = a - b;
-
-        return c;
+        assembly {
+            if gt(a, b) { revert(0, 0) }
+            r := sub(a, b)
+        }
     }
 
     /**
      * @dev Adds two unsigned integers, reverts on overflow.
      */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a + b;
-        require(c >= a);
-
-        return c;
+        assembly {
+            r := add(a,b)
+            if lt(r, a) { revert(0, 0) }
+        }
     }
 
     /**
@@ -59,7 +56,9 @@ library SafeMath {
      * reverts when dividing by zero.
      */
     function mod(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b != 0);
-        return a % b;
+        assembly {
+            if iszero(b) { revert(0, 0) }
+            r := mod(a, b)
+        }
     }
 }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -11,12 +11,10 @@ library SafeMath {
     function mul(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            if iszero(a) {
-                r := 0
-                return(r, 32)
+            if a {
+              r := mul(a, b)
+              if iszero(eq(div(r, a), b)) { revert(0, 0) }
             }
-            r := mul(a, b)
-            if iszero(eq(div(r, a), b)) { revert(0, 0) }
         }
     }
 

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -12,7 +12,8 @@ library SafeMath {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             if iszero(a) {
-                return(a, 32)
+                r := 0
+                return(r, 32)
             }
             r := mul(a, b)
             if iszero(eq(div(r, a), b)) { revert(0, 0) }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -8,24 +8,21 @@ library SafeMath {
     /**
      * @dev Multiplies two unsigned integers, reverts on overflow.
      */
-    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    function mul(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            switch a
-            case 0 {
-                r := 0
+            if iszero(a) {
+                return(a, 32)
             }
-            default {
-                r := mul(a, b)
-                if iszero(eq(div(r, a), b)) { revert(0, 0) }
-            }
+            r := mul(a, b)
+            if iszero(eq(div(r, a), b)) { revert(0, 0) }
         }
     }
 
     /**
      * @dev Integer division of two unsigned integers truncating the quotient, reverts on division by zero.
      */
-    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    function div(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             if iszero(b) { revert(0, 0) }
@@ -36,7 +33,7 @@ library SafeMath {
     /**
      * @dev Subtracts two unsigned integers, reverts on overflow (i.e. if subtrahend is greater than minuend).
      */
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    function sub(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             if lt(a, b) { revert(0, 0) }
@@ -47,7 +44,7 @@ library SafeMath {
     /**
      * @dev Adds two unsigned integers, reverts on overflow.
      */
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    function add(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             r := add(a, b)
@@ -59,7 +56,7 @@ library SafeMath {
      * @dev Divides two unsigned integers and returns the remainder (unsigned integer modulo),
      * reverts when dividing by zero.
      */
-    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+    function mod(uint256 a, uint256 b) internal pure returns (uint256 r) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             if iszero(b) { revert(0, 0) }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -9,6 +9,7 @@ library SafeMath {
      * @dev Multiplies two unsigned integers, reverts on overflow.
      */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             switch a
             case 0 {
@@ -25,6 +26,7 @@ library SafeMath {
      * @dev Integer division of two unsigned integers truncating the quotient, reverts on division by zero.
      */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             if iszero(b) { revert(0, 0) }
             r := div(a, b)
@@ -35,6 +37,7 @@ library SafeMath {
      * @dev Subtracts two unsigned integers, reverts on overflow (i.e. if subtrahend is greater than minuend).
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             if lt(a, b) { revert(0, 0) }
             r := sub(a, b)
@@ -45,8 +48,9 @@ library SafeMath {
      * @dev Adds two unsigned integers, reverts on overflow.
      */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
-            r := add(a,b)
+            r := add(a, b)
             if lt(r, a) { revert(0, 0) }
         }
     }
@@ -56,6 +60,7 @@ library SafeMath {
      * reverts when dividing by zero.
      */
     function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             if iszero(b) { revert(0, 0) }
             r := mod(a, b)

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -16,7 +16,7 @@ library SafeMath {
             }
             default {
                 r := mul(a, b)
-                if not(eq(div(r, a), b)) { revert(0, 0) }
+                if iszero(eq(div(r, a), b)) { revert(0, 0) }
             }
         }
     }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -36,7 +36,7 @@ library SafeMath {
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
         assembly {
-            if gt(a, b) { revert(0, 0) }
+            if lt(a, b) { revert(0, 0) }
             r := sub(a, b)
         }
     }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

Uses assembly in SafeMath

Tested in Remix with optimization enabled and the stable 0.5.3 compiler. The following numbers are the gas savings for each operation:
```
add(1,2): 9 gas saved
div(1,2): 38 gas saved
mod(1,2): 33 gas saved
mul(1,2): 31 gas saved
sub(2,1): 0 gas saved
```

This adds up to enormous savings for contracts that use SafeMath hundreds or thousands of times per Ethereum transaction. The simple nature of SafeMath also allows for assembly to be easily verified.

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
