### PR TITLE
Fix SafeERC20.safeApprove bug

### DIFF
--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -32,7 +32,7 @@ contract ERC20FailingMock {
 }
 
 contract ERC20SucceedingMock {
-    uint256 private _allowance;
+    mapping (address => uint256) private _allowances;
 
     // IERC20's functions are not pure, but these mock implementations are: to prevent Solidity from issuing warnings,
     // we write to a dummy state variable.
@@ -54,11 +54,11 @@ contract ERC20SucceedingMock {
     }
 
     function setAllowance(uint256 allowance_) public {
-        _allowance = allowance_;
+        _allowances[msg.sender] = allowance_;
     }
 
-    function allowance(address, address) public view returns (uint256) {
-        return _allowance;
+    function allowance(address owner, address) public view returns (uint256) {
+        return _allowances[owner];
     }
 }
 

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -24,7 +24,7 @@ library SafeERC20 {
         // safeApprove should only be called when setting an initial allowance,
         // or when resetting it to zero. To increase and decrease it, use
         // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
-        require((value == 0) || (token.allowance(msg.sender, spender) == 0));
+        require((value == 0) || (token.allowance(address(this), spender) == 0));
         require(token.approve(spender, value));
     }
 


### PR DESCRIPTION
This fixes a bug reported by @nikeshnazareth (thanks a lot!), where `SafeERC20.safeApprove` performs a safety check using the allowance of the contract caller, instead of the contract's own address. I also improved the `SafeERC20` mock contracts so that the tests fail with the old code and pass with the new one (but still kept the mock as simple as possible).

This check was added in v2.0 (see https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1407/) as a recommendation from @cwhinfrey and the LevelK team during their audit of OpenZeppelin v2.0 (which was unreleased at the time). As such, we consider this to be a minor bug, since the safety check's purpose was discouraging unsafe use of `approve` by forcing usage under safe conditions, and the only consequence is that this feature was incorrectly implemented. And even then, the (`approve` bug)[https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729] can only be exploited under specific conditions, has been known for a very long time, and only affects the user calling `approve`.

We will be releasing a hotfix for both v2.1 and v2.0 (to support both Solidity v0.5.x and v0.4.25).