### PR TITLE
Add the solidity linter command to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Fixes #
     (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
   - added tests where applicable to test new functionality,
   - made sure that your contracts are well-documented,
-  - run the Solidity linter (`npm run lint:sol`) and fix any issues,
-  - run the JS linter and fix any issues (`npm run lint:fix`), and
+  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
+  - run the JS linter and fixed any issues (`npm run lint:fix`), and
   - updated the changelog, if applicable.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Fixes #
     (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
   - added tests where applicable to test new functionality,
   - made sure that your contracts are well-documented,
-  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
+  - run the Solidity linter (`npm run lint:sol`) and fix any issues,
+  - run the JS linter and fix any issues (`npm run lint:fix`), and
   - updated the changelog, if applicable.
 -->


### PR DESCRIPTION
The Pull Request template states that a contributor should run the Solidity/JS linters before submission, but the specified command only runs the JS linter.

I think it would be useful to list the Solidity linter command as well for completeness. 