### PR TITLE
Fix typo: "an uint256" -> "a uint256"

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -34,7 +34,7 @@ contract ERC20 is IERC20 {
     /**
      * @dev Gets the balance of the specified address.
      * @param owner The address to query the balance of.
-     * @return An uint256 representing the amount owned by the passed address.
+     * @return A uint256 representing the amount owned by the passed address.
      */
     function balanceOf(address owner) public view returns (uint256) {
         return _balances[owner];


### PR DESCRIPTION
Using "a" instead of "an" makes this consistent with the comment on `allowance`.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
