### PR TITLE
Add guard to ERC20Migrator migrate function

### DIFF
--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -82,6 +82,7 @@ contract ERC20Migrator {
      * @param amount amount of tokens to be migrated
      */
     function migrate(address account, uint256 amount) public {
+        require(address(_newToken) != address(0));
         _legacyToken.safeTransferFrom(account, address(this), amount);
         _newToken.mint(account, amount);
     }

--- a/test/drafts/ERC20Migrator.test.js
+++ b/test/drafts/ERC20Migrator.test.js
@@ -44,7 +44,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
       });
     });
 
-    describe('before migration', function () {
+    context('before starting the migration', function () {
       it('returns the zero address for the new token', async function () {
         (await this.migrator.newToken()).should.be.equal(ZERO_ADDRESS);
       });

--- a/test/drafts/ERC20Migrator.test.js
+++ b/test/drafts/ERC20Migrator.test.js
@@ -44,6 +44,40 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
       });
     });
 
+    describe('before migration', function () {
+      it('returns the zero address for the new token', async function () {
+        (await this.migrator.newToken()).should.be.equal(ZERO_ADDRESS);
+      });
+
+      describe('migrateAll', function () {
+        const amount = totalSupply;
+
+        describe('when the approved balance is equal to the owned balance', function () {
+          beforeEach('approving the whole balance to the new contract', async function () {
+            await this.legacyToken.approve(this.migrator.address, amount, { from: owner });
+          });
+
+          it('reverts', async function () {
+            await shouldFail.reverting(this.migrator.migrateAll(owner));
+          });
+        });
+      });
+
+      describe('migrate', function () {
+        const amount = new BN(50);
+
+        describe('when the amount is equal to the approved value', function () {
+          beforeEach('approving tokens to the new contract', async function () {
+            await this.legacyToken.approve(this.migrator.address, amount, { from: owner });
+          });
+
+          it('reverts', async function () {
+            await shouldFail.reverting(this.migrator.migrate(owner, amount));
+          });
+        });
+      });
+    });
+
     describe('once migration began', function () {
       beforeEach('beginning migration', async function () {
         await this.newToken.addMinter(this.migrator.address);


### PR DESCRIPTION
Fixes #1656

This PR adds a guard condition to the `migrate` function of the `ERC20Migrator` contract that confirms the new token contract has previously been set ( with `beginMigration` ).

This does not change any functionality since the function would fail anyway. It just makes the reason for failure explicit. 