### PR TITLE
Improve test script.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -41,10 +41,12 @@ start_ganache() {
   if [ "$SOLIDITY_COVERAGE" = true ]; then
     node_modules/.bin/testrpc-sc --gasLimit 0xfffffffffff --port "$ganache_port" "${accounts[@]}" > /dev/null &
   else
-    node_modules/.bin/ganache-cli --gasLimit 0xfffffffffff "${accounts[@]}" > /dev/null &
+    node_modules/.bin/ganache-cli --gasLimit 0xfffffffffff --port "$ganache_port" "${accounts[@]}" > /dev/null &
   fi
 
   ganache_pid=$!
+
+  sleep 1
 }
 
 if ganache_running; then


### PR DESCRIPTION
`ganache-cli` was sometimes too slow and truffle failed to connect to it, so adding a small delay prevents that. We also shouldn't rely on the default port values and pass them explicitly.