### PR TITLE
SafeMath to use Outvars Again

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -8,7 +8,7 @@ library SafeMath {
     /**
      * @dev Multiplies two unsigned integers, reverts on overflow.
      */
-    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    function mul(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
         // benefit is lost if 'b' is also tested.
         // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
@@ -16,42 +16,34 @@ library SafeMath {
             return 0;
         }
 
-        uint256 c = a * b;
+        c = a * b;
         require(c / a == b);
-
-        return c;
     }
 
     /**
      * @dev Integer division of two unsigned integers truncating the quotient, reverts on division by zero.
      */
-    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    function div(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // Solidity only automatically asserts when dividing by 0
         require(b > 0);
-        uint256 c = a / b;
+        c = a / b;
         // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-
-        return c;
     }
 
     /**
      * @dev Subtracts two unsigned integers, reverts on overflow (i.e. if subtrahend is greater than minuend).
      */
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    function sub(uint256 a, uint256 b) internal pure returns (uint256 c) {
         require(b <= a);
-        uint256 c = a - b;
-
-        return c;
+        c = a - b;
     }
 
     /**
      * @dev Adds two unsigned integers, reverts on overflow.
      */
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a + b;
+    function add(uint256 a, uint256 b) internal pure returns (uint256 c) {
+        c = a + b;
         require(c >= a);
-
-        return c;
     }
 
     /**


### PR DESCRIPTION

#### Changes
I measured a regression in add and sub when updating SafeMath from openzeppelin-solidity version 1.9.0 to 2.0.1.
The regression went away when I reverted the outvar change and made `c` an outvar again.
The regression was measured on solc 0.4.24 for an upcoming TrustToken smart contract, and seemed to amount to 5 gas per call.
This patches the regression by switching back to outvars.
Reviewers @frangio @nventuro