### PR TITLE
update compiler to 0.5.6 and truffle to 5.0.8

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Roles

--- a/contracts/access/roles/CapperRole.sol
+++ b/contracts/access/roles/CapperRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/MinterRole.sol
+++ b/contracts/access/roles/MinterRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/PauserRole.sol
+++ b/contracts/access/roles/PauserRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/SignerRole.sol
+++ b/contracts/access/roles/SignerRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelistAdminRole.sol
+++ b/contracts/access/roles/WhitelistAdminRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 

--- a/contracts/access/roles/WhitelistedRole.sol
+++ b/contracts/access/roles/WhitelistedRole.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Roles.sol";
 import "./WhitelistAdminRole.sol";

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "../validation/TimedCrowdsale.sol";

--- a/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/PostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "./FinalizableCrowdsale.sol";

--- a/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./RefundableCrowdsale.sol";
 import "./PostDeliveryCrowdsale.sol";

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/IERC20.sol";

--- a/contracts/crowdsale/emission/MintedCrowdsale.sol
+++ b/contracts/crowdsale/emission/MintedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Crowdsale.sol";
 import "../../token/ERC20/ERC20Mintable.sol";

--- a/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
+++ b/contracts/crowdsale/price/IncreasingPriceCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../validation/TimedCrowdsale.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/crowdsale/validation/CappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/CappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/PausableCrowdsale.sol
+++ b/contracts/crowdsale/validation/PausableCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../Crowdsale.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";

--- a/contracts/crowdsale/validation/WhitelistCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 import "../Crowdsale.sol";
 import "../../access/roles/WhitelistedRole.sol";
 

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Elliptic curve signature operations

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title MerkleProof

--- a/contracts/drafts/Counters.sol
+++ b/contracts/drafts/Counters.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/drafts/ERC1046/ERC20Metadata.sol
+++ b/contracts/drafts/ERC1046/ERC20Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../token/ERC20/IERC20.sol";
 

--- a/contracts/drafts/ERC20Migrator.sol
+++ b/contracts/drafts/ERC20Migrator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/ERC20Mintable.sol";

--- a/contracts/drafts/ERC20Snapshot.sol
+++ b/contracts/drafts/ERC20Snapshot.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/SafeMath.sol";
 import "../utils/Arrays.sol";

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/SignerRole.sol";
 import "../cryptography/ECDSA.sol";

--- a/contracts/drafts/SignedSafeMath.sol
+++ b/contracts/drafts/SignedSafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title SignedSafeMath

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/SafeERC20.sol";
 import "../ownership/Ownable.sol";

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../crowdsale/validation/CappedCrowdsale.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC165.sol";
 

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title ERC165Checker

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title IERC165

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Math

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title SafeMath

--- a/contracts/mocks/Acknowledger.sol
+++ b/contracts/mocks/Acknowledger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 contract Acknowledger {
     event AcknowledgeFoo(uint256 a);

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../utils/Address.sol";
 

--- a/contracts/mocks/AllowanceCrowdsaleImpl.sol
+++ b/contracts/mocks/AllowanceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/emission/AllowanceCrowdsale.sol";

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../utils/Arrays.sol";
 

--- a/contracts/mocks/CappedCrowdsaleImpl.sol
+++ b/contracts/mocks/CappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/CappedCrowdsale.sol";

--- a/contracts/mocks/CapperRoleMock.sol
+++ b/contracts/mocks/CapperRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/CapperRole.sol";
 

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../payment/escrow/ConditionalEscrow.sol";
 

--- a/contracts/mocks/CountersImpl.sol
+++ b/contracts/mocks/CountersImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../drafts/Counters.sol";
 

--- a/contracts/mocks/CrowdsaleMock.sol
+++ b/contracts/mocks/CrowdsaleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../crowdsale/Crowdsale.sol";
 

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../cryptography/ECDSA.sol";
 

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 contract ERC165NotSupported {
     // solhint-disable-previous-line no-empty-blocks

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../introspection/ERC165Checker.sol";
 

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../introspection/ERC165.sol";
 

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20Burnable.sol";
 

--- a/contracts/mocks/ERC20DetailedMock.sol
+++ b/contracts/mocks/ERC20DetailedMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20.sol";
 import "../token/ERC20/ERC20Detailed.sol";

--- a/contracts/mocks/ERC20MetadataMock.sol
+++ b/contracts/mocks/ERC20MetadataMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20.sol";
 import "../drafts/ERC1046/ERC20Metadata.sol";

--- a/contracts/mocks/ERC20MintableMock.sol
+++ b/contracts/mocks/ERC20MintableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "./MinterRoleMock.sol";

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC20SnapshotMock.sol
+++ b/contracts/mocks/ERC20SnapshotMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../drafts/ERC20Snapshot.sol";
 

--- a/contracts/mocks/ERC721FullMock.sol
+++ b/contracts/mocks/ERC721FullMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721MintableBurnableImpl.sol
+++ b/contracts/mocks/ERC721MintableBurnableImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC721/ERC721Full.sol";
 import "../token/ERC721/ERC721Mintable.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC721/ERC721Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/EventEmitter.sol
+++ b/contracts/mocks/EventEmitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 contract EventEmitter {
     event Argumentless();

--- a/contracts/mocks/Failer.sol
+++ b/contracts/mocks/Failer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 contract Failer {
     uint256[] private array;

--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/FinalizableCrowdsale.sol";

--- a/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
+++ b/contracts/mocks/IncreasingPriceCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../crowdsale/price/IncreasingPriceCrowdsale.sol";
 import "../math/SafeMath.sol";

--- a/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
+++ b/contracts/mocks/IndividuallyCappedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/IndividuallyCappedCrowdsale.sol";

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/Math.sol";
 

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";
 

--- a/contracts/mocks/MintedCrowdsaleImpl.sol
+++ b/contracts/mocks/MintedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20Mintable.sol";
 import "../crowdsale/emission/MintedCrowdsale.sol";

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/MinterRole.sol";
 

--- a/contracts/mocks/OwnableInterfaceId.sol
+++ b/contracts/mocks/OwnableInterfaceId.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../ownership/Ownable.sol";
 

--- a/contracts/mocks/PausableCrowdsaleImpl.sol
+++ b/contracts/mocks/PausableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/ERC20.sol";
 import "../crowdsale/validation/PausableCrowdsale.sol";

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../lifecycle/Pausable.sol";
 import "./PauserRoleMock.sol";

--- a/contracts/mocks/PauserRoleMock.sol
+++ b/contracts/mocks/PauserRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/PauserRole.sol";
 

--- a/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/PostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/PostDeliveryCrowdsale.sol";

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../payment/PullPayment.sol";
 

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 contract ReentrancyAttack {
     function callSender(bytes4 data) public {

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../utils/ReentrancyGuard.sol";
 import "./ReentrancyAttack.sol";

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundableCrowdsale.sol";

--- a/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundablePostDeliveryCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/distribution/RefundablePostDeliveryCrowdsale.sol";

--- a/contracts/mocks/RolesMock.sol
+++ b/contracts/mocks/RolesMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/Roles.sol";
 

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../token/ERC20/SafeERC20.sol";

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/mocks/SecondaryMock.sol
+++ b/contracts/mocks/SecondaryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../ownership/Secondary.sol";
 

--- a/contracts/mocks/SignatureBouncerMock.sol
+++ b/contracts/mocks/SignatureBouncerMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../drafts/SignatureBouncer.sol";
 import "./SignerRoleMock.sol";

--- a/contracts/mocks/SignedSafeMathMock.sol
+++ b/contracts/mocks/SignedSafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../drafts/SignedSafeMath.sol";
 

--- a/contracts/mocks/SignerRoleMock.sol
+++ b/contracts/mocks/SignerRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/SignerRole.sol";
 

--- a/contracts/mocks/TimedCrowdsaleImpl.sol
+++ b/contracts/mocks/TimedCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/TimedCrowdsale.sol";

--- a/contracts/mocks/WhitelistAdminRoleMock.sol
+++ b/contracts/mocks/WhitelistAdminRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/WhitelistAdminRole.sol";
 

--- a/contracts/mocks/WhitelistCrowdsaleImpl.sol
+++ b/contracts/mocks/WhitelistCrowdsaleImpl.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../token/ERC20/IERC20.sol";
 import "../crowdsale/validation/WhitelistCrowdsale.sol";

--- a/contracts/mocks/WhitelistedRoleMock.sol
+++ b/contracts/mocks/WhitelistedRoleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../access/roles/WhitelistedRole.sol";
 

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Ownable

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Secondary

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/SafeMath.sol";
 

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./escrow/Escrow.sol";
 

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./Escrow.sol";
 

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../math/SafeMath.sol";
 import "../../ownership/Secondary.sol";

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ConditionalEscrow.sol";
 

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC20Mintable.sol";
 

--- a/contracts/token/ERC20/ERC20Detailed.sol
+++ b/contracts/token/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC20.sol";
 

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC20.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC20.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title ERC20 interface

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./SafeERC20.sol";
 

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721.sol";
 import "./IERC721Receiver.sol";

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721.sol";
 

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721Enumerable.sol";
 import "./ERC721.sol";

--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721.sol";
 import "./ERC721Enumerable.sol";

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721Receiver.sol";
 

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721.sol";
 import "./IERC721Metadata.sol";

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721Metadata.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721.sol";
 import "../../access/roles/MinterRole.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./ERC721.sol";
 import "../../lifecycle/Pausable.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../../introspection/IERC165.sol";
 

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Full.sol
+++ b/contracts/token/ERC721/IERC721Full.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721.sol";
 import "./IERC721Enumerable.sol";

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "./IERC721.sol";
 

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title ERC721 token receiver interface

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * Utility library of inline functions on addresses

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 import "../math/Math.sol";
 

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.5.6;
 
 /**
  * @title Helps contracts guard against reentrancy attacks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openzeppelin-solidity",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,9 +34,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -340,6 +340,23 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -531,6 +548,47 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "lodash.get": "^4.4.2",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
     },
     "coveralls": {
       "version": "3.0.1",
@@ -738,8 +796,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
@@ -1147,25 +1204,6 @@
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
-    "esprima-extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
-      "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
@@ -1297,17 +1335,6 @@
         "tmp": "^0.0.33"
       }
     },
-    "extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
-      "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "esprima-extract-comments": "^1.1.0",
-        "parse-code-context": "^1.0.0"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1379,6 +1406,12 @@
         "write": "^0.2.1"
       }
     },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1398,7 +1431,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
@@ -1494,6 +1527,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "globals": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "dev": true
     },
     "globby": {
       "version": "5.0.0",
@@ -1658,6 +1697,33 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "caller-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+          "dev": true,
+          "requires": {
+            "caller-callsite": "^2.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1796,6 +1862,12 @@
       "requires": {
         "builtin-modules": "^1.0.0"
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -1971,6 +2043,12 @@
       "dev": true,
       "optional": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1997,7 +2075,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -2121,6 +2199,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-driver": {
@@ -2289,9 +2373,9 @@
       "dev": true
     },
     "nice-try": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "nopt": {
@@ -2479,12 +2563,22 @@
         "p-limit": "^1.1.0"
       }
     },
-    "parse-code-context": {
+    "parent-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
-      "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+          "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+          "dev": true
+        }
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -2608,72 +2702,11 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
       "dev": true,
       "optional": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
-    },
-    "prettier-plugin-solidity": {
-      "version": "1.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.12.tgz",
-      "integrity": "sha512-H5SqMHv1jttrm8h8JwVIm+f3BAXLGvqgxfXioUfPl7x0Rw+3KZaQ53bW2DBpJG7NefJxnUKq5dZrWZkclqp9AA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "emoji-regex": "^7.0.1",
-        "escape-string-regexp": "^1.0.5",
-        "extract-comments": "^1.1.0",
-        "prettier": "^1.15.2",
-        "solidity-parser-antlr": "^0.3.1",
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -2921,6 +2954,15 @@
         "rx-lite": "*"
       }
     },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -3131,7 +3173,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -3161,27 +3203,28 @@
       }
     },
     "solhint": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-1.5.0.tgz",
-      "integrity": "sha512-D4vmV9hlBRcBEdCap6kHUKtBOjKJbC6JhvsoGrcTKW6+WHRDkbpif35R1Enzd0+OvvIC2UReMwK85dSqrqUSoQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-2.0.0.tgz",
+      "integrity": "sha512-K1QW6an/MSYEsR4KfM07xu1kIsV7WroH5fLosP+KMN76hoVHqYDrRr7rFEkjX63HGxYHqS7tzGcE2veIVINKyw==",
       "dev": true,
       "requires": {
+        "ajv": "^6.6.1",
         "antlr4": "4.7.1",
         "commander": "2.18.0",
+        "cosmiconfig": "^5.0.7",
         "eslint": "^5.6.0",
         "fast-diff": "^1.1.2",
-        "glob": "7.1.3",
+        "glob": "^7.1.3",
         "ignore": "^4.0.6",
+        "js-yaml": "^3.12.0",
         "lodash": "^4.17.11",
-        "prettier": "^1.14.3",
-        "prettier-linter-helpers": "^1.0.0",
-        "prettier-plugin-solidity": "^1.0.0-alpha.4"
+        "prettier": "^1.14.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         },
         "acorn-jsx": {
@@ -3191,9 +3234,9 @@
           "dev": true
         },
         "ajv": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -3201,6 +3244,12 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -3218,9 +3267,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -3262,55 +3311,63 @@
             "ms": "^2.1.1"
           }
         },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
         "eslint": {
-          "version": "5.11.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.11.0.tgz",
-          "integrity": "sha512-gbEg0ttToZPkZUv2yYjpipxuYrv/9aSSmgM4V6GkiO3u04QosHYBtduUCqLEulEg3YvNDAkk3OWzyQJ/heZ3Nw==",
+          "version": "5.15.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+          "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.5.3",
+            "ajv": "^6.9.1",
             "chalk": "^2.1.0",
             "cross-spawn": "^6.0.5",
             "debug": "^4.0.1",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^4.0.0",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^4.0.2",
             "eslint-utils": "^1.3.1",
             "eslint-visitor-keys": "^1.0.0",
-            "espree": "^5.0.0",
+            "espree": "^5.0.1",
             "esquery": "^1.0.1",
             "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
+            "file-entry-cache": "^5.0.1",
             "functional-red-black-tree": "^1.0.1",
             "glob": "^7.1.2",
             "globals": "^11.7.0",
             "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
             "imurmurhash": "^0.1.4",
-            "inquirer": "^6.1.0",
+            "inquirer": "^6.2.2",
             "js-yaml": "^3.12.0",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.3.0",
-            "lodash": "^4.17.5",
+            "lodash": "^4.17.11",
             "minimatch": "^3.0.4",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
             "optionator": "^0.8.2",
             "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
             "progress": "^2.0.0",
             "regexpp": "^2.0.1",
-            "require-uncached": "^1.0.3",
             "semver": "^5.5.1",
             "strip-ansi": "^4.0.0",
             "strip-json-comments": "^2.0.1",
-            "table": "^5.0.2",
+            "table": "^5.2.3",
             "text-table": "^0.2.0"
           }
         },
         "eslint-scope": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+          "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -3318,12 +3375,12 @@
           }
         },
         "espree": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-          "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+          "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
           "dev": true,
           "requires": {
-            "acorn": "^6.0.2",
+            "acorn": "^6.0.7",
             "acorn-jsx": "^5.0.0",
             "eslint-visitor-keys": "^1.0.0"
           }
@@ -3351,6 +3408,26 @@
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+          "dev": true,
+          "requires": {
+            "flatted": "^2.0.0",
+            "rimraf": "2.6.3",
+            "write": "1.0.3"
+          }
+        },
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -3364,12 +3441,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "globals": {
-          "version": "11.9.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-          "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
-          "dev": true
         },
         "iconv-lite": {
           "version": "0.4.24",
@@ -3386,40 +3457,50 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "inquirer": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+        "import-fresh": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+          "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
             "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
+            "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.10",
+            "lodash": "^4.17.11",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
+            "rxjs": "^6.4.0",
             "string-width": "^2.1.0",
             "strip-ansi": "^5.0.0",
             "through": "^2.3.6"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-              "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "strip-ansi": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-              "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+              "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.0.0"
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -3431,9 +3512,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.12.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -3458,13 +3539,19 @@
           "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
           "dev": true
         },
-        "rxjs": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-          "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "tslib": "^1.9.0"
+            "glob": "^7.1.3"
           }
         },
         "semver": {
@@ -3474,9 +3561,9 @@
           "dev": true
         },
         "slice-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-          "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -3513,15 +3600,52 @@
           }
         },
         "table": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
-          "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+          "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
           "dev": true,
           "requires": {
-            "ajv": "^6.6.1",
+            "ajv": "^6.9.1",
             "lodash": "^4.17.11",
-            "slice-ansi": "2.0.0",
-            "string-width": "^2.1.1"
+            "slice-ansi": "^2.1.0",
+            "string-width": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+              "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "write": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
           }
         }
       }
@@ -3542,13 +3666,6 @@
         "tree-kill": "^1.2.0",
         "web3": "^0.20.6"
       }
-    },
-    "solidity-parser-antlr": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.3.3.tgz",
-      "integrity": "sha512-RNUc18pjf7DLWs//WF+V+VnvrbetEbNFUYxm2JFbXU62G9WSu+nVyDxV5r+FG4wu8jom17vLdM/3I7bMBGfZ9g==",
-      "dev": true,
-      "optional": true
     },
     "solidity-parser-sc": {
       "version": "github:maxsam4/solidity-parser#8c93bc23aeb55e6c858ab4f79ef8cf8966034444",
@@ -3798,9 +3915,9 @@
       "dev": true
     },
     "truffle": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.0.tgz",
-      "integrity": "sha512-la0TJu+E59Ut62i6cGY0sugeubglDqH5w49a7IrpxZ1nnsDqv6qWB3ibiyYiCp/jr+iI0bLtcr3DKkfQjVDd+g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.8.tgz",
+      "integrity": "sha512-8Sf9GKD6Y99fcHDYQCE9hRxYWm+rpptye4Ez08G8OsaCSsbEqRzyCZf18FdLLL3iWYJZ9S+tA1P0YZVxGDQ2nw==",
       "dev": true,
       "requires": {
         "app-module-path": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzeppelin-solidity",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Secure Smart Contract library for Solidity",
   "files": [
     "build",
@@ -54,9 +54,9 @@
     "ganache-cli": "6.1.8",
     "openzeppelin-test-helpers": "^0.1.1",
     "pify": "^4.0.1",
-    "solhint": "^1.5.0",
+    "solhint": "^2.0.0",
     "solidity-coverage": "https://github.com:rotcivegaf/solidity-coverage.git#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
-    "truffle": "^5.0.0"
+    "truffle": "^5.0.8"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzeppelin-solidity",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "Secure Smart Contract library for Solidity",
   "files": [
     "build",
@@ -54,7 +54,7 @@
     "ganache-cli": "6.1.8",
     "openzeppelin-test-helpers": "^0.1.1",
     "pify": "^4.0.1",
-    "solhint": "^2.0.0",
+    "solhint": "^1.5.0",
     "solidity-coverage": "https://github.com:rotcivegaf/solidity-coverage.git#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
     "truffle": "^5.0.8"
   },

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ module.exports = {
 
   compilers: {
     solc: {
-      version: '0.5.2',
+      version: '0.5.6',
     },
   },
 };


### PR DESCRIPTION
I was not able to use the latest solc 0.5.6 / truffle 5.0.8 with OpenZeppelin 2.2.0,
I've updated truffle, solc, and all tests are green.


