### PR TITLE
Exclude on-hold PRs and issues on stalebot.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,8 @@ daysUntilStale: 30
 daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+exemptLabels:
+  - on-hold
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
We're now tagging some PRs and issues on-hold for the next major release (due to API breakage), this will prevent the bot from closing them.