### PR TITLE
Added basic punctuation to @dev docs (#1697)

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -10,7 +10,7 @@ library Roles {
     }
 
     /**
-     * @dev give an account access to this role
+     * @dev Give an account access to this role.
      */
     function add(Role storage role, address account) internal {
         require(account != address(0));
@@ -20,7 +20,7 @@ library Roles {
     }
 
     /**
-     * @dev remove an account's access to this role
+     * @dev Remove an account's access to this role.
      */
     function remove(Role storage role, address account) internal {
         require(account != address(0));
@@ -30,7 +30,7 @@ library Roles {
     }
 
     /**
-     * @dev check if an account has this role
+     * @dev Check if an account has this role.
      * @return bool
      */
     function has(Role storage role, address account) internal view returns (bool) {

--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -41,7 +41,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
     }
 
     /**
-     * @dev Investors can claim refunds here if crowdsale is unsuccessful
+     * @dev Investors can claim refunds here if crowdsale is unsuccessful.
      * @param refundee Whose refund will be claimed.
      */
     function claimRefund(address payable refundee) public {
@@ -60,7 +60,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
     }
 
     /**
-     * @dev escrow finalization task, called when finalize() is called
+     * @dev Escrow finalization task, called when finalize() is called.
      */
     function _finalization() internal {
         if (goalReached()) {

--- a/contracts/crowdsale/emission/AllowanceCrowdsale.sol
+++ b/contracts/crowdsale/emission/AllowanceCrowdsale.sol
@@ -18,7 +18,7 @@ contract AllowanceCrowdsale is Crowdsale {
 
     /**
      * @dev Constructor, takes token wallet address.
-     * @param tokenWallet Address holding the tokens, which has approved allowance to the crowdsale
+     * @param tokenWallet Address holding the tokens, which has approved allowance to the crowdsale.
      */
     constructor (address tokenWallet) public {
         require(tokenWallet != address(0));

--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -52,7 +52,7 @@ contract IndividuallyCappedCrowdsale is Crowdsale, CapperRole {
     }
 
     /**
-     * @dev Extend parent behavior to update beneficiary contributions
+     * @dev Extend parent behavior to update beneficiary contributions.
      * @param beneficiary Token purchaser
      * @param weiAmount Amount of wei contributed
      */

--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -74,7 +74,7 @@ contract TimedCrowdsale is Crowdsale {
     }
 
     /**
-     * @dev Extend parent behavior requiring to be within contributing period
+     * @dev Extend parent behavior requiring to be within contributing period.
      * @param beneficiary Token purchaser
      * @param weiAmount Amount of wei contributed
      */
@@ -83,7 +83,7 @@ contract TimedCrowdsale is Crowdsale {
     }
 
     /**
-     * @dev Extend crowdsale
+     * @dev Extend crowdsale.
      * @param newClosingTime Crowdsale closing time
      */
     function _extendTime(uint256 newClosingTime) internal {

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.5.2;
 
 library ECDSA {
     /**
-     * @dev Recover signer address from a message by using their signature
+     * @dev Recover signer address from a message by using their signature.
      * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
      * @param signature bytes signature, the signature is generated using web3.eth.sign()
      */
@@ -57,7 +57,7 @@ library ECDSA {
     /**
      * toEthSignedMessageHash
      * @dev prefix a bytes32 value with "\x19Ethereum Signed Message:"
-     * and hash the result
+     * and hash the result.
      */
     function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
         // 32 is the length in bytes of hash,

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -56,7 +56,7 @@ library ECDSA {
 
     /**
      * toEthSignedMessageHash
-     * @dev prefix a bytes32 value with "\x19Ethereum Signed Message:"
+     * @dev Prefix a bytes32 value with "\x19Ethereum Signed Message:"
      * and hash the result.
      */
     function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {

--- a/contracts/drafts/Counters.sol
+++ b/contracts/drafts/Counters.sol
@@ -6,7 +6,7 @@ import "../math/SafeMath.sol";
  * @title Counters
  * @author Matt Condon (@shrugs)
  * @dev Provides counters that can only be incremented or decremented by one. This can be used e.g. to track the number
- * of elements in a mapping, issuing ERC721 ids, or counting request ids
+ * of elements in a mapping, issuing ERC721 ids, or counting request ids.
  *
  * Include with `using Counters for Counters.Counter;`
  * Since it is not possible to overflow a 256 bit integer with increments of one, `increment` can skip the SafeMath

--- a/contracts/drafts/SignatureBouncer.sol
+++ b/contracts/drafts/SignatureBouncer.sol
@@ -48,7 +48,7 @@ contract SignatureBouncer is SignerRole {
     }
 
     /**
-     * @dev requires that a valid signature of a signer was provided
+     * @dev Requires that a valid signature of a signer was provided.
      */
     modifier onlyValidSignature(bytes memory signature) {
         require(_isValidSignature(msg.sender, signature));
@@ -56,7 +56,7 @@ contract SignatureBouncer is SignerRole {
     }
 
     /**
-     * @dev requires that a valid signature with a specified method of a signer was provided
+     * @dev Requires that a valid signature with a specified method of a signer was provided.
      */
     modifier onlyValidSignatureAndMethod(bytes memory signature) {
         require(_isValidSignatureAndMethod(msg.sender, signature));
@@ -64,7 +64,7 @@ contract SignatureBouncer is SignerRole {
     }
 
     /**
-     * @dev requires that a valid signature with a specified method and params of a signer was provided
+     * @dev Requires that a valid signature with a specified method and params of a signer was provided.
      */
     modifier onlyValidSignatureAndData(bytes memory signature) {
         require(_isValidSignatureAndData(msg.sender, signature));
@@ -108,8 +108,8 @@ contract SignatureBouncer is SignerRole {
     }
 
     /**
-     * @dev internal function to convert a hash to an eth signed message
-     * and then recover the signature and check it against the signer role
+     * @dev Internal function to convert a hash to an eth signed message
+     * and then recover the signature and check it against the signer role.
      * @return bool
      */
     function _isValidDataHash(bytes32 hash, bytes memory signature) internal view returns (bool) {

--- a/contracts/drafts/SignedSafeMath.sol
+++ b/contracts/drafts/SignedSafeMath.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.2;
 
 /**
  * @title SignedSafeMath
- * @dev Signed math operations with safety checks that revert on error
+ * @dev Signed math operations with safety checks that revert on error.
  */
 library SignedSafeMath {
     int256 constant private INT256_MIN = -2**255;

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -15,27 +15,27 @@ contract ERC165 is IERC165 {
      */
 
     /**
-     * @dev a mapping of interface id to whether or not it's supported
+     * @dev Mapping of interface ids to whether or not it's supported.
      */
     mapping(bytes4 => bool) private _supportedInterfaces;
 
     /**
      * @dev A contract implementing SupportsInterfaceWithLookup
-     * implement ERC165 itself
+     * implements ERC165 itself.
      */
     constructor () internal {
         _registerInterface(_INTERFACE_ID_ERC165);
     }
 
     /**
-     * @dev implement supportsInterface(bytes4) using a lookup table
+     * @dev Implement supportsInterface(bytes4) using a lookup table.
      */
     function supportsInterface(bytes4 interfaceId) external view returns (bool) {
         return _supportedInterfaces[interfaceId];
     }
 
     /**
-     * @dev internal method for registering an interface
+     * @dev Internal method for registering an interface.
      */
     function _registerInterface(bytes4 interfaceId) internal {
         require(interfaceId != 0xffffffff);

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -17,7 +17,7 @@ contract Pausable is PauserRole {
     }
 
     /**
-     * @return true if the contract is paused, false otherwise.
+     * @return True if the contract is paused, false otherwise.
      */
     function paused() public view returns (bool) {
         return _paused;
@@ -40,7 +40,7 @@ contract Pausable is PauserRole {
     }
 
     /**
-     * @dev called by the owner to pause, triggers stopped state
+     * @dev Called by a pauser to pause, triggers stopped state.
      */
     function pause() public onlyPauser whenNotPaused {
         _paused = true;
@@ -48,7 +48,7 @@ contract Pausable is PauserRole {
     }
 
     /**
-     * @dev called by the owner to unpause, returns to normal state
+     * @dev Called by a pauser to unpause, returns to normal state.
      */
     function unpause() public onlyPauser whenPaused {
         _paused = false;

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.2;
 
 /**
  * @title Math
- * @dev Assorted math operations
+ * @dev Assorted math operations.
  */
 library Math {
     /**

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.2;
 
 /**
  * @title SafeMath
- * @dev Unsigned math operations with safety checks that revert on error
+ * @dev Unsigned math operations with safety checks that revert on error.
  */
 library SafeMath {
     /**

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -20,27 +20,27 @@ contract SupportsInterfaceWithLookupMock is IERC165 {
      */
 
     /**
-     * @dev a mapping of interface id to whether or not it's supported
+     * @dev A mapping of interface id to whether or not it's supported.
      */
     mapping(bytes4 => bool) private _supportedInterfaces;
 
     /**
      * @dev A contract implementing SupportsInterfaceWithLookup
-     * implement ERC165 itself
+     * implement ERC165 itself.
      */
     constructor () public {
         _registerInterface(INTERFACE_ID_ERC165);
     }
 
     /**
-     * @dev implement supportsInterface(bytes4) using a lookup table
+     * @dev Implement supportsInterface(bytes4) using a lookup table.
      */
     function supportsInterface(bytes4 interfaceId) external view returns (bool) {
         return _supportedInterfaces[interfaceId];
     }
 
     /**
-     * @dev private method for registering an interface
+     * @dev Private method for registering an interface.
      */
     function _registerInterface(bytes4 interfaceId) internal {
         require(interfaceId != 0xffffffff);

--- a/contracts/ownership/Secondary.sol
+++ b/contracts/ownership/Secondary.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.2;
 
 /**
  * @title Secondary
- * @dev A Secondary contract can only be used by its primary account (the one that created it)
+ * @dev A Secondary contract can only be used by its primary account (the one that created it).
  */
 contract Secondary {
     address private _primary;

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -22,7 +22,7 @@ contract PaymentSplitter {
     address[] private _payees;
 
     /**
-     * @dev Constructor
+     * @dev Constructor.
      */
     constructor (address[] memory payees, uint256[] memory shares) public payable {
         require(payees.length == shares.length);
@@ -34,7 +34,7 @@ contract PaymentSplitter {
     }
 
     /**
-     * @dev payable fallback
+     * @dev Payable fallback.
      */
     function () external payable {
         emit PaymentReceived(msg.sender, msg.value);

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -33,14 +33,14 @@ contract RefundEscrow is ConditionalEscrow {
     }
 
     /**
-     * @return the current state of the escrow.
+     * @return The current state of the escrow.
      */
     function state() public view returns (State) {
         return _state;
     }
 
     /**
-     * @return the beneficiary of the escrow.
+     * @return The beneficiary of the escrow.
      */
     function beneficiary() public view returns (address) {
         return _beneficiary;

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -25,7 +25,7 @@ contract ERC20 is IERC20 {
     uint256 private _totalSupply;
 
     /**
-     * @dev Total number of tokens in existence
+     * @dev Total number of tokens in existence.
      */
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
@@ -51,7 +51,7 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev Transfer token to a specified address
+     * @dev Transfer token to a specified address.
      * @param to The address to transfer to.
      * @param value The amount to be transferred.
      */
@@ -119,7 +119,7 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev Transfer token for a specified addresses
+     * @dev Transfer token for a specified addresses.
      * @param from The address to transfer from.
      * @param to The address to transfer to.
      * @param value The amount to be transferred.

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -16,7 +16,7 @@ contract ERC20Burnable is ERC20 {
     }
 
     /**
-     * @dev Burns a specific amount of tokens from the target address and decrements allowance
+     * @dev Burns a specific amount of tokens from the target address and decrements allowance.
      * @param from address The account whose tokens will be burned.
      * @param value uint256 The amount of token to be burned.
      */

--- a/contracts/token/ERC20/ERC20Mintable.sol
+++ b/contracts/token/ERC20/ERC20Mintable.sol
@@ -5,7 +5,7 @@ import "../../access/roles/MinterRole.sol";
 
 /**
  * @title ERC20Mintable
- * @dev ERC20 minting logic
+ * @dev ERC20 minting logic.
  */
 contract ERC20Mintable is ERC20, MinterRole {
     /**

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -5,7 +5,7 @@ import "./SafeERC20.sol";
 /**
  * @title TokenTimelock
  * @dev TokenTimelock is a token holder contract that will allow a
- * beneficiary to extract the tokens after a given release time
+ * beneficiary to extract the tokens after a given release time.
  */
 contract TokenTimelock {
     using SafeERC20 for IERC20;

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -52,7 +52,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Gets the balance of the specified address
+     * @dev Gets the balance of the specified address.
      * @param owner address to query the balance of
      * @return uint256 representing the amount owned by the passed address
      */
@@ -62,7 +62,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Gets the owner of the specified token ID
+     * @dev Gets the owner of the specified token ID.
      * @param tokenId uint256 ID of the token to query the owner of
      * @return address currently marked as the owner of the given token ID
      */
@@ -102,7 +102,7 @@ contract ERC721 is ERC165, IERC721 {
 
     /**
      * @dev Sets or unsets the approval of a given operator
-     * An operator is allowed to transfer all tokens of the sender on their behalf
+     * An operator is allowed to transfer all tokens of the sender on their behalf.
      * @param to operator address to set the approval
      * @param approved representing the status of the approval to be set
      */
@@ -113,7 +113,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Tells whether an operator is approved by a given owner
+     * @dev Tells whether an operator is approved by a given owner.
      * @param owner owner address which you want to query the approval of
      * @param operator operator address which you want to query the approval of
      * @return bool whether the given operator is approved by the given owner
@@ -123,9 +123,9 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Transfers the ownership of a given token ID to another address
-     * Usage of this method is discouraged, use `safeTransferFrom` whenever possible
-     * Requires the msg.sender to be the owner, approved, or operator
+     * @dev Transfers the ownership of a given token ID to another address.
+     * Usage of this method is discouraged, use `safeTransferFrom` whenever possible.
+     * Requires the msg.sender to be the owner, approved, or operator.
      * @param from current owner of the token
      * @param to address to receive the ownership of the given token ID
      * @param tokenId uint256 ID of the token to be transferred
@@ -169,7 +169,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Returns whether the specified token exists
+     * @dev Returns whether the specified token exists.
      * @param tokenId uint256 ID of the token to query the existence of
      * @return bool whether the token exists
      */
@@ -179,7 +179,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Returns whether the given spender can transfer a given token ID
+     * @dev Returns whether the given spender can transfer a given token ID.
      * @param spender address of the spender to query
      * @param tokenId uint256 ID of the token to be transferred
      * @return bool whether the msg.sender is approved for the given token ID,
@@ -191,8 +191,8 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Internal function to mint a new token
-     * Reverts if the given token ID already exists
+     * @dev Internal function to mint a new token.
+     * Reverts if the given token ID already exists.
      * @param to The address that will own the minted token
      * @param tokenId uint256 ID of the token to be minted
      */
@@ -207,8 +207,8 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Internal function to burn a specific token
-     * Reverts if the token does not exist
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
      * Deprecated, use _burn(uint256) instead.
      * @param owner owner of the token to burn
      * @param tokenId uint256 ID of the token being burned
@@ -225,8 +225,8 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Internal function to burn a specific token
-     * Reverts if the token does not exist
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
      * @param tokenId uint256 ID of the token being burned
      */
     function _burn(uint256 tokenId) internal {
@@ -255,8 +255,8 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Internal function to invoke `onERC721Received` on a target address
-     * The call is not executed if the target address is not a contract
+     * @dev Internal function to invoke `onERC721Received` on a target address.
+     * The call is not executed if the target address is not a contract.
      * @param from address representing the previous owner of the given token ID
      * @param to target address that will receive the tokens
      * @param tokenId uint256 ID of the token to be transferred
@@ -275,7 +275,7 @@ contract ERC721 is ERC165, IERC721 {
     }
 
     /**
-     * @dev Private function to clear current approval of a given token ID
+     * @dev Private function to clear current approval of a given token ID.
      * @param tokenId uint256 ID of the token to be transferred
      */
     function _clearApproval(uint256 tokenId) private {

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -30,7 +30,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
      */
 
     /**
-     * @dev Constructor function
+     * @dev Constructor function.
      */
     constructor () public {
         // register the supported interface to conform to ERC721Enumerable via ERC165
@@ -38,7 +38,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     }
 
     /**
-     * @dev Gets the token ID at a given index of the tokens list of the requested owner
+     * @dev Gets the token ID at a given index of the tokens list of the requested owner.
      * @param owner address owning the tokens list to be accessed
      * @param index uint256 representing the index to be accessed of the requested tokens list
      * @return uint256 token ID at the given index of the tokens list owned by the requested address
@@ -49,7 +49,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     }
 
     /**
-     * @dev Gets the total amount of tokens stored by the contract
+     * @dev Gets the total amount of tokens stored by the contract.
      * @return uint256 representing the total amount of tokens
      */
     function totalSupply() public view returns (uint256) {
@@ -58,7 +58,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
 
     /**
      * @dev Gets the token ID at a given index of all the tokens in this contract
-     * Reverts if the index is greater or equal to the total number of tokens
+     * Reverts if the index is greater or equal to the total number of tokens.
      * @param index uint256 representing the index to be accessed of the tokens list
      * @return uint256 token ID at the given index of the tokens list
      */
@@ -83,8 +83,8 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     }
 
     /**
-     * @dev Internal function to mint a new token
-     * Reverts if the given token ID already exists
+     * @dev Internal function to mint a new token.
+     * Reverts if the given token ID already exists.
      * @param to address the beneficiary that will own the minted token
      * @param tokenId uint256 ID of the token to be minted
      */
@@ -97,9 +97,9 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     }
 
     /**
-     * @dev Internal function to burn a specific token
-     * Reverts if the token does not exist
-     * Deprecated, use _burn(uint256) instead
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
+     * Deprecated, use _burn(uint256) instead.
      * @param owner owner of the token to burn
      * @param tokenId uint256 ID of the token being burned
      */
@@ -114,7 +114,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     }
 
     /**
-     * @dev Gets the list of token IDs of the requested owner
+     * @dev Gets the list of token IDs of the requested owner.
      * @param owner address owning the tokens
      * @return uint256[] List of token IDs owned by the requested address
      */

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -34,7 +34,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Gets the token name
+     * @dev Gets the token name.
      * @return string representing the token name
      */
     function name() external view returns (string memory) {
@@ -42,7 +42,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Gets the token symbol
+     * @dev Gets the token symbol.
      * @return string representing the token symbol
      */
     function symbol() external view returns (string memory) {
@@ -50,7 +50,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Returns an URI for a given token ID
+     * @dev Returns an URI for a given token ID.
      * Throws if the token ID does not exist. May return an empty string.
      * @param tokenId uint256 ID of the token to query
      */
@@ -60,8 +60,8 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Internal function to set the token URI for a given token
-     * Reverts if the token ID does not exist
+     * @dev Internal function to set the token URI for a given token.
+     * Reverts if the token ID does not exist.
      * @param tokenId uint256 ID of the token to set its URI
      * @param uri string URI to assign
      */
@@ -71,9 +71,9 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     }
 
     /**
-     * @dev Internal function to burn a specific token
-     * Reverts if the token does not exist
-     * Deprecated, use _burn(uint256) instead
+     * @dev Internal function to burn a specific token.
+     * Reverts if the token does not exist.
+     * Deprecated, use _burn(uint256) instead.
      * @param owner owner of the token to burn
      * @param tokenId uint256 ID of the token being burned by the msg.sender
      */

--- a/contracts/token/ERC721/ERC721MetadataMintable.sol
+++ b/contracts/token/ERC721/ERC721MetadataMintable.sol
@@ -6,11 +6,11 @@ import "../../access/roles/MinterRole.sol";
 
 /**
  * @title ERC721MetadataMintable
- * @dev ERC721 minting logic with metadata
+ * @dev ERC721 minting logic with metadata.
  */
 contract ERC721MetadataMintable is ERC721, ERC721Metadata, MinterRole {
     /**
-     * @dev Function to mint tokens
+     * @dev Function to mint tokens.
      * @param to The address that will receive the minted tokens.
      * @param tokenId The token id to mint.
      * @param tokenURI The token URI of the minted token.

--- a/contracts/token/ERC721/ERC721Mintable.sol
+++ b/contracts/token/ERC721/ERC721Mintable.sol
@@ -5,11 +5,11 @@ import "../../access/roles/MinterRole.sol";
 
 /**
  * @title ERC721Mintable
- * @dev ERC721 minting logic
+ * @dev ERC721 minting logic.
  */
 contract ERC721Mintable is ERC721, MinterRole {
     /**
-     * @dev Function to mint tokens
+     * @dev Function to mint tokens.
      * @param to The address that will receive the minted tokens.
      * @param tokenId The token id to mint.
      * @return A boolean that indicates if the operation was successful.


### PR DESCRIPTION
Applies basic punctuation rules to @dev lines in the documentation and kept the changes to a minimum #1697