### PR TITLE
Fixes/Improves constants inline documentation.

### DIFF
--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -10,8 +10,7 @@ import "./IERC165.sol";
 contract ERC165 is IERC165 {
     bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
-     * 0x01ffc9a7 ===
-     *     bytes4(keccak256('supportsInterface(bytes4)'))
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
 
     /**

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -8,10 +8,10 @@ import "./IERC165.sol";
  * @dev Implements ERC165 using a lookup table.
  */
 contract ERC165 is IERC165 {
-    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
      * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
 
     /**
      * @dev Mapping of interface ids to whether or not it's supported.

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -11,8 +11,7 @@ library ERC165Checker {
 
     bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
-     * 0x01ffc9a7 ===
-     *     bytes4(keccak256('supportsInterface(bytes4)'))
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
 
     /**

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -9,10 +9,10 @@ library ERC165Checker {
     // As per the EIP-165 spec, no interface should ever match 0xffffffff
     bytes4 private constant _INTERFACE_ID_INVALID = 0xffffffff;
 
-    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
      * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
 
     /**
      * @notice Query if a contract supports ERC165

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -15,8 +15,7 @@ import "../../introspection/IERC165.sol";
 contract SupportsInterfaceWithLookupMock is IERC165 {
     bytes4 public constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
-     * 0x01ffc9a7 ===
-     *     bytes4(keccak256('supportsInterface(bytes4)'))
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
 
     /**

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -13,10 +13,10 @@ import "../../introspection/IERC165.sol";
  * solidity-coverage ignores the /mocks folder, so we duplicate its implementation here to avoid instrumenting it
  */
 contract SupportsInterfaceWithLookupMock is IERC165 {
-    bytes4 public constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
     /*
      * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
      */
+    bytes4 public constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
 
     /**
      * @dev A mapping of interface id to whether or not it's supported.

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -34,16 +34,17 @@ contract ERC721 is ERC165, IERC721 {
 
     bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
     /*
-     * 0x80ac58cd ===
-     *     bytes4(keccak256('balanceOf(address)')) ^
-     *     bytes4(keccak256('ownerOf(uint256)')) ^
-     *     bytes4(keccak256('approve(address,uint256)')) ^
-     *     bytes4(keccak256('getApproved(uint256)')) ^
-     *     bytes4(keccak256('setApprovalForAll(address,bool)')) ^
-     *     bytes4(keccak256('isApprovedForAll(address,address)')) ^
-     *     bytes4(keccak256('transferFrom(address,address,uint256)')) ^
-     *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) ^
-     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)'))
+     *     bytes4(keccak256('balanceOf(address)')) == 0x70a08231
+     *     bytes4(keccak256('ownerOf(uint256)')) == 0x6352211e
+     *     bytes4(keccak256('approve(address,uint256)')) == 0x095ea7b3
+     *     bytes4(keccak256('getApproved(uint256)')) == 0x081812fc
+     *     bytes4(keccak256('setApprovalForAll(address,bool)')) == 0xa22cb465
+     *     bytes4(keccak256('isApprovedForAll(address,address)')) == 0xe985e9c
+     *     bytes4(keccak256('transferFrom(address,address,uint256)')) == 0x23b872dd
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) == 0x42842e0e
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)')) == 0xb88d4fde
+     *
+     *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^ 0xa22cb465 ^ 0xe985e9c ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
      */
 
     constructor () public {

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -32,7 +32,6 @@ contract ERC721 is ERC165, IERC721 {
     // Mapping from owner to operator approvals
     mapping (address => mapping (address => bool)) private _operatorApprovals;
 
-    bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
     /*
      *     bytes4(keccak256('balanceOf(address)')) == 0x70a08231
      *     bytes4(keccak256('ownerOf(uint256)')) == 0x6352211e
@@ -47,6 +46,7 @@ contract ERC721 is ERC165, IERC721 {
      *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^
      *        0xa22cb465 ^ 0xe985e9c ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
      */
+    bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
 
     constructor () public {
         // register the supported interfaces to conform to ERC721 via ERC165

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -43,8 +43,9 @@ contract ERC721 is ERC165, IERC721 {
      *     bytes4(keccak256('transferFrom(address,address,uint256)')) == 0x23b872dd
      *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) == 0x42842e0e
      *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)')) == 0xb88d4fde
-     *
-     *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^ 0xa22cb465 ^ 0xe985e9c ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
+     *    
+     *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^
+     *        0xa22cb465 ^ 0xe985e9c ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
      */
 
     constructor () public {

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -21,7 +21,6 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     // Mapping from token id to position in the allTokens array
     mapping(uint256 => uint256) private _allTokensIndex;
 
-    bytes4 private constant _INTERFACE_ID_ERC721_ENUMERABLE = 0x780e9d63;
     /* 
      *     bytes4(keccak256('totalSupply()')) == 0x18160ddd
      *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) == 0x2f745c59
@@ -29,6 +28,7 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
      *      
      *     => 0x18160ddd ^ 0x2f745c59 ^ 0x4f6ccce7 == 0x780e9d63  
      */
+    bytes4 private constant _INTERFACE_ID_ERC721_ENUMERABLE = 0x780e9d63;
 
     /**
      * @dev Constructor function.

--- a/contracts/token/ERC721/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/ERC721Enumerable.sol
@@ -22,11 +22,12 @@ contract ERC721Enumerable is ERC165, ERC721, IERC721Enumerable {
     mapping(uint256 => uint256) private _allTokensIndex;
 
     bytes4 private constant _INTERFACE_ID_ERC721_ENUMERABLE = 0x780e9d63;
-    /*
-     * 0x780e9d63 ===
-     *     bytes4(keccak256('totalSupply()')) ^
-     *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) ^
-     *     bytes4(keccak256('tokenByIndex(uint256)'))
+    /* 
+     *     bytes4(keccak256('totalSupply()')) == 0x18160ddd
+     *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) == 0x2f745c59
+     *     bytes4(keccak256('tokenByIndex(uint256)')) == 0x4f6ccce7
+     *      
+     *     => 0x18160ddd ^ 0x2f745c59 ^ 0x4f6ccce7 == 0x780e9d63  
      */
 
     /**

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -14,7 +14,6 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
 
-    bytes4 private constant _INTERFACE_ID_ERC721_METADATA = 0x5b5e139f;
     /*
      *     bytes4(keccak256('name()')) == 0x06fdde03
      *     bytes4(keccak256('symbol()')) == 0x95d89b41
@@ -22,6 +21,7 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
      *     
      *     => 0x06fdde03 ^ 0x95d89b41 ^ 0xc87b56dd == 0x5b5e139f
      */
+    bytes4 private constant _INTERFACE_ID_ERC721_METADATA = 0x5b5e139f;
 
     /**
      * @dev Constructor function

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -16,10 +16,11 @@ contract ERC721Metadata is ERC165, ERC721, IERC721Metadata {
 
     bytes4 private constant _INTERFACE_ID_ERC721_METADATA = 0x5b5e139f;
     /*
-     * 0x5b5e139f ===
-     *     bytes4(keccak256('name()')) ^
-     *     bytes4(keccak256('symbol()')) ^
-     *     bytes4(keccak256('tokenURI(uint256)'))
+     *     bytes4(keccak256('name()')) == 0x06fdde03
+     *     bytes4(keccak256('symbol()')) == 0x95d89b41
+     *     bytes4(keccak256('tokenURI(uint256)')) == 0xc87b56dd
+     *     
+     *     => 0x06fdde03 ^ 0x95d89b41 ^ 0xc87b56dd == 0x5b5e139f
      */
 
     /**


### PR DESCRIPTION
Fixes #1182 **- Improves constants inline documentation**

- Moved the comment before the variable, replaced === with ==
**eg:** 
**Earlier** 
`0x95d89b41 === bytes4(keccak256('symbol'))`
 **Now**
`bytes4(keccak256('symbol')) == 0x95d89b41`

- Replaced /** with /*

- Modifications in comments
**Earlier:** 
`0x780e9d63 === bytes4(keccak256('totalSupply()')) ^ bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) ^ bytes4(keccak256('tokenByIndex(uint256)'))`
**Now**
`bytes4(keccak256('totalSupply()')) == 0x18160ddd`
`bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) == 0x2f745c59`
`bytes4(keccak256('tokenByIndex(uint256)')) == 0x4f6ccce7`
`=> 0x18160ddd ^ 0x2f745c59 ^ 0x4f6ccce7 == 0x780e9d63 `