### PR TITLE
Fix from account in remove role behaviors

### DIFF
--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -101,11 +101,11 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
         });
 
         it('reverts when removing from an unassigned account', async function () {
-          await shouldFail.reverting(this.contract[`remove${rolename}`](anyone), { from });
+          await shouldFail.reverting(this.contract[`remove${rolename}`](anyone, { from }));
         });
 
         it('reverts when removing role from the null account', async function () {
-          await shouldFail.reverting(this.contract[`remove${rolename}`](ZERO_ADDRESS), { from });
+          await shouldFail.reverting(this.contract[`remove${rolename}`](ZERO_ADDRESS, { from }));
         });
       });
     });


### PR DESCRIPTION
There was an error in PublicRole.behavior.js.
Trx options were passed in a wrong parameters order in some functions.
