### PR TITLE
Remove unnecessary require in Roles.

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -13,7 +13,6 @@ library Roles {
      * @dev Give an account access to this role.
      */
     function add(Role storage role, address account) internal {
-        require(account != address(0));
         require(!has(role, account));
 
         role.bearer[account] = true;
@@ -23,7 +22,6 @@ library Roles {
      * @dev Remove an account's access to this role.
      */
     function remove(Role storage role, address account) internal {
-        require(account != address(0));
         require(has(role, account));
 
         role.bearer[account] = false;

--- a/test/access/Roles.test.js
+++ b/test/access/Roles.test.js
@@ -8,7 +8,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
     this.roles = await RolesMock.new();
   });
 
-  it('reverts when querying roles for the null account', async function () {
+  it('reverts when querying roles for the zero account', async function () {
     await shouldFail.reverting(this.roles.has(ZERO_ADDRESS));
   });
 
@@ -31,7 +31,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await shouldFail.reverting(this.roles.add(authorized));
       });
 
-      it('reverts when adding roles to the null account', async function () {
+      it('reverts when adding roles to the zero account', async function () {
         await shouldFail.reverting(this.roles.add(ZERO_ADDRESS));
       });
     });
@@ -54,7 +54,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
         await shouldFail.reverting(this.roles.remove(anyone));
       });
 
-      it('reverts when removing roles from the null account', async function () {
+      it('reverts when removing roles from the zero account', async function () {
         await shouldFail.reverting(this.roles.remove(ZERO_ADDRESS));
       });
     });


### PR DESCRIPTION
`has` already performs that same check, so having it in `add` and `remove` is redundant. I don't think this merits a changelog entry.