### PR TITLE
Fix/rename anyone account #1357

### DIFF
--- a/test/access/Roles.test.js
+++ b/test/access/Roles.test.js
@@ -3,7 +3,7 @@ const { ZERO_ADDRESS } = constants;
 
 const RolesMock = artifacts.require('RolesMock');
 
-contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
+contract('Roles', function ([_, authorized, otherAuthorized, other]) {
   beforeEach(async function () {
     this.roles = await RolesMock.new();
   });
@@ -16,14 +16,14 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
     it('doesn\'t pre-assign roles', async function () {
       (await this.roles.has(authorized)).should.equal(false);
       (await this.roles.has(otherAuthorized)).should.equal(false);
-      (await this.roles.has(anyone)).should.equal(false);
+      (await this.roles.has(other)).should.equal(false);
     });
 
     describe('adding roles', function () {
       it('adds roles to a single account', async function () {
         await this.roles.add(authorized);
         (await this.roles.has(authorized)).should.equal(true);
-        (await this.roles.has(anyone)).should.equal(false);
+        (await this.roles.has(other)).should.equal(false);
       });
 
       it('reverts when adding roles to an already assigned account', async function () {
@@ -51,7 +51,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, anyone]) {
       });
 
       it('reverts when removing unassigned roles', async function () {
-        await shouldFail.reverting(this.roles.remove(anyone));
+        await shouldFail.reverting(this.roles.remove(other));
       });
 
       it('reverts when removing roles from the zero account', async function () {

--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -16,18 +16,18 @@ function capitalize (str) {
 //
 // @param authorized an account that has the role
 // @param otherAuthorized another account that also has the role
-// @param anyone an account that doesn't have the role, passed inside an array for ergonomics
+// @param other an account that doesn't have the role, passed inside an array for ergonomics
 // @param rolename a string with the name of the role
 // @param manager undefined for regular roles, or a manager account for managed roles. In these, only the manager
 // account can create and remove new role bearers.
-function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], rolename, manager) {
+function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolename, manager) {
   rolename = capitalize(rolename);
 
   describe('should behave like public role', function () {
     beforeEach('check preconditions', async function () {
       (await this.contract[`is${rolename}`](authorized)).should.equal(true);
       (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
-      (await this.contract[`is${rolename}`](anyone)).should.equal(false);
+      (await this.contract[`is${rolename}`](other)).should.equal(false);
     });
 
     if (manager === undefined) { // Managed roles are only assigned by the manager, and none are set at construction
@@ -52,7 +52,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
       });
 
       context('from unauthorized account', function () {
-        const from = anyone;
+        const from = other;
 
         it('reverts', async function () {
           await shouldFail.reverting(this.contract[`only${rolename}Mock`]({ from }));
@@ -65,13 +65,13 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
 
       context(`from ${manager ? 'the manager' : 'a role-haver'} account`, function () {
         it('adds role to a new account', async function () {
-          await this.contract[`add${rolename}`](anyone, { from });
-          (await this.contract[`is${rolename}`](anyone)).should.equal(true);
+          await this.contract[`add${rolename}`](other, { from });
+          (await this.contract[`is${rolename}`](other)).should.equal(true);
         });
 
         it(`emits a ${rolename}Added event`, async function () {
-          const { logs } = await this.contract[`add${rolename}`](anyone, { from });
-          expectEvent.inLogs(logs, `${rolename}Added`, { account: anyone });
+          const { logs } = await this.contract[`add${rolename}`](other, { from });
+          expectEvent.inLogs(logs, `${rolename}Added`, { account: other });
         });
 
         it('reverts when adding role to an already assigned account', async function () {
@@ -86,7 +86,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
 
     describe('remove', function () {
       // Non-managed roles have no restrictions on the mocked '_remove' function (exposed via 'remove').
-      const from = manager || anyone;
+      const from = manager || other;
 
       context(`from ${manager ? 'the manager' : 'any'} account`, function () {
         it('removes role from an already assigned account', async function () {
@@ -101,7 +101,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
         });
 
         it('reverts when removing from an unassigned account', async function () {
-          await shouldFail.reverting(this.contract[`remove${rolename}`](anyone, { from }));
+          await shouldFail.reverting(this.contract[`remove${rolename}`](other, { from }));
         });
 
         it('reverts when removing role from the null account', async function () {

--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -122,7 +122,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [anyone], role
       });
 
       it('reverts when renouncing unassigned role', async function () {
-        await shouldFail.reverting(this.contract[`renounce${rolename}`]({ from: anyone }));
+        await shouldFail.reverting(this.contract[`renounce${rolename}`]({ from: other }));
       });
     });
   });

--- a/test/crowdsale/FinalizableCrowdsale.test.js
+++ b/test/crowdsale/FinalizableCrowdsale.test.js
@@ -23,23 +23,23 @@ contract('FinalizableCrowdsale', function ([_, wallet, anyone]) {
   });
 
   it('cannot be finalized before ending', async function () {
-    await shouldFail.reverting(this.crowdsale.finalize({ from: anyone }));
+    await shouldFail.reverting(this.crowdsale.finalize({ from: other }));
   });
 
   it('can be finalized by anyone after ending', async function () {
     await time.increaseTo(this.afterClosingTime);
-    await this.crowdsale.finalize({ from: anyone });
+    await this.crowdsale.finalize({ from: other });
   });
 
   it('cannot be finalized twice', async function () {
     await time.increaseTo(this.afterClosingTime);
-    await this.crowdsale.finalize({ from: anyone });
-    await shouldFail.reverting(this.crowdsale.finalize({ from: anyone }));
+    await this.crowdsale.finalize({ from: other });
+    await shouldFail.reverting(this.crowdsale.finalize({ from: other }));
   });
 
   it('logs finalized', async function () {
     await time.increaseTo(this.afterClosingTime);
-    const { logs } = await this.crowdsale.finalize({ from: anyone });
+    const { logs } = await this.crowdsale.finalize({ from: other });
     expectEvent.inLogs(logs, 'CrowdsaleFinalized');
   });
 });

--- a/test/crowdsale/FinalizableCrowdsale.test.js
+++ b/test/crowdsale/FinalizableCrowdsale.test.js
@@ -3,7 +3,7 @@ const { BN, expectEvent, shouldFail, time } = require('openzeppelin-test-helpers
 const FinalizableCrowdsaleImpl = artifacts.require('FinalizableCrowdsaleImpl');
 const ERC20 = artifacts.require('ERC20');
 
-contract('FinalizableCrowdsale', function ([_, wallet, anyone]) {
+contract('FinalizableCrowdsale', function ([_, wallet, other]) {
   const rate = new BN('1000');
 
   before(async function () {

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -5,7 +5,7 @@ const SimpleToken = artifacts.require('SimpleToken');
 const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
 
 contract('IndividuallyCappedCrowdsale', function (
-  [_, capper, otherCapper, wallet, alice, bob, charlie, anyone, ...otherAccounts]) {
+  [_, capper, otherCapper, wallet, alice, bob, charlie, other, ...otherAccounts]) {
   const rate = new BN(1);
   const capAlice = ether('10');
   const capBob = ether('2');

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -34,7 +34,7 @@ contract('IndividuallyCappedCrowdsale', function (
     });
 
     it('reverts when a non-capper sets a cap', async function () {
-      await shouldFail.reverting(this.crowdsale.setCap(alice, capAlice, { from: anyone }));
+      await shouldFail.reverting(this.crowdsale.setCap(alice, capAlice, { from: other }));
     });
 
     context('with individual caps', function () {

--- a/test/crowdsale/PausableCrowdsale.test.js
+++ b/test/crowdsale/PausableCrowdsale.test.js
@@ -16,8 +16,8 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
   });
 
   it('purchases work', async function () {
-    await this.crowdsale.sendTransaction({ from: anyone, value });
-    await this.crowdsale.buyTokens(anyone, { from: anyone, value });
+    await this.crowdsale.sendTransaction({ from: other, value });
+    await this.crowdsale.buyTokens(anyone, { from: other, value });
   });
 
   context('after pause', function () {
@@ -26,8 +26,8 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
     });
 
     it('purchases do not work', async function () {
-      await shouldFail.reverting(this.crowdsale.sendTransaction({ from: anyone, value }));
-      await shouldFail.reverting(this.crowdsale.buyTokens(anyone, { from: anyone, value }));
+      await shouldFail.reverting(this.crowdsale.sendTransaction({ from: other, value }));
+      await shouldFail.reverting(this.crowdsale.buyTokens(anyone, { from: other, value }));
     });
 
     context('after unpause', function () {
@@ -36,8 +36,8 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
       });
 
       it('purchases work', async function () {
-        await this.crowdsale.sendTransaction({ from: anyone, value });
-        await this.crowdsale.buyTokens(anyone, { from: anyone, value });
+        await this.crowdsale.sendTransaction({ from: other, value });
+        await this.crowdsale.buyTokens(anyone, { from: other, value });
       });
     });
   });

--- a/test/crowdsale/PausableCrowdsale.test.js
+++ b/test/crowdsale/PausableCrowdsale.test.js
@@ -3,7 +3,7 @@ const { BN, shouldFail } = require('openzeppelin-test-helpers');
 const PausableCrowdsale = artifacts.require('PausableCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
 
-contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
+contract('PausableCrowdsale', function ([_, pauser, wallet, other]) {
   const rate = new BN(1);
   const value = new BN(1);
 
@@ -17,7 +17,7 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
 
   it('purchases work', async function () {
     await this.crowdsale.sendTransaction({ from: other, value });
-    await this.crowdsale.buyTokens(anyone, { from: other, value });
+    await this.crowdsale.buyTokens(other, { from: other, value });
   });
 
   context('after pause', function () {
@@ -27,7 +27,7 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
 
     it('purchases do not work', async function () {
       await shouldFail.reverting(this.crowdsale.sendTransaction({ from: other, value }));
-      await shouldFail.reverting(this.crowdsale.buyTokens(anyone, { from: other, value }));
+      await shouldFail.reverting(this.crowdsale.buyTokens(other, { from: other, value }));
     });
 
     context('after unpause', function () {
@@ -37,7 +37,7 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, anyone]) {
 
       it('purchases work', async function () {
         await this.crowdsale.sendTransaction({ from: other, value });
-        await this.crowdsale.buyTokens(anyone, { from: other, value });
+        await this.crowdsale.buyTokens(other, { from: other, value });
       });
     });
   });

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -61,7 +61,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, anyon
         context('after closing time and finalization', function () {
           beforeEach(async function () {
             await time.increaseTo(this.afterClosingTime);
-            await this.crowdsale.finalize({ from: anyone });
+            await this.crowdsale.finalize({ from: other });
           });
 
           it('refunds', async function () {
@@ -80,7 +80,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, anyon
         context('after closing time and finalization', function () {
           beforeEach(async function () {
             await time.increaseTo(this.afterClosingTime);
-            await this.crowdsale.finalize({ from: anyone });
+            await this.crowdsale.finalize({ from: other });
           });
 
           it('denies refunds', async function () {

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -3,7 +3,7 @@ const { balance, BN, ether, shouldFail, time } = require('openzeppelin-test-help
 const RefundableCrowdsaleImpl = artifacts.require('RefundableCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
 
-contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, anyone]) {
+contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other]) {
   const rate = new BN(1);
   const goal = ether('50');
   const lessThanGoal = ether('45');

--- a/test/crowdsale/WhitelistCrowdsale.test.js
+++ b/test/crowdsale/WhitelistCrowdsale.test.js
@@ -3,7 +3,7 @@ const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
 const WhitelistCrowdsale = artifacts.require('WhitelistCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
 
-contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, otherWhitelisted, anyone]) {
+contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, otherWhitelisted, other]) {
   const rate = new BN(1);
   const value = ether('42');
   const tokenSupply = new BN('10').pow(new BN('22'));
@@ -26,7 +26,7 @@ contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, o
 
   context('with no whitelisted addresses', function () {
     it('rejects all purchases', async function () {
-      await purchaseShouldFail(this.crowdsale, anyone, value);
+      await purchaseShouldFail(this.crowdsale, other, value);
       await purchaseShouldFail(this.crowdsale, whitelisted, value);
     });
   });
@@ -43,11 +43,11 @@ contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, o
     });
 
     it('rejects purchases from whitelisted addresses with non-whitelisted beneficiaries', async function () {
-      await shouldFail(this.crowdsale.buyTokens(anyone, { from: whitelisted, value }));
+      await shouldFail(this.crowdsale.buyTokens(other, { from: whitelisted, value }));
     });
 
     it('rejects purchases with non-whitelisted beneficiaries', async function () {
-      await purchaseShouldFail(this.crowdsale, anyone, value);
+      await purchaseShouldFail(this.crowdsale, other, value);
     });
   });
 });

--- a/test/cryptography/ECDSA.test.js
+++ b/test/cryptography/ECDSA.test.js
@@ -7,7 +7,7 @@ const ECDSAMock = artifacts.require('ECDSAMock');
 const TEST_MESSAGE = web3.utils.sha3('OpenZeppelin');
 const WRONG_MESSAGE = web3.utils.sha3('Nope');
 
-contract('ECDSA', function ([_, anyone]) {
+contract('ECDSA', function ([_, other]) {
   beforeEach(async function () {
     this.ecdsa = await ECDSAMock.new();
   });
@@ -92,23 +92,23 @@ contract('ECDSA', function ([_, anyone]) {
       context('with correct signature', function () {
         it('returns signer address', async function () {
           // Create the signature
-          const signature = fixSignature(await web3.eth.sign(TEST_MESSAGE, anyone));
+          const signature = fixSignature(await web3.eth.sign(TEST_MESSAGE, other));
 
           // Recover the signer address from the generated message and signature.
           (await this.ecdsa.recover(
             toEthSignedMessageHash(TEST_MESSAGE),
             signature
-          )).should.equal(anyone);
+          )).should.equal(other);
         });
       });
 
       context('with wrong signature', function () {
         it('does not return signer address', async function () {
           // Create the signature
-          const signature = await web3.eth.sign(TEST_MESSAGE, anyone);
+          const signature = await web3.eth.sign(TEST_MESSAGE, other);
 
           // Recover the signer address from the generated message and wrong signature.
-          (await this.ecdsa.recover(WRONG_MESSAGE, signature)).should.not.equal(anyone);
+          (await this.ecdsa.recover(WRONG_MESSAGE, signature)).should.not.equal(other);
         });
       });
     });
@@ -117,7 +117,7 @@ contract('ECDSA', function ([_, anyone]) {
       // @TODO - remove `skip` once we upgrade to solc^0.5
       it.skip('reverts', async function () {
         // Create the signature
-        const signature = await web3.eth.sign(TEST_MESSAGE, anyone);
+        const signature = await web3.eth.sign(TEST_MESSAGE, other);
         await shouldFail.reverting(
           this.ecdsa.recover(TEST_MESSAGE.substring(2), signature)
         );

--- a/test/drafts/ERC1820Implementer.test.js
+++ b/test/drafts/ERC1820Implementer.test.js
@@ -3,7 +3,7 @@ const { bufferToHex, keccak256 } = require('ethereumjs-util');
 
 const ERC1820ImplementerMock = artifacts.require('ERC1820ImplementerMock');
 
-contract('ERC1820Implementer', function ([_, registryFunder, implementee, anyone]) {
+contract('ERC1820Implementer', function ([_, registryFunder, implementee, other]) {
   const ERC1820_ACCEPT_MAGIC = bufferToHex(keccak256('ERC1820_ACCEPT_MAGIC'));
 
   beforeEach(async function () {
@@ -45,7 +45,7 @@ contract('ERC1820Implementer', function ([_, registryFunder, implementee, anyone
     });
 
     it('returns false when interface implementation for non-supported addresses is queried', async function () {
-      (await this.implementer.canImplementInterfaceForAddress(this.interfaceA, anyone))
+      (await this.implementer.canImplementInterfaceForAddress(this.interfaceA, other))
         .should.not.equal(ERC1820_ACCEPT_MAGIC);
     });
 

--- a/test/drafts/ERC20Snapshot.test.js
+++ b/test/drafts/ERC20Snapshot.test.js
@@ -1,7 +1,7 @@
 const { BN, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
 const ERC20SnapshotMock = artifacts.require('ERC20SnapshotMock');
 
-contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
+contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
   const initialSupply = new BN(100);
 
   beforeEach(async function () {
@@ -47,7 +47,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
 
       context('with supply changes after the snapshot', function () {
         beforeEach(async function () {
-          await this.token.mint(anyone, new BN('50'));
+          await this.token.mint(other, new BN('50'));
           await this.token.burn(initialHolder, new BN('20'));
         });
 
@@ -98,11 +98,11 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
 
   describe('balanceOfAt', function () {
     it('reverts with a snapshot id of 0', async function () {
-      await shouldFail.reverting(this.token.balanceOfAt(anyone, 0));
+      await shouldFail.reverting(this.token.balanceOfAt(other, 0));
     });
 
     it('reverts with a not-yet-created snapshot id', async function () {
-      await shouldFail.reverting(this.token.balanceOfAt(anyone, 1));
+      await shouldFail.reverting(this.token.balanceOfAt(other, 1));
     });
 
     context('with initial snapshot', function () {
@@ -118,7 +118,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
           (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
             .should.be.bignumber.equal(initialSupply);
           (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-          (await this.token.balanceOfAt(anyone, this.initialSnapshotId)).should.be.bignumber.equal('0');
+          (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
         });
       });
 
@@ -133,7 +133,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
           (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
             .should.be.bignumber.equal(initialSupply);
           (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-          (await this.token.balanceOfAt(anyone, this.initialSnapshotId)).should.be.bignumber.equal('0');
+          (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
         });
 
         context('with a second snapshot after supply changes', function () {
@@ -148,7 +148,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
             (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
               .should.be.bignumber.equal(initialSupply);
             (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-            (await this.token.balanceOfAt(anyone, this.initialSnapshotId)).should.be.bignumber.equal('0');
+            (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
 
             (await this.token.balanceOfAt(initialHolder, this.secondSnapshotId)).should.be.bignumber.equal(
               await this.token.balanceOf(initialHolder)
@@ -156,8 +156,8 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
             (await this.token.balanceOfAt(recipient, this.secondSnapshotId)).should.be.bignumber.equal(
               await this.token.balanceOf(recipient)
             );
-            (await this.token.balanceOfAt(anyone, this.secondSnapshotId)).should.be.bignumber.equal(
-              await this.token.balanceOf(anyone)
+            (await this.token.balanceOfAt(other, this.secondSnapshotId)).should.be.bignumber.equal(
+              await this.token.balanceOf(other)
             );
           });
         });
@@ -176,7 +176,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
             (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
               .should.be.bignumber.equal(initialSupply);
             (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-            (await this.token.balanceOfAt(anyone, this.initialSnapshotId)).should.be.bignumber.equal('0');
+            (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
 
             for (const id of this.secondSnapshotIds) {
               (await this.token.balanceOfAt(initialHolder, id)).should.be.bignumber.equal(
@@ -185,8 +185,8 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, anyone]) {
               (await this.token.balanceOfAt(recipient, id)).should.be.bignumber.equal(
                 await this.token.balanceOf(recipient)
               );
-              (await this.token.balanceOfAt(anyone, id)).should.be.bignumber.equal(
-                await this.token.balanceOf(anyone)
+              (await this.token.balanceOfAt(other, id)).should.be.bignumber.equal(
+                await this.token.balanceOf(other)
               );
             }
           });

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -37,7 +37,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
 
       it('does not allow valid signature for other sender', async function () {
         await shouldFail.reverting(
-          this.sigBouncer.onlyWithValidSignature(await this.signFor(authorizedUser), { from: anyone })
+          this.sigBouncer.onlyWithValidSignature(await this.signFor(authorizedUser), { from: other })
         );
       });
 
@@ -65,7 +65,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
       it('does not allow valid signature with correct method for other sender', async function () {
         await shouldFail.reverting(
           this.sigBouncer.onlyWithValidSignatureAndMethod(
-            await this.signFor(authorizedUser, 'onlyWithValidSignatureAndMethod'), { from: anyone }
+            await this.signFor(authorizedUser, 'onlyWithValidSignatureAndMethod'), { from: other }
           )
         );
       });
@@ -110,7 +110,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
         await shouldFail.reverting(
           this.sigBouncer.onlyWithValidSignatureAndData(UINT_VALUE,
             await this.signFor(authorizedUser, 'onlyWithValidSignatureAndData', [UINT_VALUE]),
-            { from: anyone }
+            { from: other }
           )
         );
       });

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -8,7 +8,7 @@ const UINT_VALUE = 23;
 const BYTES_VALUE = web3.utils.toHex('test');
 const INVALID_SIGNATURE = '0xabcd';
 
-contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authorizedUser, ...otherAccounts]) {
+contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorizedUser, ...otherAccounts]) {
   beforeEach(async function () {
     this.sigBouncer = await SignatureBouncerMock.new({ from: signer });
     this.signFor = getSignFor(this.sigBouncer, signer);
@@ -143,7 +143,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
       });
 
       it('does not validate valid signature for anyone', async function () {
-        (await this.sigBouncer.checkValidSignature(anyone, await this.signFor(authorizedUser))).should.equal(false);
+        (await this.sigBouncer.checkValidSignature(other, await this.signFor(authorizedUser))).should.equal(false);
       });
 
       it('does not validate valid signature for method for valid user', async function () {
@@ -165,7 +165,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
       });
 
       it('does not validate valid signature with correct method for anyone', async function () {
-        (await this.sigBouncer.checkValidSignatureAndMethod(anyone,
+        (await this.sigBouncer.checkValidSignatureAndMethod(other,
           await this.signFor(authorizedUser, 'checkValidSignatureAndMethod'))
         ).should.equal(false);
       });
@@ -197,7 +197,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, anyone, authoriz
       );
 
       it('does not validate valid signature with correct method and data for anyone', async function () {
-        (await this.sigBouncer.checkValidSignatureAndData(anyone, BYTES_VALUE, UINT_VALUE,
+        (await this.sigBouncer.checkValidSignatureAndData(other, BYTES_VALUE, UINT_VALUE,
           await this.signFor(authorizedUser, 'checkValidSignatureAndData', [authorizedUser, BYTES_VALUE, UINT_VALUE]))
         ).should.equal(false);
       });

--- a/test/lifecycle/Pausable.test.js
+++ b/test/lifecycle/Pausable.test.js
@@ -3,7 +3,7 @@ const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/Public
 
 const PausableMock = artifacts.require('PausableMock');
 
-contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts]) {
+contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]) {
   beforeEach(async function () {
     this.pausable = await PausableMock.new({ from: pauser });
   });

--- a/test/lifecycle/Pausable.test.js
+++ b/test/lifecycle/Pausable.test.js
@@ -25,12 +25,12 @@ contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts
     it('can perform normal process in non-pause', async function () {
       (await this.pausable.count()).should.be.bignumber.equal('0');
 
-      await this.pausable.normalProcess({ from: anyone });
+      await this.pausable.normalProcess({ from: other });
       (await this.pausable.count()).should.be.bignumber.equal('1');
     });
 
     it('cannot take drastic measure in non-pause', async function () {
-      await shouldFail.reverting(this.pausable.drasticMeasure({ from: anyone }));
+      await shouldFail.reverting(this.pausable.drasticMeasure({ from: other }));
       (await this.pausable.drasticMeasureTaken()).should.equal(false);
     });
 
@@ -41,7 +41,7 @@ contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts
       });
 
       it('reverts when pausing from non-pauser', async function () {
-        await shouldFail.reverting(this.pausable.pause({ from: anyone }));
+        await shouldFail.reverting(this.pausable.pause({ from: other }));
       });
 
       context('when paused', function () {
@@ -54,11 +54,11 @@ contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts
         });
 
         it('cannot perform normal process in pause', async function () {
-          await shouldFail.reverting(this.pausable.normalProcess({ from: anyone }));
+          await shouldFail.reverting(this.pausable.normalProcess({ from: other }));
         });
 
         it('can take a drastic measure in a pause', async function () {
-          await this.pausable.drasticMeasure({ from: anyone });
+          await this.pausable.drasticMeasure({ from: other });
           (await this.pausable.drasticMeasureTaken()).should.equal(true);
         });
 
@@ -73,7 +73,7 @@ contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts
           });
 
           it('reverts when unpausing from non-pauser', async function () {
-            await shouldFail.reverting(this.pausable.unpause({ from: anyone }));
+            await shouldFail.reverting(this.pausable.unpause({ from: other }));
           });
 
           context('when unpaused', function () {
@@ -87,12 +87,12 @@ contract('Pausable', function ([_, pauser, otherPauser, anyone, ...otherAccounts
 
             it('should resume allowing normal process', async function () {
               (await this.pausable.count()).should.be.bignumber.equal('0');
-              await this.pausable.normalProcess({ from: anyone });
+              await this.pausable.normalProcess({ from: other });
               (await this.pausable.count()).should.be.bignumber.equal('1');
             });
 
             it('should prevent drastic measure', async function () {
-              await shouldFail.reverting(this.pausable.drasticMeasure({ from: anyone }));
+              await shouldFail.reverting(this.pausable.drasticMeasure({ from: other }));
             });
 
             it('reverts when re-unpausing', async function () {

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -1,7 +1,7 @@
 const { constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
-function shouldBehaveLikeOwnable (owner, [anyone]) {
+function shouldBehaveLikeOwnable (owner, [other]) {
   describe('as an ownable', function () {
     it('should have an owner', async function () {
       (await this.ownable.owner()).should.equal(owner);
@@ -9,15 +9,15 @@ function shouldBehaveLikeOwnable (owner, [anyone]) {
 
     it('changes owner after transfer', async function () {
       (await this.ownable.isOwner({ from: other })).should.be.equal(false);
-      const { logs } = await this.ownable.transferOwnership(anyone, { from: owner });
+      const { logs } = await this.ownable.transferOwnership(other, { from: owner });
       expectEvent.inLogs(logs, 'OwnershipTransferred');
 
-      (await this.ownable.owner()).should.equal(anyone);
+      (await this.ownable.owner()).should.equal(other);
       (await this.ownable.isOwner({ from: other })).should.be.equal(true);
     });
 
     it('should prevent non-owners from transferring', async function () {
-      await shouldFail.reverting(this.ownable.transferOwnership(anyone, { from: other }));
+      await shouldFail.reverting(this.ownable.transferOwnership(other, { from: other }));
     });
 
     it('should guard ownership against stuck state', async function () {

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -8,16 +8,16 @@ function shouldBehaveLikeOwnable (owner, [anyone]) {
     });
 
     it('changes owner after transfer', async function () {
-      (await this.ownable.isOwner({ from: anyone })).should.be.equal(false);
+      (await this.ownable.isOwner({ from: other })).should.be.equal(false);
       const { logs } = await this.ownable.transferOwnership(anyone, { from: owner });
       expectEvent.inLogs(logs, 'OwnershipTransferred');
 
       (await this.ownable.owner()).should.equal(anyone);
-      (await this.ownable.isOwner({ from: anyone })).should.be.equal(true);
+      (await this.ownable.isOwner({ from: other })).should.be.equal(true);
     });
 
     it('should prevent non-owners from transferring', async function () {
-      await shouldFail.reverting(this.ownable.transferOwnership(anyone, { from: anyone }));
+      await shouldFail.reverting(this.ownable.transferOwnership(anyone, { from: other }));
     });
 
     it('should guard ownership against stuck state', async function () {
@@ -32,7 +32,7 @@ function shouldBehaveLikeOwnable (owner, [anyone]) {
     });
 
     it('should prevent non-owners from renouncement', async function () {
-      await shouldFail.reverting(this.ownable.renounceOwnership({ from: anyone }));
+      await shouldFail.reverting(this.ownable.renounceOwnership({ from: other }));
     });
   });
 }

--- a/test/ownership/Secondary.test.js
+++ b/test/ownership/Secondary.test.js
@@ -18,7 +18,7 @@ contract('Secondary', function ([_, primary, newPrimary, anyone]) {
     });
 
     it('reverts when anyone calls onlyPrimary functions', async function () {
-      await shouldFail.reverting(this.secondary.onlyPrimaryMock({ from: anyone }));
+      await shouldFail.reverting(this.secondary.onlyPrimaryMock({ from: other }));
     });
   });
 
@@ -34,7 +34,7 @@ contract('Secondary', function ([_, primary, newPrimary, anyone]) {
     });
 
     it('reverts when called by anyone', async function () {
-      await shouldFail.reverting(this.secondary.transferPrimary(newPrimary, { from: anyone }));
+      await shouldFail.reverting(this.secondary.transferPrimary(newPrimary, { from: other }));
     });
 
     context('with new primary', function () {

--- a/test/ownership/Secondary.test.js
+++ b/test/ownership/Secondary.test.js
@@ -3,7 +3,7 @@ const { ZERO_ADDRESS } = constants;
 
 const SecondaryMock = artifacts.require('SecondaryMock');
 
-contract('Secondary', function ([_, primary, newPrimary, anyone]) {
+contract('Secondary', function ([_, primary, newPrimary, other]) {
   beforeEach(async function () {
     this.secondary = await SecondaryMock.new({ from: primary });
   });

--- a/test/token/ERC20/behaviors/ERC20Capped.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Capped.behavior.js
@@ -1,6 +1,6 @@
 const { shouldFail } = require('openzeppelin-test-helpers');
 
-function shouldBehaveLikeERC20Capped (minter, [anyone], cap) {
+function shouldBehaveLikeERC20Capped (minter, [other], cap) {
   describe('capped token', function () {
     const from = minter;
 
@@ -9,18 +9,18 @@ function shouldBehaveLikeERC20Capped (minter, [anyone], cap) {
     });
 
     it('should mint when amount is less than cap', async function () {
-      await this.token.mint(anyone, cap.subn(1), { from });
+      await this.token.mint(other, cap.subn(1), { from });
       (await this.token.totalSupply()).should.be.bignumber.equal(cap.subn(1));
     });
 
     it('should fail to mint if the amount exceeds the cap', async function () {
-      await this.token.mint(anyone, cap.subn(1), { from });
-      await shouldFail.reverting(this.token.mint(anyone, 2, { from }));
+      await this.token.mint(other, cap.subn(1), { from });
+      await shouldFail.reverting(this.token.mint(other, 2, { from }));
     });
 
     it('should fail to mint after cap is reached', async function () {
-      await this.token.mint(anyone, cap, { from });
-      await shouldFail.reverting(this.token.mint(anyone, 1, { from }));
+      await this.token.mint(other, cap, { from });
+      await shouldFail.reverting(this.token.mint(other, 1, { from }));
     });
   });
 }

--- a/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
@@ -1,7 +1,7 @@
 const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
-function shouldBehaveLikeERC20Mintable (minter, [anyone]) {
+function shouldBehaveLikeERC20Mintable (minter, [other]) {
   describe('as a mintable token', function () {
     describe('mint', function () {
       const amount = new BN(100);
@@ -19,17 +19,17 @@ function shouldBehaveLikeERC20Mintable (minter, [anyone]) {
 
         function shouldMint (amount) {
           beforeEach(async function () {
-            ({ logs: this.logs } = await this.token.mint(anyone, amount, { from }));
+            ({ logs: this.logs } = await this.token.mint(other, amount, { from }));
           });
 
           it('mints the requested amount', async function () {
-            (await this.token.balanceOf(anyone)).should.be.bignumber.equal(amount);
+            (await this.token.balanceOf(other)).should.be.bignumber.equal(amount);
           });
 
           it('emits a mint and a transfer event', async function () {
             expectEvent.inLogs(this.logs, 'Transfer', {
               from: ZERO_ADDRESS,
-              to: anyone,
+              to: other,
               value: amount,
             });
           });
@@ -37,10 +37,10 @@ function shouldBehaveLikeERC20Mintable (minter, [anyone]) {
       });
 
       context('when the sender doesn\'t have minting permission', function () {
-        const from = anyone;
+        const from = other;
 
         it('reverts', async function () {
-          await shouldFail.reverting(this.token.mint(anyone, amount, { from }));
+          await shouldFail.reverting(this.token.mint(other, amount, { from }));
         });
       });
     });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -185,7 +185,7 @@ function shouldBehaveLikeERC721 (
 
         context('when the sender is not authorized for the token id', function () {
           it('reverts', async function () {
-            await shouldFail.reverting(transferFunction.call(this, owner, anyone, tokenId, { from: anyone })
+            await shouldFail.reverting(transferFunction.call(this, owner, anyone, tokenId, { from: other })
             );
           });
         });
@@ -398,7 +398,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the sender does not own the given token ID', function () {
         it('reverts', async function () {
-          await shouldFail.reverting(this.token.approve(approved, tokenId, { from: anyone }));
+          await shouldFail.reverting(this.token.approve(approved, tokenId, { from: other }));
         });
       });
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -7,7 +7,7 @@ const ERC721ReceiverMock = artifacts.require('ERC721ReceiverMock.sol');
 function shouldBehaveLikeERC721 (
   creator,
   minter,
-  [owner, approved, anotherApproved, operator, anyone]
+  [owner, approved, anotherApproved, operator, other]
 ) {
   const firstTokenId = new BN(1);
   const secondTokenId = new BN(2);
@@ -18,7 +18,7 @@ function shouldBehaveLikeERC721 (
     beforeEach(async function () {
       await this.token.mint(owner, firstTokenId, { from: minter });
       await this.token.mint(owner, secondTokenId, { from: minter });
-      this.toWhom = anyone; // default to anyone for toWhom in context-dependent tests
+      this.toWhom = other; // default to anyone for toWhom in context-dependent tests
     });
 
     describe('balanceOf', function () {
@@ -30,7 +30,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the given address does not own any tokens', function () {
         it('returns 0', async function () {
-          (await this.token.balanceOf(anyone)).should.be.bignumber.equal('0');
+          (await this.token.balanceOf(other)).should.be.bignumber.equal('0');
         });
       });
 
@@ -178,21 +178,21 @@ function shouldBehaveLikeERC721 (
 
         context('when the address of the previous owner is incorrect', function () {
           it('reverts', async function () {
-            await shouldFail.reverting(transferFunction.call(this, anyone, anyone, tokenId, { from: owner })
+            await shouldFail.reverting(transferFunction.call(this, other, other, tokenId, { from: owner })
             );
           });
         });
 
         context('when the sender is not authorized for the token id', function () {
           it('reverts', async function () {
-            await shouldFail.reverting(transferFunction.call(this, owner, anyone, tokenId, { from: other })
+            await shouldFail.reverting(transferFunction.call(this, owner, other, tokenId, { from: other })
             );
           });
         });
 
         context('when the given token ID does not exist', function () {
           it('reverts', async function () {
-            await shouldFail.reverting(transferFunction.call(this, owner, anyone, unknownTokenId, { from: owner })
+            await shouldFail.reverting(transferFunction.call(this, owner, other, unknownTokenId, { from: owner })
             );
           });
         });

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -4,7 +4,7 @@ const { ZERO_ADDRESS } = constants;
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
 const ERC721Mock = artifacts.require('ERC721Mock.sol');
 
-contract('ERC721', function ([_, creator, tokenOwner, anyone, ...accounts]) {
+contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
   beforeEach(async function () {
     this.token = await ERC721Mock.new({ from: creator });
   });
@@ -50,7 +50,7 @@ contract('ERC721', function ([_, creator, tokenOwner, anyone, ...accounts]) {
         });
 
         it('reverts when the account is not the owner', async function () {
-          await shouldFail.reverting(this.token.methods['burn(address,uint256)'](anyone, tokenId));
+          await shouldFail.reverting(this.token.methods['burn(address,uint256)'](other, tokenId));
         });
 
         context('with burnt token', function () {

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -4,7 +4,7 @@ const { ZERO_ADDRESS } = constants;
 function shouldBehaveLikeMintAndBurnERC721 (
   creator,
   minter,
-  [owner, newOwner, approved, anyone]
+  [owner, newOwner, approved, other]
 ) {
   const firstTokenId = new BN(1);
   const secondTokenId = new BN(2);

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -3,13 +3,13 @@ require('openzeppelin-test-helpers');
 const AddressImpl = artifacts.require('AddressImpl');
 const SimpleToken = artifacts.require('SimpleToken');
 
-contract('Address', function ([_, anyone]) {
+contract('Address', function ([_, other]) {
   beforeEach(async function () {
     this.mock = await AddressImpl.new();
   });
 
   it('should return false for account address', async function () {
-    (await this.mock.isContract(anyone)).should.equal(false);
+    (await this.mock.isContract(other)).should.equal(false);
   });
 
   it('should return true for contract address', async function () {


### PR DESCRIPTION
<!-- 1. Does this close any open issues? Please list them below. -->
Fixes #1357 - https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1357

<!-- 2. Describe the changes introduced in this pull request. -->
Changing all references of an "anyone" account to "other" but keeping descriptions intact. 

<!--    Include any context necessary for understanding the PR's purpose. -->
The "anyone" account is not the best name for a random account with no special permissions. "Other" was decided to be a better descriptor.

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
