### PR TITLE
Update stalebot wording and timing.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 15
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 15
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -25,17 +25,27 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  Hi all!
+
+  This Pull Request has not had any recent activity, is it still relevant? If so, what is blocking it?
+  Is there anything we can do to help move it forward?
+
+  Thanks!
+
 
 # Comment to post when removing the stale label.
 # unmarkComment: >
 #   Your comment here.
 
 # Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
+closeComment: >
+  Hi folks!
+
+  This Pull Request is being closed as there was no response to the previous prompt.
+  However, please leave a comment whenever you're ready to resume, so it can be reopened.
+
+  Thanks again!
+
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
See https://github.com/probot/stale/pull/162 for some related discussion.

I think this new wording is less final-sounding, and prompts for action to help the PR move forward. 

I've also reduced the time until the bot kicks in, since a whole month of no activity seems excessive - I'd rather we intervene before then. Also, a single week to reply may be too little time.