### PR TITLE
Enable solc nightly job on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       name: "Unit tests using solc nightly"
       script: npm run test
       env: SOLC_NIGHTLY=true
+      if: branch = master and type != pull_request
 
 notifications:
   slack:


### PR DESCRIPTION
We don't want to run the nightly job on pull requests because it's eating up resources, and it's just to keep us informed of changes on solc nightly. I quickly looked into enabling notifications when that specific job fails, but since we allow the job to fail without making the entire build fail, it's not possible to have notifications about it.

I wonder if Circle CI would suit this use case better. :slightly_smiling_face: 