### PR TITLE
Update transferFrom to modify allowance in-between hook calls.

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -140,7 +140,7 @@ contract ERC777 is IERC777, IERC20 {
         _move(operator, from, to, value, "", "");
         _approve(from, operator, _allowances[from][operator].sub(value));
 
-        _callTokensReceived(from, from, to, value, "", "", false);
+        _callTokensReceived(operator, from, to, value, "", "", false);
 
         return true;
     }


### PR DESCRIPTION
Fixes an issue in the current release candidate ERC777 implementation, found by @guylando in https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1749. 

`transferFrom` now updates allowances after calling the send hook, but before calling the receive hook.

I also, uh, did a small refactor and changed some variable names while figuring out the best way to introduce this. Sorry!

The code looks somewhat weird at the moment (e.g. I'd expect to find similarities in `_transfer` and `_send` which aren't there), but all of this will make more sense once we make the ERC20 extension opt-in.

We also need to add new tests cases for this, by logging extra data in our mock sender and receiver contracts, and possibly creating new behavior-like functions that check this on ERC20 calls (including `transferFrom`). This may be something we want to leave for when we extract built-in ERC20 support out of the base ERC777 contract, since all of the associated ERC20 testing code will need to be changed at that point.