### PR TITLE
Disallow ERC20._transfer from the zero address.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bugfixes:
  * `PostDeliveryCrowdsale`: some validations where skipped when paired with other crowdsale flavors, such as `AllowanceCrowdsale`, or `MintableCrowdsale` and `ERC20Capped`, which could cause buyers to not be able to claim their purchased tokens. ([#1721](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1721))
- * (minor): `ERC20._transfer` allowed the `from` parameter to be the zero address, so it was possible to trigger a transfer of 0 tokens from it to any other address. The zero address is not a valid destinatary of transfers, not can it emit or receive allowance, so this behavior was inconsistent. It now reverts. ([#1752](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1752))
+ * `ERC20._transfer`: the `from` argument was allowed to be the zero address, so it was possible to internally trigger a transfer of 0 tokens from the zero address. This address is not a valid destinatary of transfers, nor can it give or receive allowance, so this behavior was inconsistent. It now reverts. ([#1752](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1752))
 
 ## 2.2.0 (2019-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugfixes:
  * `PostDeliveryCrowdsale`: some validations where skipped when paired with other crowdsale flavors, such as `AllowanceCrowdsale`, or `MintableCrowdsale` and `ERC20Capped`, which could cause buyers to not be able to claim their purchased tokens. ([#1721](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1721))
+ * (minor): `ERC20._transfer` allowed the `from` parameter to be the zero address, so it was possible to trigger a transfer of 0 tokens from it to any other address. The zero address is not a valid destinatary of transfers, not can it emit or receive allowance, so this behavior was inconsistent. It now reverts. ([#1752](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1752))
 
 ## 2.2.0 (2019-03-14)
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -20,6 +20,10 @@ contract ERC20Mock is ERC20 {
         _burnFrom(account, amount);
     }
 
+    function transferInternal(address from, address to, uint256 value) public {
+        _transfer(from, to, value);
+    }
+
     function approveInternal(address owner, address spender, uint256 value) public {
         _approve(owner, spender, value);
     }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -125,6 +125,7 @@ contract ERC20 is IERC20 {
      * @param value The amount to be transferred.
      */
     function _transfer(address from, address to, uint256 value) internal {
+        require(from != address(0), "ERC20: transfer from the zero address");
         require(to != address(0), "ERC20: transfer to the zero address");
 
         _balances[from] = _balances[from].sub(value);

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -190,6 +190,28 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
         });
       });
     });
+
+    describe('when the sender transfers zero tokens', function () {
+      const amount = new BN('0');
+
+      it('transfers the requested amount', async function () {
+        await transfer.call(this, from, to, amount);
+
+        (await this.token.balanceOf(from)).should.be.bignumber.equal(balance);
+
+        (await this.token.balanceOf(to)).should.be.bignumber.equal('0');
+      });
+
+      it('emits a transfer event', async function () {
+        const { logs } = await transfer.call(this, from, to, amount);
+
+        expectEvent.inLogs(logs, 'Transfer', {
+          from,
+          to,
+          value: amount,
+        });
+      });
+    });
   });
 
   describe('when the recipient is the zero address', function () {
@@ -283,5 +305,6 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
 
 module.exports = {
   shouldBehaveLikeERC20,
+  shouldBehaveLikeERC20Transfer,
   shouldBehaveLikeERC20Approve,
 };

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -24,7 +24,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
   describe('transfer', function () {
     shouldBehaveLikeERC20Transfer('ERC20', initialHolder, recipient, initialSupply,
-      function(from, to, value) {
+      function (from, to, value) {
         return this.token.transfer(to, value, { from });
       }
     );

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -73,101 +73,116 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
   describe('transfer from', function () {
     const spender = recipient;
 
-    describe('when the recipient is not the zero address', function () {
-      const to = anotherAccount;
+    describe('when the token owner is not the zero address', function () {
+      const tokenOwner = initialHolder;
 
-      describe('when the spender has enough approved balance', function () {
-        beforeEach(async function () {
-          await this.token.approve(spender, initialSupply, { from: initialHolder });
-        });
+      describe('when the recipient is not the zero address', function () {
+        const to = anotherAccount;
 
-        describe('when the initial holder has enough balance', function () {
-          const amount = initialSupply;
-
-          it('transfers the requested amount', async function () {
-            await this.token.transferFrom(initialHolder, to, amount, { from: spender });
-
-            (await this.token.balanceOf(initialHolder)).should.be.bignumber.equal('0');
-
-            (await this.token.balanceOf(to)).should.be.bignumber.equal(amount);
+        describe('when the spender has enough approved balance', function () {
+          beforeEach(async function () {
+            await this.token.approve(spender, initialSupply, { from: initialHolder });
           });
 
-          it('decreases the spender allowance', async function () {
-            await this.token.transferFrom(initialHolder, to, amount, { from: spender });
+          describe('when the token owner has enough balance', function () {
+            const amount = initialSupply;
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal('0');
-          });
+            it('transfers the requested amount', async function () {
+              await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
 
-          it('emits a transfer event', async function () {
-            const { logs } = await this.token.transferFrom(initialHolder, to, amount, { from: spender });
+              (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
 
-            expectEvent.inLogs(logs, 'Transfer', {
-              from: initialHolder,
-              to: to,
-              value: amount,
+              (await this.token.balanceOf(to)).should.be.bignumber.equal(amount);
+            });
+
+            it('decreases the spender allowance', async function () {
+              await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
+
+              (await this.token.allowance(tokenOwner, spender)).should.be.bignumber.equal('0');
+            });
+
+            it('emits a transfer event', async function () {
+              const { logs } = await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
+
+              expectEvent.inLogs(logs, 'Transfer', {
+                from: tokenOwner,
+                to: to,
+                value: amount,
+              });
+            });
+
+            it('emits an approval event', async function () {
+              const { logs } = await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
+
+              expectEvent.inLogs(logs, 'Approval', {
+                owner: tokenOwner,
+                spender: spender,
+                value: await this.token.allowance(tokenOwner, spender),
+              });
             });
           });
 
-          it('emits an approval event', async function () {
-            const { logs } = await this.token.transferFrom(initialHolder, to, amount, { from: spender });
+          describe('when the token owner does not have enough balance', function () {
+            const amount = initialSupply.addn(1);
 
-            expectEvent.inLogs(logs, 'Approval', {
-              owner: initialHolder,
-              spender: spender,
-              value: await this.token.allowance(initialHolder, spender),
+            it('reverts', async function () {
+              await shouldFail.reverting.withMessage(this.token.transferFrom(
+                tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
+              );
             });
           });
         });
 
-        describe('when the initial holder does not have enough balance', function () {
-          const amount = initialSupply.addn(1);
+        describe('when the spender does not have enough approved balance', function () {
+          beforeEach(async function () {
+            await this.token.approve(spender, initialSupply.subn(1), { from: tokenOwner });
+          });
 
-          it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.token.transferFrom(
-              initialHolder, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
-            );
+          describe('when the token owner has enough balance', function () {
+            const amount = initialSupply;
+
+            it('reverts', async function () {
+              await shouldFail.reverting.withMessage(this.token.transferFrom(
+                tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
+              );
+            });
+          });
+
+          describe('when the token owner does not have enough balance', function () {
+            const amount = initialSupply.addn(1);
+
+            it('reverts', async function () {
+              await shouldFail.reverting.withMessage(this.token.transferFrom(
+                tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
+              );
+            });
           });
         });
       });
 
-      describe('when the spender does not have enough approved balance', function () {
+      describe('when the recipient is the zero address', function () {
+        const amount = initialSupply;
+        const to = ZERO_ADDRESS;
+
         beforeEach(async function () {
-          await this.token.approve(spender, initialSupply.subn(1), { from: initialHolder });
+          await this.token.approve(spender, amount, { from: tokenOwner });
         });
 
-        describe('when the initial holder has enough balance', function () {
-          const amount = initialSupply;
-
-          it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.token.transferFrom(
-              initialHolder, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
-            );
-          });
-        });
-
-        describe('when the initial holder does not have enough balance', function () {
-          const amount = initialSupply.addn(1);
-
-          it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.token.transferFrom(
-              initialHolder, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
-            );
-          });
+        it('reverts', async function () {
+          await shouldFail.reverting.withMessage(this.token.transferFrom(
+            tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`
+          );
         });
       });
     });
 
-    describe('when the recipient is the zero address', function () {
-      const amount = initialSupply;
-      const to = ZERO_ADDRESS;
-
-      beforeEach(async function () {
-        await this.token.approve(spender, amount, { from: initialHolder });
-      });
+    describe('when the token owner is the zero address', function () {
+      const amount = 0;
+      const to = recipient;
 
       it('reverts', async function () {
         await shouldFail.reverting.withMessage(this.token.transferFrom(
-          initialHolder, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`
+          ZERO_ADDRESS, to, amount, { from: to }), `${errorPrefix}: transfer from the zero address`
         );
       });
     });

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -23,7 +23,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
   });
 
   describe('transfer', function () {
-    shouldBehaveLikeERC20Transfer('ERC20', initialHolder, recipient, initialSupply,
+    shouldBehaveLikeERC20Transfer(errorPrefix, initialHolder, recipient, initialSupply,
       function (from, to, value) {
         return this.token.transfer(to, value, { from });
       }

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -138,11 +138,12 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
     describe('when the token owner is the zero address', function () {
       const amount = 0;
+      const tokenOwner = ZERO_ADDRESS;
       const to = recipient;
 
       it('reverts', async function () {
         await shouldFail.reverting.withMessage(this.token.transferFrom(
-          ZERO_ADDRESS, to, amount, { from: to }), `${errorPrefix}: transfer from the zero address`
+          tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`
         );
       });
     });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -3,6 +3,7 @@ const { ZERO_ADDRESS } = constants;
 
 const {
   shouldBehaveLikeERC20,
+  shouldBehaveLikeERC20Transfer,
   shouldBehaveLikeERC20Approve,
 } = require('./ERC20.behavior');
 
@@ -327,6 +328,34 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
       describeBurnFrom('for entire allowance', allowance);
       describeBurnFrom('for less amount than allowance', allowance.subn(1));
+    });
+  });
+
+  describe('_transfer', function () {
+    shouldBehaveLikeERC20Approve('ERC20', initialHolder, recipient, initialSupply, function (owner, spender, amount) {
+      return this.token.approveInternal(owner, spender, amount);
+    });
+
+    describe('when the owner is the zero address', function () {
+      it('reverts', async function () {
+        await shouldFail.reverting.withMessage(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
+          'ERC20: approve from the zero address'
+        );
+      });
+    });
+  });
+
+  describe('_transfer', function () {
+    shouldBehaveLikeERC20Transfer('ERC20', initialHolder, recipient, initialSupply, function (from, to, amount) {
+      return this.token.transferInternal(from, to, amount);
+    });
+
+    describe('when the sender is the zero address', function () {
+      it('reverts', async function () {
+        await shouldFail.reverting.withMessage(this.token.transferInternal(ZERO_ADDRESS, recipient, initialSupply),
+          'ERC20: transfer from the zero address'
+        );
+      });
     });
   });
 

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -332,20 +332,6 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
   });
 
   describe('_transfer', function () {
-    shouldBehaveLikeERC20Approve('ERC20', initialHolder, recipient, initialSupply, function (owner, spender, amount) {
-      return this.token.approveInternal(owner, spender, amount);
-    });
-
-    describe('when the owner is the zero address', function () {
-      it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: approve from the zero address'
-        );
-      });
-    });
-  });
-
-  describe('_transfer', function () {
     shouldBehaveLikeERC20Transfer('ERC20', initialHolder, recipient, initialSupply, function (from, to, amount) {
       return this.token.transferInternal(from, to, amount);
     });


### PR DESCRIPTION
This came up while reviewing #1751.

The two consequences of this inconsistency were:
 * `_transfer` was allowed to have `from` be the zero address
 * a call to `transferFrom` with `from` being the zero address reverted, but with an revert reason about setting allowance to the zero address.