### PR TITLE
 restrain from approving to self

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -172,6 +172,7 @@ contract ERC20 is IERC20 {
         require(owner != address(0), "ERC20: approve from the zero address");
         require(spender != address(0), "ERC20: approve to the zero address");
         require(spender != msg.sender, "ERC20: approval to current owner");
+        
         _allowances[owner][spender] = value;
         emit Approval(owner, spender, value);
     }

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -171,7 +171,7 @@ contract ERC20 is IERC20 {
     function _approve(address owner, address spender, uint256 value) internal {
         require(owner != address(0), "ERC20: approve from the zero address");
         require(spender != address(0), "ERC20: approve to the zero address");
-
+        require(spender != msg.sender, "ERC20: approval to current owner");
         _allowances[owner][spender] = value;
         emit Approval(owner, spender, value);
     }


### PR DESCRIPTION
Fixes #

- ERC20: Should not approve to self #1757

Added addition require the statement for validating owner is not approving ERC-20 tokens to himself
