### PR TITLE
Add ERC827 Draft

### DIFF
--- a/contracts/drafts/ERC827/ERC827.sol
+++ b/contracts/drafts/ERC827/ERC827.sol
@@ -1,0 +1,98 @@
+/* solium-disable security/no-low-level-calls */
+
+pragma solidity ^0.5.2;
+
+import "../../token/ERC20/ERC20.sol";
+import "./ERC827Proxy.sol";
+
+
+/**
+ * @title ERC827, an extension of ERC20 token standard
+ *
+ * @dev Implementation the ERC827, following the ERC20 standard with extra
+ * methods to transfer value, data and execute calls inside transfers and
+ * approvals. Uses OpenZeppelin ERC20.
+ */
+contract ERC827 is ERC20 {
+
+    ERC827Proxy public proxy;
+
+    /**
+     * @dev Constructor
+     */
+    constructor() public {
+        proxy = new ERC827Proxy();
+    }
+
+    /**
+     * @dev Addition to ERC20 token methods. It allows to
+     * approve the transfer of value and execute a call with the sent data.
+     * Beware that changing an allowance with this method brings the risk that
+     * someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race condition
+     * is to first reduce the spender's allowance to 0 and set the desired value
+     * afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     * @param _spender The address that will spend the funds.
+     * @param _value The amount of tokens to be spent.
+     * @param _data ABI-encoded contract call to call `_spender` address.
+     * @return true if the call function was executed successfully
+     */
+    function approveAndCall(
+        address _spender, uint256 _value, bytes memory _data
+    ) public payable returns (bool) {
+        super.approve(_spender, _value);
+        // solhint-disable-next-line avoid-low-level-calls
+        _call(_spender, _data);
+        return true;
+    }
+
+    /**
+     * @dev Addition to ERC20 token methods. Transfer tokens to a specified
+     * address and execute a call with the sent data on the same transaction
+     * @param _to address The address which you want to transfer to
+     * @param _value uint256 the amout of tokens to be transfered
+     * @param _data ABI-encoded contract call to call `_to` address.
+     * @return true if the call function was executed successfully
+     */
+    function transferAndCall(
+        address _to, uint256 _value, bytes memory _data
+    ) public payable returns (bool) {
+        super.transfer(_to, _value);
+        // solhint-disable-next-line avoid-low-level-calls
+        _call(_to, _data);
+        return true;
+    }
+
+    /**
+     * @dev Addition to ERC20 token methods. Transfer tokens from one address to
+     * another and make a contract call on the same transaction
+     * @param _from The address which you want to send tokens from
+     * @param _to The address which you want to transfer to
+     * @param _value The amout of tokens to be transferred
+     * @param _data ABI-encoded contract call to call `_to` address.
+     * @return true if the call function was executed successfully
+     */
+    function transferFromAndCall(
+        address _from, address _to, uint256 _value, bytes memory _data
+    ) public payable returns (bool) {
+        super.transferFrom(_from, _to, _value);
+        // solhint-disable-next-line avoid-low-level-calls
+        _call(_to, _data);
+        return true;
+    }
+
+    /**
+     * @dev Call a external contract
+     * @param _to The address of the contract to call
+     * @param _data ABI-encoded contract call to call `_to` address.
+     */
+    function _call(address _to, bytes memory _data) internal {
+        // solhint-disable-next-line avoid-call-value, no-unused-vars
+        (bool success, bytes memory data) = address(proxy).call.value(msg.value)(
+            abi.encodeWithSelector(proxy.callContractFunctionSignature(), _to, _data)
+        );
+        require(success, "Call to external contract failed");
+    }
+
+}

--- a/contracts/drafts/ERC827/ERC827Proxy.sol
+++ b/contracts/drafts/ERC827/ERC827Proxy.sol
@@ -1,0 +1,44 @@
+/* solium-disable security/no-low-level-calls */
+
+pragma solidity ^0.5.2;
+
+
+/**
+ * @title ERC827Proxy
+ *
+ * @dev Proxy to forward contract calls from token contract to any other
+ * contract.
+ */
+contract ERC827Proxy {
+
+    address public token;
+    bytes4 public callContractFunctionSignature = bytes4(
+        keccak256("callContract(address,bytes)")
+    );
+
+    /**
+     * @dev constructor, executed by the ERC827 token when it is deployed.
+     */
+    constructor() public {
+        token = address(msg.sender);
+    }
+
+    /**
+     * @dev Forward calls only from the token contract that created it
+     * @param _target address The address which you want to transfer to
+     * @param _data bytes The data to be executed in the call
+     */
+    function callContract(
+        address _target, bytes memory _data
+    ) public payable returns (bool) {
+        require(
+            msg.sender == address(token),
+            "Proxy cant execute calls to the token contract"
+        );
+        // solhint-disable-next-line avoid-call-value, no-unused-vars
+        (bool success, bytes memory data) = _target.call.value(msg.value)(_data);
+        require(success, "Proxy call failed");
+        return true;
+    }
+
+}

--- a/contracts/drafts/ERC827/IERC827.sol
+++ b/contracts/drafts/ERC827/IERC827.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.5.2;
+
+
+/**
+ * @title ERC827 interface, an extension of ERC20 token standard
+ *
+ * @dev Interface of a ERC827 token, following the ERC20 standard with extra
+ * methods to transfer value and data and execute calls in transfers and
+ * approvals.
+ */
+interface IERC827 {
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+
+    function approveAndCall(address _spender, uint256 _value, bytes calldata _data)
+        external payable returns (bool);
+
+    function transferAndCall(address _to, uint256 _value, bytes calldata _data)
+        external payable returns (bool);
+
+    function transferFromAndCall(
+        address _from, address _to, uint256 _value, bytes calldata _data
+    ) external payable returns (bool);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address who) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/contracts/mocks/ERC827TokenMock.sol
+++ b/contracts/mocks/ERC827TokenMock.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+
+import "../drafts/ERC827/ERC827.sol";
+
+
+// mock class using ERC827 Token
+contract ERC827TokenMock is ERC827 {
+
+    constructor(address initialAccount, uint256 initialBalance) public ERC827() {
+        _mint(initialAccount, initialBalance);
+    }
+
+}

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+
+contract MessageHelper {
+
+    event Show(bytes32 b32, uint256 number, string text);
+
+    function showMessage(bytes32 b32, uint256 number, string memory text)
+        public payable returns (bool)
+    {
+        emit Show(b32, number, text);
+        return true;
+    }
+
+    function fail() public {
+        revert("MessageHelper fail function failed");
+    }
+
+}

--- a/test/drafts/ERC827/ERC827.test.js
+++ b/test/drafts/ERC827/ERC827.test.js
@@ -1,0 +1,193 @@
+
+const { BN, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const MessageHelper = artifacts.require('MessageHelper');
+const ERC827TokenMock = artifacts.require('ERC827TokenMock');
+const {
+  shouldBehaveLikeERC20,
+} = require('../../token/ERC20/ERC20.behavior');
+
+contract('ERC827 Token', function ([_, initialHolder, recipient, anotherAccount]) {
+  let message;
+
+  const initialSupply = new BN(100);
+  const extraData = web3.eth.abi.encodeFunctionCall({
+    name: 'showMessage',
+    type: 'function',
+    inputs: [
+      { type: 'bytes32', name: 'b32' },
+      { type: 'uint256', name: 'number' },
+      { type: 'string', name: 'text' },
+    ],
+  }, ['0x1234', 666, 'Transfer Done']);
+  const extraDataFail = web3.eth.abi.encodeFunctionCall(
+    { name: 'fail', type: 'function', inputs: [] }, []
+  );
+
+  beforeEach(async function () {
+    this.token = await ERC827TokenMock.new(initialHolder, initialSupply);
+    message = await MessageHelper.new();
+  });
+
+  const checkSuccessEvent = async function (txHash) {
+    await expectEvent.inTransaction(txHash, MessageHelper, 'Show', {
+      'b32': web3.utils.padRight('0x1234', 64),
+      'number': '666',
+      'text': 'Transfer Done',
+    });
+  };
+
+  shouldBehaveLikeERC20('ERC20', initialSupply, initialHolder, recipient, anotherAccount);
+
+  it(
+    'should allow payment through transfer'
+    , async function () {
+      await this.token.transferAndCall(
+        message.address, 100, extraData, { from: initialHolder, value: 1000 }
+      );
+
+      (await this.token.balanceOf(message.address))
+        .should.be.bignumber.equal(new BN(100));
+      (await web3.eth.getBalance(message.address)).should.be.equal('1000');
+    });
+
+  it(
+    'should allow payment through approve'
+    , async function () {
+      await this.token.approveAndCall(
+        message.address, 100, extraData, { from: initialHolder, value: 1000 }
+      );
+
+      (await this.token.allowance(initialHolder, message.address))
+        .should.be.bignumber.equal(new BN(100));
+      (await web3.eth.getBalance(message.address)).should.be.equal('1000');
+    });
+
+  it(
+    'should allow payment through transferFrom'
+    , async function () {
+      await this.token.approve(recipient, 100, { from: initialHolder });
+
+      await this.token.transferFromAndCall(
+        initialHolder, message.address, 100, extraData, { from: recipient, value: 1000 }
+      );
+
+      (await this.token.balanceOf(message.address))
+        .should.be.bignumber.equal(new BN(100));
+      (await web3.eth.getBalance(message.address)).should.be.equal('1000');
+    });
+
+  it('should revert funds of failure inside approve', async function () {
+    await shouldFail.reverting(this.token.approveAndCall(
+      message.address, 10, extraDataFail, { from: initialHolder, value: 1000 }
+    ));
+
+    (await this.token.allowance(initialHolder, message.address))
+      .should.be.bignumber.equal(new BN(0));
+    (await web3.eth.getBalance(message.address)).should.be.equal('0');
+  });
+
+  it('should revert funds of failure inside transfer', async function () {
+    await shouldFail.reverting(this.token.transferAndCall(
+      message.address, 10, extraDataFail, { from: initialHolder, value: 1000 }
+    ));
+
+    (await this.token.allowance(initialHolder, message.address))
+      .should.be.bignumber.equal(new BN(0));
+    (await web3.eth.getBalance(message.address)).should.be.equal('0');
+  });
+
+  it('should revert funds of failure inside transferFrom', async function () {
+    await this.token.approve(anotherAccount, 10, { from: initialHolder });
+    await shouldFail.reverting(this.token.transferFromAndCall(
+      initialHolder, message.address, 10, extraDataFail, { from: anotherAccount, value: 1000 }
+    ));
+
+    (await this.token.allowance(initialHolder, anotherAccount))
+      .should.be.bignumber.equal(new BN(10));
+    (await this.token.balanceOf(message.address))
+      .should.be.bignumber.equal(new BN(0));
+    (await web3.eth.getBalance(message.address)).should.be.equal('0');
+  });
+
+  it(
+    'should return correct balances after transfer and show the event on receiver contract'
+    , async function () {
+      const { receipt } = await this.token.transferAndCall(message.address, 100, extraData, { from: initialHolder });
+      await checkSuccessEvent(receipt.transactionHash);
+      (await this.token.balanceOf(message.address))
+        .should.be.bignumber.equal(new BN(100));
+    });
+
+  it(
+    'should return correct allowance after approve and show the event on receiver contract'
+    , async function () {
+      const { receipt } = await this.token.approveAndCall(message.address, 100, extraData, { from: initialHolder });
+      await checkSuccessEvent(receipt.transactionHash);
+      (await this.token.allowance(initialHolder, message.address))
+        .should.be.bignumber.equal(new BN(100));
+    });
+
+  it(
+    'should return correct balances after transferFrom and show the event on receiver contract'
+    , async function () {
+      await this.token.approve(recipient, 100, { from: initialHolder });
+      const { receipt } = await this.token.transferFromAndCall(
+        initialHolder, message.address, 100, extraData, { from: recipient }
+      );
+      await checkSuccessEvent(receipt.transactionHash);
+      (await this.token.balanceOf(message.address))
+        .should.be.bignumber.equal(new BN(100));
+    });
+
+  it('should fail inside approve', async function () {
+    await shouldFail.reverting.withMessage(
+      this.token.approveAndCall(message.address, 10, extraDataFail, { from: initialHolder }),
+      'Call to external contract failed'
+    );
+    (await this.token.allowance(initialHolder, message.address))
+      .should.be.bignumber.equal(new BN(0));
+  });
+
+  it('should fail inside transfer', async function () {
+    await shouldFail.reverting.withMessage(
+      this.token.transferAndCall(message.address, 10, extraDataFail, { from: initialHolder }),
+      'Call to external contract failed'
+    );
+    (await this.token.balanceOf(message.address))
+      .should.be.bignumber.equal(new BN(0));
+  });
+
+  it('should fail inside transferFrom', async function () {
+    await this.token.approve(recipient, 10, { from: initialHolder });
+    await shouldFail.reverting.withMessage(
+      this.token.transferFromAndCall(initialHolder, message.address, 10, extraDataFail, { from: recipient }),
+      'Call to external contract failed'
+    );
+    (await this.token.allowance(initialHolder, recipient))
+      .should.be.bignumber.equal(new BN(10));
+    (await this.token.balanceOf(message.address))
+      .should.be.bignumber.equal(new BN(0));
+  });
+
+  it('should fail approve when using token contract address as receiver', async function () {
+    await shouldFail.reverting.withMessage(
+      this.token.approveAndCall(this.token.address, 100, extraDataFail, { from: initialHolder }),
+      'Call to external contract failed'
+    );
+  });
+
+  it('should fail transfer when using token contract address as receiver', async function () {
+    await shouldFail.reverting.withMessage(
+      this.token.transferAndCall(this.token.address, 100, extraData, { from: initialHolder }),
+      'Call to external contract failed'
+    );
+  });
+
+  it('should fail transferFrom when using token contract address as receiver', async function () {
+    await this.token.approve(recipient, 10, { from: initialHolder });
+    await shouldFail.reverting.withMessage(
+      this.token.transferFromAndCall(initialHolder, this.token.address, 10, extraData, { from: recipient }),
+      'Call to external contract failed'
+    );
+  });
+});


### PR DESCRIPTION
Adds back the ERC827 token standard once supported by the zeppelin-solidity repo. Since the issues found in the standard has been solved and updated and there is a place now in the repo where EIPs drafts can be submitted.

- Adds ERC827 folder in contracts/drafts with ERC827, ERC827Proxy and ERC827Mock.
- Adds tests for ERC827, testing it should behave like ERC20 and testing the new ERC827 methods.
