### PR TITLE
Fix spelling mistake in ERC20Burnable.sol

### DIFF
--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -9,7 +9,7 @@ import "./ERC20.sol";
  */
 contract ERC20Burnable is ERC20 {
     /**
-     * @dev Destoys `amount` tokens from the caller.
+     * @dev Destroys `amount` tokens from the caller.
      *
      * See `ERC20._burn`.
      */


### PR DESCRIPTION
- Fix spelling mistake in `ERC20Burnable.sol` (https://github.com/OpenZeppelin/openzeppelin-solidity/commit/ad86cc2c4762d336f5d9cd69975f553bfb3f9b29)