### PR TITLE
Update test-helpers to v0.4.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5712,6 +5712,11 @@
         "pkg-dir": "^3.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -6502,9 +6507,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -9609,9 +9614,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-      "integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.0.tgz",
+      "integrity": "sha512-eBpLEjI6tK4RKK44BbUBQu89lrNh+5WeX3wf2U6Uwo6RtRGAQ77qvKeuuQh3lVXHF1aPndVww9VcjqmLThIdtA==",
       "dev": true
     },
     "mout": {
@@ -10048,16 +10053,17 @@
       }
     },
     "openzeppelin-test-helpers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/openzeppelin-test-helpers/-/openzeppelin-test-helpers-0.3.2.tgz",
-      "integrity": "sha512-PFTIzyYswBt5IiZu/qayIjnS1HJ+Mr0ekVzLfube/qcUGvoA4Ru5SJdit2FYKljaPdiyvLD1jYJJecA50A2RtA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-test-helpers/-/openzeppelin-test-helpers-0.4.0.tgz",
+      "integrity": "sha512-dcYUSolaWlZuQ6Dnc75ECZVWj6/6ALUcZBeihIKT82UXF7+UozoR+Azmg6aRw+mMLf/Bktzto+44dDooGUPw9g==",
       "dev": true,
       "requires": {
         "ansi-colors": "^3.2.3",
         "chai-bn": "^0.1.1",
         "ethjs-abi": "^0.2.1",
         "semver": "^5.6.0",
-        "truffle-contract": "^4.0.8"
+        "truffle-contract": "^4.0.8",
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "semver": {
@@ -14270,13 +14276,13 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -14603,23 +14609,23 @@
       }
     },
     "truffle-blockchain-utils": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.8.tgz",
-      "integrity": "sha512-4dbgqd4GrloKNLiaXACiymE3R2PsNFOlbgOh/CGkQVLArtcbgBAl7Fg2l5yVfDV8dtOFWHddj/2UkY25KY1+Dw==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.9.tgz",
+      "integrity": "sha512-UJlWLN53AYU108c2A7rY6ri2Ollj8ygRnpSyBD4MPq+MF15PFvqwNHa/4rnj6ajOo7JYV07nNQ4hmBwh0KSeoA==",
       "dev": true
     },
     "truffle-contract": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-4.0.14.tgz",
-      "integrity": "sha512-gPSNNR/ozIkEVJO+rOu6wElNgy6NT6uH4+Bm6Kwerpnzo8eCTCTTSmBbJcaTKm+YAei7Dw7v427yU3gXPDkK/A==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-4.0.17.tgz",
+      "integrity": "sha512-LV9Ws/RaHReSf6gTmrka92I4jXRPy59t3bsiF0655gAXe7Pz4DYCTmNti2bR7/vZIU8qtLlDSUmImuyFpO8p5g==",
       "dev": true,
       "requires": {
         "bignumber.js": "^7.2.1",
         "ethers": "^4.0.0-beta.1",
-        "truffle-blockchain-utils": "^0.0.8",
+        "truffle-blockchain-utils": "^0.0.9",
         "truffle-contract-schema": "^3.0.9",
         "truffle-error": "^0.0.4",
-        "truffle-interface-adapter": "^0.1.4",
+        "truffle-interface-adapter": "^0.1.5",
         "web3": "1.0.0-beta.37",
         "web3-core-promievent": "1.0.0-beta.37",
         "web3-eth-abi": "1.0.0-beta.37",
@@ -14661,9 +14667,9 @@
       "dev": true
     },
     "truffle-interface-adapter": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/truffle-interface-adapter/-/truffle-interface-adapter-0.1.4.tgz",
-      "integrity": "sha512-BVqHzsqHO1KKjTLLmkphmPxdeSvlpqPmDrAVg5QzOpAjqtBE0QV6bQOtBcZGCVY6eh37mfbNpaKKSXauziRr6w==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/truffle-interface-adapter/-/truffle-interface-adapter-0.1.5.tgz",
+      "integrity": "sha512-TbKD7oUdz/0GqeR4PStNoad4uwKkHtZMUQQH+Xyy5acVZxBCJ7uTGwYVaOvtxeAITaX5zxeyhjlU8IKyrnd4QA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.8",
@@ -15312,9 +15318,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
           "dev": true
         },
         "elliptic": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "micromatch": "^4.0.2",
     "nodemon": "^1.19.0",
     "openzeppelin-docsite": "github:OpenZeppelin/openzeppelin-docsite#22388b7a891a6fcdd333efef9e4f7f584ae5b826",
-    "openzeppelin-test-helpers": "^0.3.2",
+    "openzeppelin-test-helpers": "^0.4",
     "solhint": "^1.5.0",
     "solidity-coverage": "github:rotcivegaf/solidity-coverage#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
     "solidity-docgen": "github:OpenZeppelin/solidity-docgen#03f42b5e271b1e1c1d0b814b921ecdc086055255",

--- a/test/access/Roles.test.js
+++ b/test/access/Roles.test.js
@@ -1,4 +1,4 @@
-const { shouldFail, constants } = require('openzeppelin-test-helpers');
+const { expectRevert, constants } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const RolesMock = artifacts.require('RolesMock');
@@ -9,7 +9,7 @@ contract('Roles', function ([_, authorized, otherAuthorized, other]) {
   });
 
   it('reverts when querying roles for the zero account', async function () {
-    await shouldFail.reverting.withMessage(this.roles.has(ZERO_ADDRESS), 'Roles: account is the zero address');
+    await expectRevert(this.roles.has(ZERO_ADDRESS), 'Roles: account is the zero address');
   });
 
   context('initially', function () {
@@ -28,11 +28,11 @@ contract('Roles', function ([_, authorized, otherAuthorized, other]) {
 
       it('reverts when adding roles to an already assigned account', async function () {
         await this.roles.add(authorized);
-        await shouldFail.reverting.withMessage(this.roles.add(authorized), 'Roles: account already has role');
+        await expectRevert(this.roles.add(authorized), 'Roles: account already has role');
       });
 
       it('reverts when adding roles to the zero account', async function () {
-        await shouldFail.reverting.withMessage(this.roles.add(ZERO_ADDRESS), 'Roles: account is the zero address');
+        await expectRevert(this.roles.add(ZERO_ADDRESS), 'Roles: account is the zero address');
       });
     });
   });
@@ -51,11 +51,11 @@ contract('Roles', function ([_, authorized, otherAuthorized, other]) {
       });
 
       it('reverts when removing unassigned roles', async function () {
-        await shouldFail.reverting.withMessage(this.roles.remove(other), 'Roles: account does not have role');
+        await expectRevert(this.roles.remove(other), 'Roles: account does not have role');
       });
 
       it('reverts when removing roles from the zero account', async function () {
-        await shouldFail.reverting.withMessage(this.roles.remove(ZERO_ADDRESS), 'Roles: account is the zero address');
+        await expectRevert(this.roles.remove(ZERO_ADDRESS), 'Roles: account is the zero address');
       });
     });
   });

--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -1,4 +1,4 @@
-const { shouldFail, constants, expectEvent } = require('openzeppelin-test-helpers');
+const { expectRevert, constants, expectEvent } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function capitalize (str) {
@@ -39,7 +39,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
     }
 
     it('reverts when querying roles for the null account', async function () {
-      await shouldFail.reverting.withMessage(this.contract[`is${rolename}`](ZERO_ADDRESS),
+      await expectRevert(this.contract[`is${rolename}`](ZERO_ADDRESS),
         'Roles: account is the zero address'
       );
     });
@@ -57,7 +57,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
         const from = other;
 
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.contract[`only${rolename}Mock`]({ from }),
+          await expectRevert(this.contract[`only${rolename}Mock`]({ from }),
             `${rolename}Role: caller does not have the ${rolename} role`
           );
         });
@@ -79,13 +79,13 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
         });
 
         it('reverts when adding role to an already assigned account', async function () {
-          await shouldFail.reverting.withMessage(this.contract[`add${rolename}`](authorized, { from }),
+          await expectRevert(this.contract[`add${rolename}`](authorized, { from }),
             'Roles: account already has role'
           );
         });
 
         it('reverts when adding role to the null account', async function () {
-          await shouldFail.reverting.withMessage(this.contract[`add${rolename}`](ZERO_ADDRESS, { from }),
+          await expectRevert(this.contract[`add${rolename}`](ZERO_ADDRESS, { from }),
             'Roles: account is the zero address'
           );
         });
@@ -109,13 +109,13 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
         });
 
         it('reverts when removing from an unassigned account', async function () {
-          await shouldFail.reverting.withMessage(this.contract[`remove${rolename}`](other, { from }),
+          await expectRevert(this.contract[`remove${rolename}`](other, { from }),
             'Roles: account does not have role'
           );
         });
 
         it('reverts when removing role from the null account', async function () {
-          await shouldFail.reverting.withMessage(this.contract[`remove${rolename}`](ZERO_ADDRESS, { from }),
+          await expectRevert(this.contract[`remove${rolename}`](ZERO_ADDRESS, { from }),
             'Roles: account is the zero address'
           );
         });
@@ -134,7 +134,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
       });
 
       it('reverts when renouncing unassigned role', async function () {
-        await shouldFail.reverting.withMessage(this.contract[`renounce${rolename}`]({ from: other }),
+        await expectRevert(this.contract[`renounce${rolename}`]({ from: other }),
           'Roles: account does not have role'
         );
       });

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { balance, BN, constants, ether, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { balance, BN, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const AllowanceCrowdsaleImpl = artifacts.require('AllowanceCrowdsaleImpl');
@@ -75,7 +75,7 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
   describe('when token wallet is the zero address', function () {
     it('creation reverts', async function () {
       this.token = await SimpleToken.new({ from: tokenWallet });
-      await shouldFail.reverting.withMessage(AllowanceCrowdsaleImpl.new(rate, wallet, this.token.address, ZERO_ADDRESS),
+      await expectRevert(AllowanceCrowdsaleImpl.new(rate, wallet, this.token.address, ZERO_ADDRESS),
         'AllowanceCrowdsale: token wallet is the zero address'
       );
     });

--- a/test/crowdsale/CappedCrowdsale.test.js
+++ b/test/crowdsale/CappedCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 
 const CappedCrowdsaleImpl = artifacts.require('CappedCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -14,7 +14,7 @@ contract('CappedCrowdsale', function ([_, wallet]) {
   });
 
   it('rejects a cap of zero', async function () {
-    await shouldFail.reverting.withMessage(CappedCrowdsaleImpl.new(rate, wallet, this.token.address, 0),
+    await expectRevert(CappedCrowdsaleImpl.new(rate, wallet, this.token.address, 0),
       'CappedCrowdsale: cap is 0'
     );
   });
@@ -33,11 +33,11 @@ contract('CappedCrowdsale', function ([_, wallet]) {
 
       it('should reject payments outside cap', async function () {
         await this.crowdsale.send(cap);
-        await shouldFail.reverting.withMessage(this.crowdsale.send(1), 'CappedCrowdsale: cap exceeded');
+        await expectRevert(this.crowdsale.send(1), 'CappedCrowdsale: cap exceeded');
       });
 
       it('should reject payments that exceed cap', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.send(cap.addn(1)), 'CappedCrowdsale: cap exceeded');
+        await expectRevert(this.crowdsale.send(cap.addn(1)), 'CappedCrowdsale: cap exceeded');
       });
     });
 

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -1,4 +1,4 @@
-const { balance, BN, constants, ether, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { balance, BN, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const Crowdsale = artifacts.require('CrowdsaleMock');
@@ -11,7 +11,7 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
   const expectedTokenAmount = rate.mul(value);
 
   it('requires a non-null token', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       Crowdsale.new(rate, wallet, ZERO_ADDRESS),
       'Crowdsale: token is the zero address'
     );
@@ -23,13 +23,13 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
     });
 
     it('requires a non-zero rate', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         Crowdsale.new(0, wallet, this.token.address), 'Crowdsale: rate is 0'
       );
     });
 
     it('requires a non-null wallet', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         Crowdsale.new(rate, ZERO_ADDRESS, this.token.address), 'Crowdsale: wallet is the zero address'
       );
     });
@@ -47,7 +47,7 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
           });
 
           it('reverts on zero-valued payments', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.crowdsale.send(0, { from: purchaser }), 'Crowdsale: weiAmount is 0'
             );
           });
@@ -59,13 +59,13 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
           });
 
           it('reverts on zero-valued payments', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.crowdsale.buyTokens(investor, { value: 0, from: purchaser }), 'Crowdsale: weiAmount is 0'
             );
           });
 
           it('requires a non-null beneficiary', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.crowdsale.buyTokens(ZERO_ADDRESS, { value: value, from: purchaser }),
               'Crowdsale: beneficiary is the zero address'
             );

--- a/test/crowdsale/FinalizableCrowdsale.test.js
+++ b/test/crowdsale/FinalizableCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, expectEvent, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, expectEvent, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const FinalizableCrowdsaleImpl = artifacts.require('FinalizableCrowdsaleImpl');
 const ERC20 = artifacts.require('ERC20');
@@ -23,7 +23,7 @@ contract('FinalizableCrowdsale', function ([_, wallet, other]) {
   });
 
   it('cannot be finalized before ending', async function () {
-    await shouldFail.reverting.withMessage(this.crowdsale.finalize({ from: other }),
+    await expectRevert(this.crowdsale.finalize({ from: other }),
       'FinalizableCrowdsale: not closed'
     );
   });
@@ -36,7 +36,7 @@ contract('FinalizableCrowdsale', function ([_, wallet, other]) {
   it('cannot be finalized twice', async function () {
     await time.increaseTo(this.afterClosingTime);
     await this.crowdsale.finalize({ from: other });
-    await shouldFail.reverting.withMessage(this.crowdsale.finalize({ from: other }),
+    await expectRevert(this.crowdsale.finalize({ from: other }),
       'FinalizableCrowdsale: already finalized'
     );
   });

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const IncreasingPriceCrowdsaleImpl = artifacts.require('IncreasingPriceCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -26,19 +26,19 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
     });
 
     it('reverts with a final rate larger than the initial rate', async function () {
-      await shouldFail.reverting.withMessage(IncreasingPriceCrowdsaleImpl.new(
+      await expectRevert(IncreasingPriceCrowdsaleImpl.new(
         this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate.addn(1)
       ), 'IncreasingPriceCrowdsale: initial rate is not greater than final rate');
     });
 
     it('reverts with a final rate equal to the initial rate', async function () {
-      await shouldFail.reverting.withMessage(IncreasingPriceCrowdsaleImpl.new(
+      await expectRevert(IncreasingPriceCrowdsaleImpl.new(
         this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate
       ), 'IncreasingPriceCrowdsale: initial rate is not greater than final rate');
     });
 
     it('reverts with a final rate of zero', async function () {
-      await shouldFail.reverting.withMessage(IncreasingPriceCrowdsaleImpl.new(
+      await expectRevert(IncreasingPriceCrowdsaleImpl.new(
         this.startTime, this.closingTime, wallet, this.token.address, initialRate, 0
       ), 'IncreasingPriceCrowdsale: final rate is 0');
     });
@@ -57,7 +57,7 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
       });
 
       it('reverts when the base Crowdsale\'s rate function is called', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.rate(),
+        await expectRevert(this.crowdsale.rate(),
           'IncreasingPriceCrowdsale: rate() called'
         );
       });

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 
 const IndividuallyCappedCrowdsaleImpl = artifacts.require('IndividuallyCappedCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -34,7 +34,7 @@ contract('IndividuallyCappedCrowdsale', function (
     });
 
     it('reverts when a non-capper sets a cap', async function () {
-      await shouldFail.reverting.withMessage(this.crowdsale.setCap(alice, capAlice, { from: other }),
+      await expectRevert(this.crowdsale.setCap(alice, capAlice, { from: other }),
         'CapperRole: caller does not have the Capper role'
       );
     });
@@ -54,29 +54,29 @@ contract('IndividuallyCappedCrowdsale', function (
 
         it('should reject payments outside cap', async function () {
           await this.crowdsale.buyTokens(alice, { value: capAlice });
-          await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(alice, { value: 1 }),
+          await expectRevert(this.crowdsale.buyTokens(alice, { value: 1 }),
             'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
           );
         });
 
         it('should reject payments that exceed cap', async function () {
-          await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(alice, { value: capAlice.addn(1) }),
+          await expectRevert(this.crowdsale.buyTokens(alice, { value: capAlice.addn(1) }),
             'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
           );
-          await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(bob, { value: capBob.addn(1) }),
+          await expectRevert(this.crowdsale.buyTokens(bob, { value: capBob.addn(1) }),
             'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
           );
         });
 
         it('should manage independent caps', async function () {
           await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
-          await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(bob, { value: lessThanCapAlice }),
+          await expectRevert(this.crowdsale.buyTokens(bob, { value: lessThanCapAlice }),
             'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
           );
         });
 
         it('should default to a cap of zero', async function () {
-          await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }),
+          await expectRevert(this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }),
             'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
           );
         });

--- a/test/crowdsale/MintedCrowdsale.test.js
+++ b/test/crowdsale/MintedCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 const { shouldBehaveLikeMintedCrowdsale } = require('./MintedCrowdsale.behavior');
 
 const MintedCrowdsaleImpl = artifacts.require('MintedCrowdsaleImpl');
@@ -32,11 +32,11 @@ contract('MintedCrowdsale', function ([_, deployer, investor, wallet, purchaser]
     });
 
     it('rejects bare payments', async function () {
-      await shouldFail.reverting(this.crowdsale.send(value));
+      await expectRevert.unspecified(this.crowdsale.send(value));
     });
 
     it('rejects token purchases', async function () {
-      await shouldFail.reverting(this.crowdsale.buyTokens(investor, { value: value, from: purchaser }));
+      await expectRevert.unspecified(this.crowdsale.buyTokens(investor, { value: value, from: purchaser }));
     });
   });
 });

--- a/test/crowdsale/PausableCrowdsale.test.js
+++ b/test/crowdsale/PausableCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, expectRevert } = require('openzeppelin-test-helpers');
 
 const PausableCrowdsale = artifacts.require('PausableCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -26,10 +26,10 @@ contract('PausableCrowdsale', function ([_, pauser, wallet, other]) {
     });
 
     it('purchases do not work', async function () {
-      await shouldFail.reverting.withMessage(this.crowdsale.sendTransaction({ from: other, value }),
+      await expectRevert(this.crowdsale.sendTransaction({ from: other, value }),
         'Pausable: paused'
       );
-      await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(other, { from: other, value }),
+      await expectRevert(this.crowdsale.buyTokens(other, { from: other, value }),
         'Pausable: paused'
       );
     });

--- a/test/crowdsale/PostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/PostDeliveryCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const PostDeliveryCrowdsaleImpl = artifacts.require('PostDeliveryCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -41,7 +41,7 @@ contract('PostDeliveryCrowdsale', function ([_, investor, wallet, purchaser]) {
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+        await expectRevert(this.crowdsale.withdrawTokens(investor),
           'PostDeliveryCrowdsale: not closed'
         );
       });
@@ -59,7 +59,7 @@ contract('PostDeliveryCrowdsale', function ([_, investor, wallet, purchaser]) {
 
         it('rejects multiple withdrawals', async function () {
           await this.crowdsale.withdrawTokens(investor);
-          await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+          await expectRevert(this.crowdsale.withdrawTokens(investor),
             'PostDeliveryCrowdsale: beneficiary is not due any tokens'
           );
         });

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { balance, BN, ether, shouldFail, time } = require('openzeppelin-test-helpers');
+const { balance, BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const RefundableCrowdsaleImpl = artifacts.require('RefundableCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -24,7 +24,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
   });
 
   it('rejects a goal of zero', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       RefundableCrowdsaleImpl.new(this.openingTime, this.closingTime, rate, wallet, this.token.address, 0),
       'RefundableCrowdsale: goal is 0'
     );
@@ -41,7 +41,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
 
     context('before opening time', function () {
       it('denies refunds', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.claimRefund(investor),
+        await expectRevert(this.crowdsale.claimRefund(investor),
           'RefundableCrowdsale: not finalized'
         );
       });
@@ -53,7 +53,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
       });
 
       it('denies refunds', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.claimRefund(investor),
+        await expectRevert(this.crowdsale.claimRefund(investor),
           'RefundableCrowdsale: not finalized'
         );
       });
@@ -89,7 +89,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
           });
 
           it('denies refunds', async function () {
-            await shouldFail.reverting.withMessage(this.crowdsale.claimRefund(investor),
+            await expectRevert(this.crowdsale.claimRefund(investor),
               'RefundableCrowdsale: goal reached'
             );
           });

--- a/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const RefundablePostDeliveryCrowdsaleImpl = artifacts.require('RefundablePostDeliveryCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -42,7 +42,7 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+        await expectRevert(this.crowdsale.withdrawTokens(investor),
           'RefundablePostDeliveryCrowdsale: not finalized'
         );
       });
@@ -54,7 +54,7 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
         });
 
         it('rejects token withdrawals', async function () {
-          await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+          await expectRevert(this.crowdsale.withdrawTokens(investor),
             'RefundablePostDeliveryCrowdsale: goal not reached'
           );
         });
@@ -74,7 +74,7 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
-        await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+        await expectRevert(this.crowdsale.withdrawTokens(investor),
           'RefundablePostDeliveryCrowdsale: not finalized'
         );
       });
@@ -93,7 +93,7 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
 
         it('rejects multiple withdrawals', async function () {
           await this.crowdsale.withdrawTokens(investor);
-          await shouldFail.reverting.withMessage(this.crowdsale.withdrawTokens(investor),
+          await expectRevert(this.crowdsale.withdrawTokens(investor),
             'PostDeliveryCrowdsale: beneficiary is not due any tokens'
           );
         });

--- a/test/crowdsale/WhitelistCrowdsale.test.js
+++ b/test/crowdsale/WhitelistCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 
 const WhitelistCrowdsale = artifacts.require('WhitelistCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -19,19 +19,19 @@ contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, o
     await crowdsale.sendTransaction({ from: beneficiary, value });
   }
 
-  async function purchaseShouldFail (crowdsale, beneficiary, value) {
-    await shouldFail.reverting.withMessage(crowdsale.buyTokens(beneficiary, { from: beneficiary, value }),
+  async function purchaseExpectRevert (crowdsale, beneficiary, value) {
+    await expectRevert(crowdsale.buyTokens(beneficiary, { from: beneficiary, value }),
       'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role'
     );
-    await shouldFail.reverting.withMessage(crowdsale.sendTransaction({ from: beneficiary, value }),
+    await expectRevert(crowdsale.sendTransaction({ from: beneficiary, value }),
       'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role'
     );
   }
 
   context('with no whitelisted addresses', function () {
     it('rejects all purchases', async function () {
-      await purchaseShouldFail(this.crowdsale, other, value);
-      await purchaseShouldFail(this.crowdsale, whitelisted, value);
+      await purchaseExpectRevert(this.crowdsale, other, value);
+      await purchaseExpectRevert(this.crowdsale, whitelisted, value);
     });
   });
 
@@ -47,11 +47,11 @@ contract('WhitelistCrowdsale', function ([_, wallet, whitelister, whitelisted, o
     });
 
     it('rejects purchases from whitelisted addresses with non-whitelisted beneficiaries', async function () {
-      await shouldFail(this.crowdsale.buyTokens(other, { from: whitelisted, value }));
+      await expectRevert.unspecified(this.crowdsale.buyTokens(other, { from: whitelisted, value }));
     });
 
     it('rejects purchases with non-whitelisted beneficiaries', async function () {
-      await purchaseShouldFail(this.crowdsale, other, value);
+      await purchaseExpectRevert(this.crowdsale, other, value);
     });
   });
 });

--- a/test/cryptography/ECDSA.test.js
+++ b/test/cryptography/ECDSA.test.js
@@ -1,4 +1,4 @@
-const { constants, shouldFail } = require('openzeppelin-test-helpers');
+const { constants, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 const { toEthSignedMessageHash, fixSignature } = require('../helpers/sign');
 
@@ -118,7 +118,7 @@ contract('ECDSA', function ([_, other]) {
       it.skip('reverts', async function () {
         // Create the signature
         const signature = await web3.eth.sign(TEST_MESSAGE, other);
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.ecdsa.recover(TEST_MESSAGE.substring(2), signature),
           'Failure message'
         );

--- a/test/drafts/Counters.test.js
+++ b/test/drafts/Counters.test.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 
 const CountersImpl = artifacts.require('CountersImpl');
 
@@ -39,7 +39,7 @@ contract('Counters', function () {
 
     it('reverts if the current value is 0', async function () {
       await this.counter.decrement();
-      await shouldFail.reverting.withMessage(this.counter.decrement(), 'SafeMath: subtraction overflow');
+      await expectRevert(this.counter.decrement(), 'SafeMath: subtraction overflow');
     });
 
     it('can be called multiple times', async function () {

--- a/test/drafts/ERC20Migrator.test.js
+++ b/test/drafts/ERC20Migrator.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const ERC20Mock = artifacts.require('ERC20Mock');
@@ -9,7 +9,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
   const totalSupply = new BN('200');
 
   it('reverts with a null legacy token address', async function () {
-    await shouldFail.reverting.withMessage(ERC20Migrator.new(ZERO_ADDRESS),
+    await expectRevert(ERC20Migrator.new(ZERO_ADDRESS),
       'ERC20Migrator: legacy token is the zero address'
     );
   });
@@ -27,13 +27,13 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
 
     describe('beginMigration', function () {
       it('reverts with a null new token address', async function () {
-        await shouldFail.reverting.withMessage(this.migrator.beginMigration(ZERO_ADDRESS),
+        await expectRevert(this.migrator.beginMigration(ZERO_ADDRESS),
           'ERC20Migrator: new token is the zero address'
         );
       });
 
       it('reverts if not a minter of the token', async function () {
-        await shouldFail.reverting.withMessage(this.migrator.beginMigration(this.newToken.address),
+        await expectRevert(this.migrator.beginMigration(this.newToken.address),
           'ERC20Migrator: not a minter for new token'
         );
       });
@@ -46,7 +46,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
       it('reverts the second time it is called', async function () {
         await this.newToken.addMinter(this.migrator.address);
         await this.migrator.beginMigration(this.newToken.address);
-        await shouldFail.reverting.withMessage(this.migrator.beginMigration(this.newToken.address),
+        await expectRevert(this.migrator.beginMigration(this.newToken.address),
           'ERC20Migrator: migration already started'
         );
       });
@@ -66,7 +66,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
           });
 
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.migrator.migrateAll(owner),
+            await expectRevert(this.migrator.migrateAll(owner),
               'ERC20Migrator: migration not started'
             );
           });
@@ -82,7 +82,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
           });
 
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.migrator.migrate(owner, amount),
+            await expectRevert(this.migrator.migrate(owner, amount),
               'ERC20Migrator: migration not started'
             );
           });
@@ -186,7 +186,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
           const amount = baseAmount.addn(1);
 
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.migrator.migrate(owner, amount),
+            await expectRevert(this.migrator.migrate(owner, amount),
               'SafeERC20: low-level call failed'
             );
           });

--- a/test/drafts/ERC20Snapshot.test.js
+++ b/test/drafts/ERC20Snapshot.test.js
@@ -1,4 +1,4 @@
-const { BN, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const ERC20SnapshotMock = artifacts.require('ERC20SnapshotMock');
 
 contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
@@ -24,11 +24,11 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
 
   describe('totalSupplyAt', function () {
     it('reverts with a snapshot id of 0', async function () {
-      await shouldFail.reverting.withMessage(this.token.totalSupplyAt(0), 'ERC20Snapshot: id is 0');
+      await expectRevert(this.token.totalSupplyAt(0), 'ERC20Snapshot: id is 0');
     });
 
     it('reverts with a not-yet-created snapshot id', async function () {
-      await shouldFail.reverting.withMessage(this.token.totalSupplyAt(1), 'ERC20Snapshot: nonexistent id');
+      await expectRevert(this.token.totalSupplyAt(1), 'ERC20Snapshot: nonexistent id');
     });
 
     context('with initial snapshot', function () {
@@ -98,11 +98,11 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
 
   describe('balanceOfAt', function () {
     it('reverts with a snapshot id of 0', async function () {
-      await shouldFail.reverting.withMessage(this.token.balanceOfAt(other, 0), 'ERC20Snapshot: id is 0');
+      await expectRevert(this.token.balanceOfAt(other, 0), 'ERC20Snapshot: id is 0');
     });
 
     it('reverts with a not-yet-created snapshot id', async function () {
-      await shouldFail.reverting.withMessage(this.token.balanceOfAt(other, 1), 'ERC20Snapshot: nonexistent id');
+      await expectRevert(this.token.balanceOfAt(other, 1), 'ERC20Snapshot: nonexistent id');
     });
 
     context('with initial snapshot', function () {

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 const { getSignFor } = require('../helpers/sign');
 const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
 
@@ -30,21 +30,21 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow invalid signature for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignature(INVALID_SIGNATURE, { from: authorizedUser }),
           'SignatureBouncer: invalid signature for caller'
         );
       });
 
       it('does not allow valid signature for other sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignature(await this.signFor(authorizedUser), { from: other }),
           'SignatureBouncer: invalid signature for caller'
         );
       });
 
       it('does not allow valid signature for method for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignature(await this.signFor(authorizedUser, 'onlyWithValidSignature'),
             { from: authorizedUser }), 'SignatureBouncer: invalid signature for caller'
         );
@@ -59,14 +59,14 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow invalid signature with correct method for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndMethod(INVALID_SIGNATURE, { from: authorizedUser }),
           'SignatureBouncer: invalid signature for caller and method'
         );
       });
 
       it('does not allow valid signature with correct method for other sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndMethod(
             await this.signFor(authorizedUser, 'onlyWithValidSignatureAndMethod'), { from: other }
           ),
@@ -75,14 +75,14 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow valid method signature with incorrect method for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndMethod(await this.signFor(authorizedUser, 'theWrongMethod'),
             { from: authorizedUser }), 'SignatureBouncer: invalid signature for caller and method'
         );
       });
 
       it('does not allow valid non-method signature method for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndMethod(await this.signFor(authorizedUser), { from: authorizedUser }),
           'SignatureBouncer: invalid signature for caller and method'
         );
@@ -97,14 +97,14 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow invalid signature with correct method and data for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndData(UINT_VALUE, INVALID_SIGNATURE, { from: authorizedUser }),
           'SignatureBouncer: invalid signature for caller and data'
         );
       });
 
       it('does not allow valid signature with correct method and incorrect data for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndData(UINT_VALUE + 10,
             await this.signFor(authorizedUser, 'onlyWithValidSignatureAndData', [UINT_VALUE]),
             { from: authorizedUser }
@@ -113,7 +113,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow valid signature with correct method and data for other sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndData(UINT_VALUE,
             await this.signFor(authorizedUser, 'onlyWithValidSignatureAndData', [UINT_VALUE]),
             { from: other }
@@ -122,7 +122,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow valid non-method signature for sender', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.onlyWithValidSignatureAndData(UINT_VALUE,
             await this.signFor(authorizedUser), { from: authorizedUser }
           ), 'SignatureBouncer: invalid signature for caller and data'
@@ -130,7 +130,7 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
       });
 
       it('does not allow msg.data shorter than SIGNATURE_SIZE', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.sigBouncer.tooShortMsgData({ from: authorizedUser }), 'SignatureBouncer: data is too short'
         );
       });

--- a/test/drafts/SignedSafeMath.test.js
+++ b/test/drafts/SignedSafeMath.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
 const { MAX_INT256, MIN_INT256 } = constants;
 
 const SignedSafeMathMock = artifacts.require('SignedSafeMathMock');
@@ -14,8 +14,8 @@ contract('SignedSafeMath', function () {
   }
 
   async function testFailsCommutative (fn, lhs, rhs, reason) {
-    await shouldFail.reverting.withMessage(fn(lhs, rhs), reason);
-    await shouldFail.reverting.withMessage(fn(rhs, lhs), reason);
+    await expectRevert(fn(lhs, rhs), reason);
+    await expectRevert(fn(rhs, lhs), reason);
   }
 
   describe('add', function () {
@@ -69,14 +69,14 @@ contract('SignedSafeMath', function () {
       const a = MAX_INT256;
       const b = new BN('-1');
 
-      await shouldFail.reverting.withMessage(this.safeMath.sub(a, b), 'SignedSafeMath: subtraction overflow');
+      await expectRevert(this.safeMath.sub(a, b), 'SignedSafeMath: subtraction overflow');
     });
 
     it('reverts on negative subtraction overflow', async function () {
       const a = MIN_INT256;
       const b = new BN('1');
 
-      await shouldFail.reverting.withMessage(this.safeMath.sub(a, b), 'SignedSafeMath: subtraction overflow');
+      await expectRevert(this.safeMath.sub(a, b), 'SignedSafeMath: subtraction overflow');
     });
   });
 
@@ -137,14 +137,14 @@ contract('SignedSafeMath', function () {
       const a = new BN('-5678');
       const b = new BN('0');
 
-      await shouldFail.reverting.withMessage(this.safeMath.div(a, b), 'SignedSafeMath: division by zero');
+      await expectRevert(this.safeMath.div(a, b), 'SignedSafeMath: division by zero');
     });
 
     it('reverts on overflow, negative second', async function () {
       const a = new BN(MIN_INT256);
       const b = new BN('-1');
 
-      await shouldFail.reverting.withMessage(this.safeMath.div(a, b), 'SignedSafeMath: division overflow');
+      await expectRevert(this.safeMath.div(a, b), 'SignedSafeMath: division overflow');
     });
   });
 });

--- a/test/drafts/TokenVesting.test.js
+++ b/test/drafts/TokenVesting.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert, time } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const ERC20Mintable = artifacts.require('ERC20Mintable');
@@ -20,14 +20,14 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
     cliffDuration.should.be.bignumber.that.is.at.least(duration);
 
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       TokenVesting.new(beneficiary, this.start, cliffDuration, duration, true, { from: owner }),
       'TokenVesting: cliff is longer than duration'
     );
   });
 
   it('reverts with a null beneficiary', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       TokenVesting.new(ZERO_ADDRESS, this.start, this.cliffDuration, this.duration, true, { from: owner }),
       'TokenVesting: beneficiary is the zero address'
     );
@@ -35,7 +35,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
   it('reverts with a null duration', async function () {
     // cliffDuration should also be 0, since the duration must be larger than the cliff
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       TokenVesting.new(beneficiary, this.start, 0, 0, true, { from: owner }), 'TokenVesting: duration is 0'
     );
   });
@@ -44,7 +44,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
     const now = await time.latest();
 
     this.start = now.sub(this.duration).sub(time.duration.minutes(1));
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       TokenVesting.new(beneficiary, this.start, this.cliffDuration, this.duration, true, { from: owner }),
       'TokenVesting: final time is before current time'
     );
@@ -68,7 +68,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
     });
 
     it('cannot be released before cliff', async function () {
-      await shouldFail.reverting.withMessage(this.vesting.release(this.token.address),
+      await expectRevert(this.vesting.release(this.token.address),
         'TokenVesting: no tokens are due'
       );
     });
@@ -126,7 +126,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
         beneficiary, this.start, this.cliffDuration, this.duration, false, { from: owner }
       );
 
-      await shouldFail.reverting.withMessage(vesting.revoke(this.token.address, { from: owner }),
+      await expectRevert(vesting.revoke(this.token.address, { from: owner }),
         'TokenVesting: cannot revoke'
       );
     });
@@ -155,7 +155,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
     it('should fail to be revoked a second time', async function () {
       await this.vesting.revoke(this.token.address, { from: owner });
-      await shouldFail.reverting.withMessage(this.vesting.revoke(this.token.address, { from: owner }),
+      await expectRevert(this.vesting.revoke(this.token.address, { from: owner }),
         'TokenVesting: token already revoked'
       );
     });

--- a/test/examples/SampleCrowdsale.test.js
+++ b/test/examples/SampleCrowdsale.test.js
@@ -1,4 +1,4 @@
-const { BN, balance, ether, shouldFail, time } = require('openzeppelin-test-helpers');
+const { BN, balance, ether, expectRevert, time } = require('openzeppelin-test-helpers');
 
 const SampleCrowdsale = artifacts.require('SampleCrowdsale');
 const SampleCrowdsaleToken = artifacts.require('SampleCrowdsaleToken');
@@ -38,8 +38,8 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
   });
 
   it('should not accept payments before start', async function () {
-    await shouldFail.reverting.withMessage(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
-    await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(investor, { from: investor, value: ether('1') }),
+    await expectRevert(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
+    await expectRevert(this.crowdsale.buyTokens(investor, { from: investor, value: ether('1') }),
       'TimedCrowdsale: not open'
     );
   });
@@ -57,8 +57,8 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
 
   it('should reject payments after end', async function () {
     await time.increaseTo(this.afterClosingTime);
-    await shouldFail.reverting.withMessage(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
-    await shouldFail.reverting.withMessage(this.crowdsale.buyTokens(investor, { value: ether('1'), from: investor }),
+    await expectRevert(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
+    await expectRevert(this.crowdsale.buyTokens(investor, { value: ether('1'), from: investor }),
       'TimedCrowdsale: not open'
     );
   });
@@ -66,7 +66,7 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
   it('should reject payments over cap', async function () {
     await time.increaseTo(this.openingTime);
     await this.crowdsale.send(CAP);
-    await shouldFail.reverting.withMessage(this.crowdsale.send(1), 'CappedCrowdsale: cap exceeded');
+    await expectRevert(this.crowdsale.send(1), 'CappedCrowdsale: cap exceeded');
   });
 
   it('should allow finalization and transfer funds to wallet if the goal is reached', async function () {
@@ -97,7 +97,7 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
     const HIGH_GOAL = ether('30');
 
     it('creation reverts', async function () {
-      await shouldFail.reverting.withMessage(SampleCrowdsale.new(
+      await expectRevert(SampleCrowdsale.new(
         this.openingTime, this.closingTime, RATE, wallet, CAP, this.token.address, HIGH_GOAL
       ), 'SampleCrowdSale: goal is greater than cap');
     });

--- a/test/introspection/ERC165.test.js
+++ b/test/introspection/ERC165.test.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 const { shouldSupportInterfaces } = require('./SupportsInterface.behavior');
 
 const ERC165Mock = artifacts.require('ERC165Mock');
@@ -9,7 +9,7 @@ contract('ERC165', function () {
   });
 
   it('does not allow 0xffffffff', async function () {
-    await shouldFail.reverting.withMessage(this.mock.registerInterface('0xffffffff'), 'ERC165: invalid interface id');
+    await expectRevert(this.mock.registerInterface('0xffffffff'), 'ERC165: invalid interface id');
   });
 
   shouldSupportInterfaces([

--- a/test/introspection/ERC1820Implementer.test.js
+++ b/test/introspection/ERC1820Implementer.test.js
@@ -1,4 +1,4 @@
-const { shouldFail, singletons } = require('openzeppelin-test-helpers');
+const { expectRevert, singletons } = require('openzeppelin-test-helpers');
 const { bufferToHex, keccak256 } = require('ethereumjs-util');
 
 const ERC1820ImplementerMock = artifacts.require('ERC1820ImplementerMock');
@@ -21,7 +21,7 @@ contract('ERC1820Implementer', function ([_, registryFunder, implementee, other]
     });
 
     it('reverts when attempting to set as implementer in the registry', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.registry.setInterfaceImplementer(
           implementee, this.interfaceA, this.implementer.address, { from: implementee }
         ),

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -30,10 +30,10 @@ const INTERFACES = {
 const INTERFACE_IDS = {};
 const FN_SIGNATURES = {};
 for (const k of Object.getOwnPropertyNames(INTERFACES)) {
-  INTERFACE_IDS[k] = makeInterfaceId(INTERFACES[k]);
+  INTERFACE_IDS[k] = makeInterfaceId.ERC165(INTERFACES[k]);
   for (const fnName of INTERFACES[k]) {
     // the interface id of a single function is equivalent to its function signature
-    FN_SIGNATURES[fnName] = makeInterfaceId([fnName]);
+    FN_SIGNATURES[fnName] = makeInterfaceId.ERC165([fnName]);
   }
 }
 

--- a/test/lifecycle/Pausable.test.js
+++ b/test/lifecycle/Pausable.test.js
@@ -1,4 +1,4 @@
-const { expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
 
 const PausableMock = artifacts.require('PausableMock');
@@ -30,7 +30,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
     });
 
     it('cannot take drastic measure in non-pause', async function () {
-      await shouldFail.reverting.withMessage(this.pausable.drasticMeasure({ from: other }),
+      await expectRevert(this.pausable.drasticMeasure({ from: other }),
         'Pausable: not paused'
       );
       (await this.pausable.drasticMeasureTaken()).should.equal(false);
@@ -43,7 +43,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
       });
 
       it('reverts when pausing from non-pauser', async function () {
-        await shouldFail.reverting.withMessage(this.pausable.pause({ from: other }),
+        await expectRevert(this.pausable.pause({ from: other }),
           'PauserRole: caller does not have the Pauser role'
         );
       });
@@ -58,7 +58,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
         });
 
         it('cannot perform normal process in pause', async function () {
-          await shouldFail.reverting.withMessage(this.pausable.normalProcess({ from: other }), 'Pausable: paused');
+          await expectRevert(this.pausable.normalProcess({ from: other }), 'Pausable: paused');
         });
 
         it('can take a drastic measure in a pause', async function () {
@@ -67,7 +67,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
         });
 
         it('reverts when re-pausing', async function () {
-          await shouldFail.reverting.withMessage(this.pausable.pause({ from: pauser }), 'Pausable: paused');
+          await expectRevert(this.pausable.pause({ from: pauser }), 'Pausable: paused');
         });
 
         describe('unpausing', function () {
@@ -77,7 +77,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
           });
 
           it('reverts when unpausing from non-pauser', async function () {
-            await shouldFail.reverting.withMessage(this.pausable.unpause({ from: other }),
+            await expectRevert(this.pausable.unpause({ from: other }),
               'PauserRole: caller does not have the Pauser role'
             );
           });
@@ -98,13 +98,13 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
             });
 
             it('should prevent drastic measure', async function () {
-              await shouldFail.reverting.withMessage(this.pausable.drasticMeasure({ from: other }),
+              await expectRevert(this.pausable.drasticMeasure({ from: other }),
                 'Pausable: not paused'
               );
             });
 
             it('reverts when re-unpausing', async function () {
-              await shouldFail.reverting.withMessage(this.pausable.unpause({ from: pauser }), 'Pausable: not paused');
+              await expectRevert(this.pausable.unpause({ from: pauser }), 'Pausable: not paused');
             });
           });
         });

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
 const { MAX_UINT256 } = constants;
 
 const SafeMathMock = artifacts.require('SafeMathMock');
@@ -14,8 +14,8 @@ contract('SafeMath', function () {
   }
 
   async function testFailsCommutative (fn, lhs, rhs, reason) {
-    await shouldFail.reverting.withMessage(fn(lhs, rhs), reason);
-    await shouldFail.reverting.withMessage(fn(rhs, lhs), reason);
+    await expectRevert(fn(lhs, rhs), reason);
+    await expectRevert(fn(rhs, lhs), reason);
   }
 
   describe('add', function () {
@@ -46,7 +46,7 @@ contract('SafeMath', function () {
       const a = new BN('1234');
       const b = new BN('5678');
 
-      await shouldFail.reverting.withMessage(this.safeMath.sub(a, b), 'SafeMath: subtraction overflow');
+      await expectRevert(this.safeMath.sub(a, b), 'SafeMath: subtraction overflow');
     });
   });
 
@@ -99,7 +99,7 @@ contract('SafeMath', function () {
       const a = new BN('5678');
       const b = new BN('0');
 
-      await shouldFail.reverting.withMessage(this.safeMath.div(a, b), 'SafeMath: division by zero');
+      await expectRevert(this.safeMath.div(a, b), 'SafeMath: division by zero');
     });
   });
 
@@ -138,7 +138,7 @@ contract('SafeMath', function () {
       const a = new BN('5678');
       const b = new BN('0');
 
-      await shouldFail.reverting.withMessage(this.safeMath.mod(a, b), 'SafeMath: modulo by zero');
+      await expectRevert(this.safeMath.mod(a, b), 'SafeMath: modulo by zero');
     });
   });
 });

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -1,4 +1,4 @@
-const { constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeOwnable (owner, [other]) {
@@ -17,14 +17,14 @@ function shouldBehaveLikeOwnable (owner, [other]) {
     });
 
     it('should prevent non-owners from transferring', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.ownable.transferOwnership(other, { from: other }),
         'Ownable: caller is not the owner'
       );
     });
 
     it('should guard ownership against stuck state', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.ownable.transferOwnership(ZERO_ADDRESS, { from: owner }),
         'Ownable: new owner is the zero address'
       );
@@ -38,7 +38,7 @@ function shouldBehaveLikeOwnable (owner, [other]) {
     });
 
     it('should prevent non-owners from renouncement', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.ownable.renounceOwnership({ from: other }),
         'Ownable: caller is not the owner'
       );

--- a/test/ownership/Secondary.test.js
+++ b/test/ownership/Secondary.test.js
@@ -1,4 +1,4 @@
-const { constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const SecondaryMock = artifacts.require('SecondaryMock');
@@ -18,7 +18,7 @@ contract('Secondary', function ([_, primary, newPrimary, other]) {
     });
 
     it('reverts when anyone calls onlyPrimary functions', async function () {
-      await shouldFail.reverting.withMessage(this.secondary.onlyPrimaryMock({ from: other }),
+      await expectRevert(this.secondary.onlyPrimaryMock({ from: other }),
         'Secondary: caller is not the primary account'
       );
     });
@@ -32,13 +32,13 @@ contract('Secondary', function ([_, primary, newPrimary, other]) {
     });
 
     it('reverts when transferring to the null address', async function () {
-      await shouldFail.reverting.withMessage(this.secondary.transferPrimary(ZERO_ADDRESS, { from: primary }),
+      await expectRevert(this.secondary.transferPrimary(ZERO_ADDRESS, { from: primary }),
         'Secondary: new primary is the zero address'
       );
     });
 
     it('reverts when called by anyone', async function () {
-      await shouldFail.reverting.withMessage(this.secondary.transferPrimary(newPrimary, { from: other }),
+      await expectRevert(this.secondary.transferPrimary(newPrimary, { from: other }),
         'Secondary: caller is not the primary account'
       );
     });
@@ -53,7 +53,7 @@ contract('Secondary', function ([_, primary, newPrimary, other]) {
       });
 
       it('reverts when the old primary account calls onlyPrimary functions', async function () {
-        await shouldFail.reverting.withMessage(this.secondary.onlyPrimaryMock({ from: primary }),
+        await expectRevert(this.secondary.onlyPrimaryMock({ from: primary }),
           'Secondary: caller is not the primary account'
         );
       });

--- a/test/payment/PaymentSplitter.test.js
+++ b/test/payment/PaymentSplitter.test.js
@@ -1,4 +1,4 @@
-const { balance, constants, ether, expectEvent, send, shouldFail } = require('openzeppelin-test-helpers');
+const { balance, constants, ether, expectEvent, send, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const PaymentSplitter = artifacts.require('PaymentSplitter');
@@ -7,35 +7,35 @@ contract('PaymentSplitter', function ([_, owner, payee1, payee2, payee3, nonpaye
   const amount = ether('1');
 
   it('rejects an empty set of payees', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([], []), 'PaymentSplitter: no payees');
+    await expectRevert(PaymentSplitter.new([], []), 'PaymentSplitter: no payees');
   });
 
   it('rejects more payees than shares', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([payee1, payee2, payee3], [20, 30]),
+    await expectRevert(PaymentSplitter.new([payee1, payee2, payee3], [20, 30]),
       'PaymentSplitter: payees and shares length mismatch'
     );
   });
 
   it('rejects more shares than payees', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([payee1, payee2], [20, 30, 40]),
+    await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 30, 40]),
       'PaymentSplitter: payees and shares length mismatch'
     );
   });
 
   it('rejects null payees', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([payee1, ZERO_ADDRESS], [20, 30]),
+    await expectRevert(PaymentSplitter.new([payee1, ZERO_ADDRESS], [20, 30]),
       'PaymentSplitter: account is the zero address'
     );
   });
 
   it('rejects zero-valued shares', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([payee1, payee2], [20, 0]),
+    await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 0]),
       'PaymentSplitter: shares are 0'
     );
   });
 
   it('rejects repeated payees', async function () {
-    await shouldFail.reverting.withMessage(PaymentSplitter.new([payee1, payee1], [20, 30]),
+    await expectRevert(PaymentSplitter.new([payee1, payee1], [20, 30]),
       'PaymentSplitter: account already has shares'
     );
   });
@@ -74,14 +74,14 @@ contract('PaymentSplitter', function ([_, owner, payee1, payee2, payee3, nonpaye
     });
 
     it('should throw if no funds to claim', async function () {
-      await shouldFail.reverting.withMessage(this.contract.release(payee1),
+      await expectRevert(this.contract.release(payee1),
         'PaymentSplitter: account is not due payment'
       );
     });
 
     it('should throw if non-payee want to claim', async function () {
       await send.ether(payer1, this.contract.address, amount);
-      await shouldFail.reverting.withMessage(this.contract.release(nonpayee1),
+      await expectRevert(this.contract.release(nonpayee1),
         'PaymentSplitter: account has no shares'
       );
     });

--- a/test/payment/escrow/ConditionalEscrow.test.js
+++ b/test/payment/escrow/ConditionalEscrow.test.js
@@ -1,4 +1,4 @@
-const { ether, shouldFail } = require('openzeppelin-test-helpers');
+const { ether, expectRevert } = require('openzeppelin-test-helpers');
 const { shouldBehaveLikeEscrow } = require('./Escrow.behavior');
 
 const ConditionalEscrowMock = artifacts.require('ConditionalEscrowMock');
@@ -26,7 +26,7 @@ contract('ConditionalEscrow', function ([_, owner, payee, ...otherAccounts]) {
     it('reverts on withdrawals', async function () {
       await this.escrow.deposit(payee, { from: owner, value: amount });
 
-      await shouldFail.reverting.withMessage(this.escrow.withdraw(payee, { from: owner }),
+      await expectRevert(this.escrow.withdraw(payee, { from: owner }),
         'ConditionalEscrow: payee is not allowed to withdraw'
       );
     });

--- a/test/payment/escrow/Escrow.behavior.js
+++ b/test/payment/escrow/Escrow.behavior.js
@@ -1,4 +1,4 @@
-const { balance, ether, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { balance, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 
 function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
   const amount = ether('42');
@@ -18,7 +18,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
       });
 
       it('only the primary account can deposit', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.deposit(payee1, { from: payee2 }),
+        await expectRevert(this.escrow.deposit(payee1, { from: payee2 }),
           'Secondary: caller is not the primary account'
         );
       });
@@ -70,7 +70,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
       });
 
       it('only the primary account can withdraw', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.withdraw(payee1, { from: payee1 }),
+        await expectRevert(this.escrow.withdraw(payee1, { from: payee1 }),
           'Secondary: caller is not the primary account'
         );
       });

--- a/test/payment/escrow/RefundEscrow.test.js
+++ b/test/payment/escrow/RefundEscrow.test.js
@@ -1,4 +1,4 @@
-const { balance, constants, ether, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { balance, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const RefundEscrow = artifacts.require('RefundEscrow');
@@ -8,7 +8,7 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
   const refundees = [refundee1, refundee2];
 
   it('requires a non-null beneficiary', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       RefundEscrow.new(ZERO_ADDRESS, { from: primary }), 'RefundEscrow: beneficiary is the zero address'
     );
   });
@@ -32,21 +32,21 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
 
       it('does not refund refundees', async function () {
         await this.escrow.deposit(refundee1, { from: primary, value: amount });
-        await shouldFail.reverting.withMessage(this.escrow.withdraw(refundee1),
+        await expectRevert(this.escrow.withdraw(refundee1),
           'ConditionalEscrow: payee is not allowed to withdraw'
         );
       });
 
       it('does not allow beneficiary withdrawal', async function () {
         await this.escrow.deposit(refundee1, { from: primary, value: amount });
-        await shouldFail.reverting.withMessage(this.escrow.beneficiaryWithdraw(),
+        await expectRevert(this.escrow.beneficiaryWithdraw(),
           'RefundEscrow: beneficiary can only withdraw while closed'
         );
       });
     });
 
     it('only the primary account can enter closed state', async function () {
-      await shouldFail.reverting.withMessage(this.escrow.close({ from: beneficiary }),
+      await expectRevert(this.escrow.close({ from: beneficiary }),
         'Secondary: caller is not the primary account'
       );
 
@@ -62,13 +62,13 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       });
 
       it('rejects deposits', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.deposit(refundee1, { from: primary, value: amount }),
+        await expectRevert(this.escrow.deposit(refundee1, { from: primary, value: amount }),
           'RefundEscrow: can only deposit while active'
         );
       });
 
       it('does not refund refundees', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.withdraw(refundee1),
+        await expectRevert(this.escrow.withdraw(refundee1),
           'ConditionalEscrow: payee is not allowed to withdraw'
         );
       });
@@ -80,20 +80,20 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       });
 
       it('prevents entering the refund state', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.enableRefunds({ from: primary }),
+        await expectRevert(this.escrow.enableRefunds({ from: primary }),
           'RefundEscrow: can only enable refunds while active'
         );
       });
 
       it('prevents re-entering the closed state', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.close({ from: primary }),
+        await expectRevert(this.escrow.close({ from: primary }),
           'RefundEscrow: can only close while active'
         );
       });
     });
 
     it('only the primary account can enter refund state', async function () {
-      await shouldFail.reverting.withMessage(this.escrow.enableRefunds({ from: beneficiary }),
+      await expectRevert(this.escrow.enableRefunds({ from: beneficiary }),
         'Secondary: caller is not the primary account'
       );
 
@@ -109,7 +109,7 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       });
 
       it('rejects deposits', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.deposit(refundee1, { from: primary, value: amount }),
+        await expectRevert(this.escrow.deposit(refundee1, { from: primary, value: amount }),
           'RefundEscrow: can only deposit while active'
         );
       });
@@ -123,19 +123,19 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       });
 
       it('does not allow beneficiary withdrawal', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.beneficiaryWithdraw(),
+        await expectRevert(this.escrow.beneficiaryWithdraw(),
           'RefundEscrow: beneficiary can only withdraw while closed'
         );
       });
 
       it('prevents entering the closed state', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.close({ from: primary }),
+        await expectRevert(this.escrow.close({ from: primary }),
           'RefundEscrow: can only close while active'
         );
       });
 
       it('prevents re-entering the refund state', async function () {
-        await shouldFail.reverting.withMessage(this.escrow.enableRefunds({ from: primary }),
+        await expectRevert(this.escrow.enableRefunds({ from: primary }),
           'RefundEscrow: can only enable refunds while active'
         );
       });

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recipient, anotherAccount) {
@@ -86,7 +86,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
             const amount = initialSupply.addn(1);
 
             it('reverts', async function () {
-              await shouldFail.reverting.withMessage(this.token.transferFrom(
+              await expectRevert(this.token.transferFrom(
                 tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
               );
             });
@@ -102,7 +102,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
             const amount = initialSupply;
 
             it('reverts', async function () {
-              await shouldFail.reverting.withMessage(this.token.transferFrom(
+              await expectRevert(this.token.transferFrom(
                 tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
               );
             });
@@ -112,7 +112,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
             const amount = initialSupply.addn(1);
 
             it('reverts', async function () {
-              await shouldFail.reverting.withMessage(this.token.transferFrom(
+              await expectRevert(this.token.transferFrom(
                 tokenOwner, to, amount, { from: spender }), 'SafeMath: subtraction overflow'
               );
             });
@@ -129,7 +129,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
         });
 
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.transferFrom(
+          await expectRevert(this.token.transferFrom(
             tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`
           );
         });
@@ -142,7 +142,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
       const to = recipient;
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.transferFrom(
+        await expectRevert(this.token.transferFrom(
           tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`
         );
       });
@@ -164,7 +164,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
       const amount = balance.addn(1);
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(transfer.call(this, from, to, amount),
+        await expectRevert(transfer.call(this, from, to, amount),
           'SafeMath: subtraction overflow'
         );
       });
@@ -217,7 +217,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
 
   describe('when the recipient is the zero address', function () {
     it('reverts', async function () {
-      await shouldFail.reverting.withMessage(transfer.call(this, from, ZERO_ADDRESS, balance),
+      await expectRevert(transfer.call(this, from, ZERO_ADDRESS, balance),
         `${errorPrefix}: transfer to the zero address`
       );
     });
@@ -297,7 +297,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
 
   describe('when the spender is the zero address', function () {
     it('reverts', async function () {
-      await shouldFail.reverting.withMessage(approve.call(this, owner, ZERO_ADDRESS, supply),
+      await expectRevert(approve.call(this, owner, ZERO_ADDRESS, supply),
         `${errorPrefix}: approve to the zero address`
       );
     });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const {
@@ -25,7 +25,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
       function shouldDecreaseApproval (amount) {
         describe('when there was no approved amount before', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(this.token.decreaseAllowance(
+            await expectRevert(this.token.decreaseAllowance(
               spender, amount, { from: initialHolder }), 'SafeMath: subtraction overflow'
             );
           });
@@ -60,7 +60,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           });
 
           it('reverts when more than the full allowance is removed', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.decreaseAllowance(spender, approvedAmount.addn(1), { from: initialHolder }),
               'SafeMath: subtraction overflow'
             );
@@ -86,8 +86,8 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
       const spender = ZERO_ADDRESS;
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.decreaseAllowance(
-          spender, amount, { from: initialHolder }, 'ERC20: approve to the zero address')
+        await expectRevert(this.token.decreaseAllowance(
+          spender, amount, { from: initialHolder }), 'SafeMath: subtraction overflow'
         );
       });
     });
@@ -170,7 +170,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
       const spender = ZERO_ADDRESS;
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.increaseAllowance(spender, amount, { from: initialHolder }), 'ERC20: approve to the zero address'
         );
       });
@@ -180,7 +180,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
   describe('_mint', function () {
     const amount = new BN(50);
     it('rejects a null account', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address'
       );
     });
@@ -213,13 +213,13 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
   describe('_burn', function () {
     it('rejects a null account', async function () {
-      await shouldFail.reverting.withMessage(this.token.burn(ZERO_ADDRESS, new BN(1)),
+      await expectRevert(this.token.burn(ZERO_ADDRESS, new BN(1)),
         'ERC20: burn from the zero address');
     });
 
     describe('for a non zero account', function () {
       it('rejects burning more than balance', async function () {
-        await shouldFail.reverting.withMessage(this.token.burn(
+        await expectRevert(this.token.burn(
           initialHolder, initialSupply.addn(1)), 'SafeMath: subtraction overflow'
         );
       });
@@ -267,20 +267,20 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
     });
 
     it('rejects a null account', async function () {
-      await shouldFail.reverting.withMessage(this.token.burnFrom(ZERO_ADDRESS, new BN(1)),
+      await expectRevert(this.token.burnFrom(ZERO_ADDRESS, new BN(1)),
         'ERC20: burn from the zero address'
       );
     });
 
     describe('for a non zero account', function () {
       it('rejects burning more than allowance', async function () {
-        await shouldFail.reverting.withMessage(this.token.burnFrom(initialHolder, allowance.addn(1)),
+        await expectRevert(this.token.burnFrom(initialHolder, allowance.addn(1)),
           'SafeMath: subtraction overflow'
         );
       });
 
       it('rejects burning more than balance', async function () {
-        await shouldFail.reverting.withMessage(this.token.burnFrom(initialHolder, initialSupply.addn(1)),
+        await expectRevert(this.token.burnFrom(initialHolder, initialSupply.addn(1)),
           'SafeMath: subtraction overflow'
         );
       });
@@ -338,7 +338,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
     describe('when the sender is the zero address', function () {
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.transferInternal(ZERO_ADDRESS, recipient, initialSupply),
+        await expectRevert(this.token.transferInternal(ZERO_ADDRESS, recipient, initialSupply),
           'ERC20: transfer from the zero address'
         );
       });
@@ -352,7 +352,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
     describe('when the owner is the zero address', function () {
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
+        await expectRevert(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
           'ERC20: approve from the zero address'
         );
       });

--- a/test/token/ERC20/ERC20Capped.test.js
+++ b/test/token/ERC20/ERC20Capped.test.js
@@ -1,4 +1,4 @@
-const { BN, ether, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 const { shouldBehaveLikeERC20Mintable } = require('./behaviors/ERC20Mintable.behavior');
 const { shouldBehaveLikeERC20Capped } = require('./behaviors/ERC20Capped.behavior');
 
@@ -8,7 +8,7 @@ contract('ERC20Capped', function ([_, minter, ...otherAccounts]) {
   const cap = ether('1000');
 
   it('requires a non-zero cap', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       ERC20Capped.new(new BN(0), { from: minter }), 'ERC20Capped: cap is 0'
     );
   });

--- a/test/token/ERC20/ERC20Pausable.test.js
+++ b/test/token/ERC20/ERC20Pausable.test.js
@@ -1,4 +1,4 @@
-const { BN, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 
 const ERC20PausableMock = artifacts.require('ERC20PausableMock');
 const { shouldBehaveLikePublicRole } = require('../../behaviors/access/roles/PublicRole.behavior');
@@ -42,7 +42,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
         });
 
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.pause({ from }), 'Pausable: paused');
+          await expectRevert(this.token.pause({ from }), 'Pausable: paused');
         });
       });
     });
@@ -51,7 +51,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       const from = anotherAccount;
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.pause({ from }),
+        await expectRevert(this.token.pause({ from }),
           'PauserRole: caller does not have the Pauser role'
         );
       });
@@ -81,7 +81,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
       describe('when the token is unpaused', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.unpause({ from }), 'Pausable: not paused');
+          await expectRevert(this.token.unpause({ from }), 'Pausable: not paused');
         });
       });
     });
@@ -90,7 +90,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       const from = anotherAccount;
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.unpause({ from }),
+        await expectRevert(this.token.unpause({ from }),
           'PauserRole: caller does not have the Pauser role'
         );
       });
@@ -138,7 +138,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('reverts when trying to transfer when paused', async function () {
         await this.token.pause({ from: pauser });
 
-        await shouldFail.reverting.withMessage(this.token.transfer(recipient, initialSupply, { from: pauser }),
+        await expectRevert(this.token.transfer(recipient, initialSupply, { from: pauser }),
           'Pausable: paused'
         );
       });
@@ -165,7 +165,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('reverts when trying to approve when paused', async function () {
         await this.token.pause({ from: pauser });
 
-        await shouldFail.reverting.withMessage(this.token.approve(anotherAccount, allowance, { from: pauser }),
+        await expectRevert(this.token.approve(anotherAccount, allowance, { from: pauser }),
           'Pausable: paused'
         );
       });
@@ -198,7 +198,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('reverts when trying to transfer from when paused', async function () {
         await this.token.pause({ from: pauser });
 
-        await shouldFail.reverting.withMessage(this.token.transferFrom(
+        await expectRevert(this.token.transferFrom(
           pauser, recipient, allowance, { from: anotherAccount }), 'Pausable: paused'
         );
       });
@@ -230,7 +230,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('reverts when trying to transfer when paused', async function () {
         await this.token.pause({ from: pauser });
 
-        await shouldFail.reverting.withMessage(this.token.decreaseAllowance(
+        await expectRevert(this.token.decreaseAllowance(
           anotherAccount, decrement, { from: pauser }), 'Pausable: paused'
         );
       });
@@ -262,7 +262,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('reverts when trying to increase approval when paused', async function () {
         await this.token.pause({ from: pauser });
 
-        await shouldFail.reverting.withMessage(this.token.increaseAllowance(
+        await expectRevert(this.token.increaseAllowance(
           anotherAccount, increment, { from: pauser }), 'Pausable: paused'
         );
       });

--- a/test/token/ERC20/SafeERC20.test.js
+++ b/test/token/ERC20/SafeERC20.test.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 
 const ERC20ReturnFalseMock = artifacts.require('ERC20ReturnFalseMock');
 const ERC20ReturnTrueMock = artifacts.require('ERC20ReturnTrueMock');
@@ -41,25 +41,25 @@ contract('SafeERC20', function ([_, hasNoCode]) {
 
 function shouldRevertOnAllCalls (reason) {
   it('reverts on transfer', async function () {
-    await shouldFail.reverting.withMessage(this.wrapper.transfer(), reason);
+    await expectRevert(this.wrapper.transfer(), reason);
   });
 
   it('reverts on transferFrom', async function () {
-    await shouldFail.reverting.withMessage(this.wrapper.transferFrom(), reason);
+    await expectRevert(this.wrapper.transferFrom(), reason);
   });
 
   it('reverts on approve', async function () {
-    await shouldFail.reverting.withMessage(this.wrapper.approve(0), reason);
+    await expectRevert(this.wrapper.approve(0), reason);
   });
 
   it('reverts on increaseAllowance', async function () {
     // [TODO] make sure it's reverting for the right reason
-    await shouldFail.reverting(this.wrapper.increaseAllowance(0));
+    await expectRevert.unspecified(this.wrapper.increaseAllowance(0));
   });
 
   it('reverts on decreaseAllowance', async function () {
     // [TODO] make sure it's reverting for the right reason
-    await shouldFail.reverting(this.wrapper.decreaseAllowance(0));
+    await expectRevert.unspecified(this.wrapper.decreaseAllowance(0));
   });
 }
 
@@ -91,7 +91,7 @@ function shouldOnlyRevertOnErrors () {
       });
 
       it('reverts when decreasing the allowance', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.wrapper.decreaseAllowance(10),
           'SafeMath: subtraction overflow'
         );
@@ -104,7 +104,7 @@ function shouldOnlyRevertOnErrors () {
       });
 
       it('reverts when approving a non-zero allowance', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.wrapper.approve(20),
           'SafeERC20: approve from non-zero to non-zero allowance'
         );
@@ -123,7 +123,7 @@ function shouldOnlyRevertOnErrors () {
       });
 
       it('reverts when decreasing the allowance to a negative value', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.wrapper.decreaseAllowance(200),
           'SafeMath: subtraction overflow'
         );

--- a/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
@@ -35,7 +35,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
       const amount = initialBalance.addn(1);
 
       it('reverts', async function () {
-        await shouldFail.reverting.withMessage(this.token.burn(amount, { from: owner }),
+        await expectRevert(this.token.burn(amount, { from: owner }),
           'SafeMath: subtraction overflow'
         );
       });
@@ -84,7 +84,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
 
       it('reverts', async function () {
         await this.token.approve(burner, amount, { from: owner });
-        await shouldFail.reverting.withMessage(this.token.burnFrom(owner, amount, { from: burner }),
+        await expectRevert(this.token.burnFrom(owner, amount, { from: burner }),
           'SafeMath: subtraction overflow'
         );
       });
@@ -95,7 +95,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
 
       it('reverts', async function () {
         await this.token.approve(burner, allowance, { from: owner });
-        await shouldFail.reverting.withMessage(this.token.burnFrom(owner, allowance.addn(1), { from: burner }),
+        await expectRevert(this.token.burnFrom(owner, allowance.addn(1), { from: burner }),
           'SafeMath: subtraction overflow'
         );
       });

--- a/test/token/ERC20/behaviors/ERC20Capped.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Capped.behavior.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 
 function shouldBehaveLikeERC20Capped (minter, [other], cap) {
   describe('capped token', function () {
@@ -15,12 +15,12 @@ function shouldBehaveLikeERC20Capped (minter, [other], cap) {
 
     it('should fail to mint if the amount exceeds the cap', async function () {
       await this.token.mint(other, cap.subn(1), { from });
-      await shouldFail.reverting.withMessage(this.token.mint(other, 2, { from }), 'ERC20Capped: cap exceeded');
+      await expectRevert(this.token.mint(other, 2, { from }), 'ERC20Capped: cap exceeded');
     });
 
     it('should fail to mint after cap is reached', async function () {
       await this.token.mint(other, cap, { from });
-      await shouldFail.reverting.withMessage(this.token.mint(other, 1, { from }), 'ERC20Capped: cap exceeded');
+      await expectRevert(this.token.mint(other, 1, { from }), 'ERC20Capped: cap exceeded');
     });
   });
 }

--- a/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20Mintable (minter, [other]) {
@@ -40,7 +40,7 @@ function shouldBehaveLikeERC20Mintable (minter, [other]) {
         const from = other;
 
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.mint(other, amount, { from }),
+          await expectRevert(this.token.mint(other, amount, { from }),
             'MinterRole: caller does not have the Minter role'
           );
         });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
@@ -36,7 +36,7 @@ function shouldBehaveLikeERC721 (
 
       context('when querying the zero address', function () {
         it('throws', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.balanceOf(ZERO_ADDRESS), 'ERC721: balance query for the zero address'
           );
         });
@@ -56,7 +56,7 @@ function shouldBehaveLikeERC721 (
         const tokenId = unknownTokenId;
 
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
           );
         });
@@ -182,7 +182,7 @@ function shouldBehaveLikeERC721 (
 
         context('when the address of the previous owner is incorrect', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               transferFunction.call(this, other, other, tokenId, { from: owner }),
               'ERC721: transfer of token that is not own'
             );
@@ -191,7 +191,7 @@ function shouldBehaveLikeERC721 (
 
         context('when the sender is not authorized for the token id', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               transferFunction.call(this, owner, other, tokenId, { from: other }),
               'ERC721: transfer caller is not owner nor approved'
             );
@@ -200,7 +200,7 @@ function shouldBehaveLikeERC721 (
 
         context('when the given token ID does not exist', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               transferFunction.call(this, owner, other, unknownTokenId, { from: owner }),
               'ERC721: operator query for nonexistent token'
             );
@@ -209,7 +209,7 @@ function shouldBehaveLikeERC721 (
 
         context('when the address to transfer the token to is the zero address', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               transferFunction.call(this, owner, ZERO_ADDRESS, tokenId, { from: owner }),
               'ERC721: transfer to the zero address'
             );
@@ -269,7 +269,7 @@ function shouldBehaveLikeERC721 (
 
             describe('with an invalid token id', function () {
               it('reverts', async function () {
-                await shouldFail.reverting.withMessage(
+                await expectRevert(
                   transferFun.call(
                     this,
                     owner,
@@ -295,7 +295,7 @@ function shouldBehaveLikeERC721 (
         describe('to a receiver contract returning unexpected value', function () {
           it('reverts', async function () {
             const invalidReceiver = await ERC721ReceiverMock.new('0x42', false);
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.safeTransferFrom(owner, invalidReceiver.address, tokenId, { from: owner }),
               'ERC721: transfer to non ERC721Receiver implementer'
             );
@@ -305,7 +305,7 @@ function shouldBehaveLikeERC721 (
         describe('to a receiver contract that throws', function () {
           it('reverts', async function () {
             const invalidReceiver = await ERC721ReceiverMock.new(RECEIVER_MAGIC_VALUE, true);
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.safeTransferFrom(owner, invalidReceiver.address, tokenId, { from: owner }),
               'ERC721ReceiverMock: reverting'
             );
@@ -315,7 +315,7 @@ function shouldBehaveLikeERC721 (
         describe('to a contract that does not implement the required function', function () {
           it('reverts', async function () {
             const invalidReceiver = this.token;
-            await shouldFail.reverting(
+            await expectRevert.unspecified(
               this.token.safeTransferFrom(owner, invalidReceiver.address, tokenId, { from: owner })
             );
           });
@@ -404,7 +404,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the address that receives the approval is the owner', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.approve(owner, tokenId, { from: owner }), 'ERC721: approval to current owner'
           );
         });
@@ -412,7 +412,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the sender does not own the given token ID', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.approve(approved, tokenId, { from: other }),
+          await expectRevert(this.token.approve(approved, tokenId, { from: other }),
             'ERC721: approve caller is not owner nor approved');
         });
       });
@@ -420,7 +420,7 @@ function shouldBehaveLikeERC721 (
       context('when the sender is approved for the given token ID', function () {
         it('reverts', async function () {
           await this.token.approve(approved, tokenId, { from: owner });
-          await shouldFail.reverting.withMessage(this.token.approve(anotherApproved, tokenId, { from: approved }),
+          await expectRevert(this.token.approve(anotherApproved, tokenId, { from: approved }),
             'ERC721: approve caller is not owner nor approved for all');
         });
       });
@@ -437,7 +437,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the given token ID does not exist', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.approve(approved, unknownTokenId, { from: operator }),
+          await expectRevert(this.token.approve(approved, unknownTokenId, { from: operator }),
             'ERC721: owner query for nonexistent token');
         });
       });
@@ -516,7 +516,7 @@ function shouldBehaveLikeERC721 (
 
       context('when the operator is the owner', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.setApprovalForAll(owner, true, { from: owner }),
+          await expectRevert(this.token.setApprovalForAll(owner, true, { from: owner }),
             'ERC721: approve to caller');
         });
       });

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
@@ -16,7 +16,7 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
 
     describe('_mint(address, uint256)', function () {
       it('reverts with a null destination address', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.mint(ZERO_ADDRESS, tokenId), 'ERC721: mint to the zero address'
         );
       });
@@ -36,14 +36,14 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
         });
 
         it('reverts when adding a token id that already exists', async function () {
-          await shouldFail.reverting.withMessage(this.token.mint(tokenOwner, tokenId), 'ERC721: token already minted');
+          await expectRevert(this.token.mint(tokenOwner, tokenId), 'ERC721: token already minted');
         });
       });
     });
 
     describe('_burn(address, uint256)', function () {
       it('reverts when burning a non-existent token id', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.methods['burn(address,uint256)'](tokenOwner, tokenId), 'ERC721: owner query for nonexistent token'
         );
       });
@@ -54,7 +54,7 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
         });
 
         it('reverts when the account is not the owner', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.methods['burn(address,uint256)'](other, tokenId), 'ERC721: burn of token that is not own'
           );
         });
@@ -70,13 +70,13 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
 
           it('deletes the token', async function () {
             (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
             );
           });
 
           it('reverts when burning a token id that has been deleted', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.methods['burn(address,uint256)'](tokenOwner, tokenId),
               'ERC721: owner query for nonexistent token'
             );
@@ -87,7 +87,7 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
 
     describe('_burn(uint256)', function () {
       it('reverts when burning a non-existent token id', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token'
         );
       });
@@ -108,13 +108,13 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
 
           it('deletes the token', async function () {
             (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
             );
           });
 
           it('reverts when burning a token id that has been deleted', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token'
             );
           });

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -1,4 +1,4 @@
-const { BN, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, expectRevert } = require('openzeppelin-test-helpers');
 
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
@@ -64,7 +64,7 @@ contract('ERC721Full', function ([
       it('burns all tokens', async function () {
         await this.token.burn(secondTokenId, { from: owner });
         (await this.token.totalSupply()).should.be.bignumber.equal('0');
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.tokenByIndex(0), 'ERC721Enumerable: global index out of bounds'
         );
       });
@@ -87,7 +87,7 @@ contract('ERC721Full', function ([
       });
 
       it('reverts when setting metadata for non existent token id', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.setTokenURI(nonExistentTokenId, sampleUri), 'ERC721Metadata: URI set of nonexistent token'
         );
       });
@@ -103,7 +103,7 @@ contract('ERC721Full', function ([
       });
 
       it('reverts when querying metadata for non existent token id', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.tokenURI(nonExistentTokenId), 'ERC721Metadata: URI query for nonexistent token'
         );
       });
@@ -133,7 +133,7 @@ contract('ERC721Full', function ([
 
       describe('when the index is greater than or equal to the total tokens owned by the given address', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.tokenOfOwnerByIndex(owner, 2), 'ERC721Enumerable: owner index out of bounds'
           );
         });
@@ -141,7 +141,7 @@ contract('ERC721Full', function ([
 
       describe('when the given address does not own any token', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.tokenOfOwnerByIndex(another, 0), 'ERC721Enumerable: owner index out of bounds'
           );
         });
@@ -163,7 +163,7 @@ contract('ERC721Full', function ([
 
         it('returns empty collection for original owner', async function () {
           (await this.token.balanceOf(owner)).should.be.bignumber.equal('0');
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.tokenOfOwnerByIndex(owner, 0), 'ERC721Enumerable: owner index out of bounds'
           );
         });
@@ -179,7 +179,7 @@ contract('ERC721Full', function ([
       });
 
       it('should revert if index is greater than supply', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.tokenByIndex(2), 'ERC721Enumerable: global index out of bounds'
         );
       });

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeMintAndBurnERC721 (
@@ -46,7 +46,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
 
       describe('when the given owner address is the zero address', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.mint(ZERO_ADDRESS, thirdTokenId, { from: minter }),
             'ERC721: mint to the zero address'
           );
@@ -55,7 +55,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
 
       describe('when the given token ID was already tracked by this contract', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(this.token.mint(owner, firstTokenId, { from: minter }),
+          await expectRevert(this.token.mint(owner, firstTokenId, { from: minter }),
             'ERC721: token already minted.'
           );
         });
@@ -81,7 +81,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
         });
 
         it('burns the given token ID and adjusts the balance of the owner', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.ownerOf(tokenId),
             'ERC721: owner query for nonexistent token'
           );
@@ -106,7 +106,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
 
         context('getApproved', function () {
           it('reverts', async function () {
-            await shouldFail.reverting.withMessage(
+            await expectRevert(
               this.token.getApproved(tokenId), 'ERC721: approved query for nonexistent token'
             );
           });
@@ -115,7 +115,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
 
       describe('when the given token ID was not tracked by this contract', function () {
         it('reverts', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.burn(unknownTokenId, { from: creator }), 'ERC721: operator query for nonexistent token'
           );
         });

--- a/test/token/ERC721/ERC721PausedToken.behavior.js
+++ b/test/token/ERC721/ERC721PausedToken.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC721PausedToken (owner, [recipient, operator]) {
@@ -12,31 +12,31 @@ function shouldBehaveLikeERC721PausedToken (owner, [recipient, operator]) {
     });
 
     it('reverts when trying to approve', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.approve(recipient, firstTokenId, { from: owner }), 'Pausable: paused'
       );
     });
 
     it('reverts when trying to setApprovalForAll', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.setApprovalForAll(operator, true, { from: owner }), 'Pausable: paused'
       );
     });
 
     it('reverts when trying to transferFrom', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.transferFrom(owner, recipient, firstTokenId, { from: owner }), 'Pausable: paused'
       );
     });
 
     it('reverts when trying to safeTransferFrom', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.safeTransferFrom(owner, recipient, firstTokenId, { from: owner }), 'Pausable: paused'
       );
     });
 
     it('reverts when trying to safeTransferFrom with data', async function () {
-      await shouldFail.reverting.withMessage(
+      await expectRevert(
         this.token.methods['safeTransferFrom(address,address,uint256,bytes)'](
           owner, recipient, firstTokenId, mockData, { from: owner }
         ), 'Pausable: paused'

--- a/test/token/ERC777/ERC777.behavior.js
+++ b/test/token/ERC777/ERC777.behavior.js
@@ -1,4 +1,4 @@
-const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 const ERC777SenderRecipientMock = artifacts.require('ERC777SenderRecipientMock');
@@ -26,11 +26,11 @@ function shouldBehaveLikeERC777DirectSend (holder, recipient, data) {
 
       it('reverts when sending more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
-        await shouldFail.reverting(this.token.send(recipient, balance.addn(1), data, { from: holder }));
+        await expectRevert.unspecified(this.token.send(recipient, balance.addn(1), data, { from: holder }));
       });
 
       it('reverts when sending to the zero address', async function () {
-        await shouldFail.reverting(this.token.send(ZERO_ADDRESS, new BN('1'), data, { from: holder }));
+        await expectRevert.unspecified(this.token.send(ZERO_ADDRESS, new BN('1'), data, { from: holder }));
       });
     });
 
@@ -40,7 +40,7 @@ function shouldBehaveLikeERC777DirectSend (holder, recipient, data) {
       shouldDirectSendTokens(holder, recipient, new BN('0'), data);
 
       it('reverts when sending a non-zero amount', async function () {
-        await shouldFail.reverting(this.token.send(recipient, new BN('1'), data, { from: holder }));
+        await expectRevert.unspecified(this.token.send(recipient, new BN('1'), data, { from: holder }));
       });
     });
   });
@@ -54,13 +54,13 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
 
       it('reverts when sending more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorSend(holder, recipient, balance.addn(1), data, operatorData, { from: operator })
         );
       });
 
       it('reverts when sending to the zero address', async function () {
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorSend(
             holder, ZERO_ADDRESS, new BN('1'), data, operatorData, { from: operator }
           )
@@ -74,14 +74,14 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
       shouldOperatorSendTokens(holder, operator, recipient, new BN('0'), data, operatorData);
 
       it('reverts when sending a non-zero amount', async function () {
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorSend(holder, recipient, new BN('1'), data, operatorData, { from: operator })
         );
       });
 
       it('reverts when sending from the zero address', async function () {
         // This is not yet reflected in the spec
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorSend(
             ZERO_ADDRESS, recipient, new BN('0'), data, operatorData, { from: operator }
           )
@@ -94,7 +94,7 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
 function shouldBehaveLikeERC777UnauthorizedOperatorSend (holder, recipient, operator, data, operatorData) {
   describe('operator send', function () {
     it('reverts', async function () {
-      await shouldFail.reverting(this.token.operatorSend(holder, recipient, new BN('0'), data, operatorData));
+      await expectRevert.unspecified(this.token.operatorSend(holder, recipient, new BN('0'), data, operatorData));
     });
   });
 }
@@ -107,7 +107,7 @@ function shouldBehaveLikeERC777DirectBurn (holder, data) {
 
       it('reverts when burning more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
-        await shouldFail.reverting(this.token.burn(balance.addn(1), data, { from: holder }));
+        await expectRevert.unspecified(this.token.burn(balance.addn(1), data, { from: holder }));
       });
     });
 
@@ -117,7 +117,7 @@ function shouldBehaveLikeERC777DirectBurn (holder, data) {
       shouldDirectBurnTokens(holder, new BN('0'), data);
 
       it('reverts when burning a non-zero amount', async function () {
-        await shouldFail.reverting(this.token.burn(new BN('1'), data, { from: holder }));
+        await expectRevert.unspecified(this.token.burn(new BN('1'), data, { from: holder }));
       });
     });
   });
@@ -131,7 +131,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
 
       it('reverts when burning more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorBurn(holder, balance.addn(1), data, operatorData, { from: operator })
         );
       });
@@ -143,14 +143,14 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
       shouldOperatorBurnTokens(holder, operator, new BN('0'), data, operatorData);
 
       it('reverts when burning a non-zero amount', async function () {
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorBurn(holder, new BN('1'), data, operatorData, { from: operator })
         );
       });
 
       it('reverts when burning from the zero address', async function () {
         // This is not yet reflected in the spec
-        await shouldFail.reverting(
+        await expectRevert.unspecified(
           this.token.operatorBurn(
             ZERO_ADDRESS, new BN('0'), data, operatorData, { from: operator }
           )
@@ -163,7 +163,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
 function shouldBehaveLikeERC777UnauthorizedOperatorBurn (holder, operator, data, operatorData) {
   describe('operator burn', function () {
     it('reverts', async function () {
-      await shouldFail.reverting(this.token.operatorBurn(holder, new BN('0'), data, operatorData));
+      await expectRevert.unspecified(this.token.operatorBurn(holder, new BN('0'), data, operatorData));
     });
   });
 }
@@ -278,7 +278,7 @@ function shouldBehaveLikeERC777InternalMint (recipient, operator, amount, data, 
   shouldInternalMintTokens(operator, recipient, amount, data, operatorData);
 
   it('reverts when minting tokens for the zero address', async function () {
-    await shouldFail.reverting(this.token.mintInternal(operator, ZERO_ADDRESS, amount, data, operatorData));
+    await expectRevert.unspecified(this.token.mintInternal(operator, ZERO_ADDRESS, amount, data, operatorData));
   });
 }
 
@@ -318,17 +318,17 @@ function shouldBehaveLikeERC777SendBurnMintInternalWithReceiveHook (operator, am
     });
 
     it('send reverts', async function () {
-      await shouldFail.reverting(sendFromHolder(this.token, this.sender, this.recipient, amount, data));
+      await expectRevert.unspecified(sendFromHolder(this.token, this.sender, this.recipient, amount, data));
     });
 
     it('operatorSend reverts', async function () {
-      await shouldFail.reverting(
+      await expectRevert.unspecified(
         this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
       );
     });
 
     it('mint (internal) reverts', async function () {
-      await shouldFail.reverting(
+      await expectRevert.unspecified(
         this.token.mintInternal(operator, this.recipient, amount, data, operatorData)
       );
     });
@@ -412,21 +412,21 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
     });
 
     it('send reverts', async function () {
-      await shouldFail.reverting(sendFromHolder(this.token, this.sender, this.recipient, amount, data));
+      await expectRevert.unspecified(sendFromHolder(this.token, this.sender, this.recipient, amount, data));
     });
 
     it('operatorSend reverts', async function () {
-      await shouldFail.reverting(
+      await expectRevert.unspecified(
         this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
       );
     });
 
     it('burn reverts', async function () {
-      await shouldFail.reverting(burnFromHolder(this.token, this.sender, amount, data));
+      await expectRevert.unspecified(burnFromHolder(this.token, this.sender, amount, data));
     });
 
     it('operatorBurn reverts', async function () {
-      await shouldFail.reverting(
+      await expectRevert.unspecified(
         this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator })
       );
     });

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -1,4 +1,4 @@
-const { BN, expectEvent, shouldFail, singletons } = require('openzeppelin-test-helpers');
+const { BN, expectEvent, expectRevert, singletons } = require('openzeppelin-test-helpers');
 
 const {
   shouldBehaveLikeERC777DirectSendBurn,
@@ -159,13 +159,13 @@ contract('ERC777', function ([
       });
 
       it('reverts when self-authorizing', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.authorizeOperator(holder, { from: holder }), 'ERC777: authorizing self as operator'
         );
       });
 
       it('reverts when self-revoking', async function () {
-        await shouldFail.reverting.withMessage(
+        await expectRevert(
           this.token.revokeOperator(holder, { from: holder }), 'ERC777: revoking self as operator'
         );
       });
@@ -228,7 +228,7 @@ contract('ERC777', function ([
         });
 
         it('cannot be revoked for themselves', async function () {
-          await shouldFail.reverting.withMessage(
+          await expectRevert(
             this.token.revokeOperator(defaultOperatorA, { from: defaultOperatorA }),
             'ERC777: revoking self as operator'
           );
@@ -281,21 +281,21 @@ contract('ERC777', function ([
             });
 
             it('send reverts', async function () {
-              await shouldFail.reverting.withMessage(
+              await expectRevert(
                 this.token.send(this.recipient, amount, data, { from: holder }),
                 'ERC777: token recipient contract has no implementer for ERC777TokensRecipient',
               );
             });
 
             it('operatorSend reverts', async function () {
-              await shouldFail.reverting.withMessage(
+              await expectRevert(
                 this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator }),
                 'ERC777: token recipient contract has no implementer for ERC777TokensRecipient',
               );
             });
 
             it('mint (internal) reverts', async function () {
-              await shouldFail.reverting.withMessage(
+              await expectRevert(
                 this.token.mintInternal(operator, this.recipient, amount, data, operatorData),
                 'ERC777: token recipient contract has no implementer for ERC777TokensRecipient',
               );

--- a/test/utils/ReentrancyGuard.test.js
+++ b/test/utils/ReentrancyGuard.test.js
@@ -1,4 +1,4 @@
-const { shouldFail } = require('openzeppelin-test-helpers');
+const { expectRevert } = require('openzeppelin-test-helpers');
 
 const ReentrancyMock = artifacts.require('ReentrancyMock');
 const ReentrancyAttack = artifacts.require('ReentrancyAttack');
@@ -11,7 +11,7 @@ contract('ReentrancyGuard', function () {
 
   it('should not allow remote callback', async function () {
     const attacker = await ReentrancyAttack.new();
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       this.reentrancyMock.countAndCall(attacker.address), 'ReentrancyGuard: reentrant call');
   });
 
@@ -20,13 +20,13 @@ contract('ReentrancyGuard', function () {
   // in the side-effects.
 
   it('should not allow local recursion', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       this.reentrancyMock.countLocalRecursive(10), 'ReentrancyGuard: reentrant call'
     );
   });
 
   it('should not allow indirect local recursion', async function () {
-    await shouldFail.reverting.withMessage(
+    await expectRevert(
       this.reentrancyMock.countThisRecursive(10), 'ReentrancyMock: failed call'
     );
   });


### PR DESCRIPTION
The new `expectRevert` makes the tests both more readable and harder to get wrong.

Fixes https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1765