### PR TITLE
Small sub() and div() gas optimization.

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -41,9 +41,8 @@ library SafeMath {
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b <= a, "SafeMath: subtraction overflow");
-        uint256 c = a - b;
 
-        return c;
+        return a - b;
     }
 
     /**
@@ -83,10 +82,9 @@ library SafeMath {
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
         // Solidity only automatically asserts when dividing by 0
         require(b > 0, "SafeMath: division by zero");
-        uint256 c = a / b;
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        // assert(a == b * (a / b) + a % b); // There is no case in which this doesn't hold
 
-        return c;
+        return a / b;
     }
 
     /**


### PR DESCRIPTION

Includes a small gas optimization when doing sub and div operations. Basically it removes the auxiliary variable that stores the result and just returns the result. In both of these methods, the result is not used for security check, that's why it's not needed as an auxiliary variable.

These changes make the implementation similar to mod, where the result is returned directly instead of saving it to an auxiliary variable first.


