### PR TITLE
20x performance for merkle tree lib

### DIFF
--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -5,10 +5,10 @@ class MerkleTree {
     // Filter empty strings and hash elements
     this.elements = elements.filter(el => el).map(el => keccak256(el));
 
-    // Deduplicate elements
-    this.elements = this.bufDedup(this.elements);
     // Sort elements
     this.elements.sort(Buffer.compare);
+    // Deduplicate elements
+    this.elements = this.bufDedup(this.elements);
 
     // Create layers
     this.layers = this.getLayers(this.elements);
@@ -113,7 +113,7 @@ class MerkleTree {
 
   bufDedup (elements) {
     return elements.filter((el, idx) => {
-      return this.bufIndexOf(el, elements) === idx;
+      return idx > 0 && !elements[idx - 1].equals(el)
     });
   }
 

--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -113,7 +113,7 @@ class MerkleTree {
 
   bufDedup (elements) {
     return elements.filter((el, idx) => {
-      return idx > 0 && !elements[idx - 1].equals(el);
+      return idx === 0 || !elements[idx - 1].equals(el);
     });
   }
 

--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -113,7 +113,7 @@ class MerkleTree {
 
   bufDedup (elements) {
     return elements.filter((el, idx) => {
-      return idx > 0 && !elements[idx - 1].equals(el)
+      return idx > 0 && !elements[idx - 1].equals(el);
     });
   }
 


### PR DESCRIPTION

Fixes #
When I tested with 30,000 leafs, it look ~ 23seconds to generate the tree. 
With this PR, it optimizes the performance in 20x.