### PR TITLE
Documentation: Typos and add npm init -y to setup instructions

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -14,6 +14,7 @@ Please install Truffle and initialize your project:
 ```sh
 $ mkdir myproject
 $ cd myproject
+$ npm init -y
 $ npm install truffle
 $ npx truffle init
 ```

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -112,10 +112,10 @@ contract GameItem is ERC721Full {
     constructor() ERC721Full("GameItem", "ITM") public {
     }
 
-    function awardItem(address player, string memory tokenURI) public returs (uint256) {
+    function awardItem(address player, string memory tokenURI) public returns (uint256) {
         _tokenIds.increment();
 
-        uint256 newItemId = _tokenIds.current()
+        uint256 newItemId = _tokenIds.current();
         _mint(player, newItemId);
         _setTokenURI(newItemId, tokenURI);
 


### PR DESCRIPTION
Fix typos in GameItem example ERC721
Suggest adding `npm init -y` to create package.json as part of setup instructions