### PR TITLE
Update ERC20 Guide link (was 404)

### DIFF
--- a/contracts/token/ERC20/README.md
+++ b/contracts/token/ERC20/README.md
@@ -19,7 +19,7 @@ sections:
 
 This set of interfaces, contracts, and utilities are all related to the [ERC20 Token Standard](https://eips.ethereum.org/EIPS/eip-20).
 
-*For a walkthrough on how to create an ERC20 token read our [ERC20 guide](../../tokens.md#constructing-a-nice-erc20-token).*
+*For a walkthrough on how to create an ERC20 token read our [ERC20 guide](../../../docs/tokens.md#constructing-a-nice-erc20-token).*
 
 There a few core contracts that implement the behavior specified in the EIP: `IERC20`, `ERC20`, `ERC20Detailed`.
 


### PR DESCRIPTION
Link for "ERC20 Guide" on [Token Readme](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/README.md) is giving 404.  

https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/tokens.md#constructing-a-nice-erc20-token

Looks like `tokens.md` has been moved to the `./docs` dir. The # link matched the section title so I assume this is where it was meant to go. 

EDIT: No issue found for this.  https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1790 is also about broken links, but not this particular one. 