### PR TITLE
Fix/chai.expect for chai.should

### DIFF
--- a/test/access/Roles.test.js
+++ b/test/access/Roles.test.js
@@ -1,4 +1,5 @@
 const { expectRevert, constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const RolesMock = artifacts.require('RolesMock');
@@ -14,16 +15,16 @@ contract('Roles', function ([_, authorized, otherAuthorized, other]) {
 
   context('initially', function () {
     it('doesn\'t pre-assign roles', async function () {
-      (await this.roles.has(authorized)).should.equal(false);
-      (await this.roles.has(otherAuthorized)).should.equal(false);
-      (await this.roles.has(other)).should.equal(false);
+      expect(await this.roles.has(authorized)).to.equal(false);
+      expect(await this.roles.has(otherAuthorized)).to.equal(false);
+      expect(await this.roles.has(other)).to.equal(false);
     });
 
     describe('adding roles', function () {
       it('adds roles to a single account', async function () {
         await this.roles.add(authorized);
-        (await this.roles.has(authorized)).should.equal(true);
-        (await this.roles.has(other)).should.equal(false);
+        expect(await this.roles.has(authorized)).to.equal(true);
+        expect(await this.roles.has(other)).to.equal(false);
       });
 
       it('reverts when adding roles to an already assigned account', async function () {
@@ -46,8 +47,8 @@ contract('Roles', function ([_, authorized, otherAuthorized, other]) {
     describe('removing roles', function () {
       it('removes a single role', async function () {
         await this.roles.remove(authorized);
-        (await this.roles.has(authorized)).should.equal(false);
-        (await this.roles.has(otherAuthorized)).should.equal(true);
+        expect(await this.roles.has(authorized)).to.equal(false);
+        expect(await this.roles.has(otherAuthorized)).to.equal(true);
       });
 
       it('reverts when removing unassigned roles', async function () {

--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -1,4 +1,5 @@
 const { expectRevert, constants, expectEvent } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function capitalize (str) {
@@ -25,9 +26,9 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
   describe('should behave like public role', function () {
     beforeEach('check preconditions', async function () {
-      (await this.contract[`is${rolename}`](authorized)).should.equal(true);
-      (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
-      (await this.contract[`is${rolename}`](other)).should.equal(false);
+      expect(await this.contract[`is${rolename}`](authorized)).to.equal(true);
+      expect(await this.contract[`is${rolename}`](otherAuthorized)).to.equal(true);
+      expect(await this.contract[`is${rolename}`](other)).to.equal(false);
     });
 
     if (manager === undefined) { // Managed roles are only assigned by the manager, and none are set at construction
@@ -70,7 +71,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
       context(`from ${manager ? 'the manager' : 'a role-haver'} account`, function () {
         it('adds role to a new account', async function () {
           await this.contract[`add${rolename}`](other, { from });
-          (await this.contract[`is${rolename}`](other)).should.equal(true);
+          expect(await this.contract[`is${rolename}`](other)).to.equal(true);
         });
 
         it(`emits a ${rolename}Added event`, async function () {
@@ -99,8 +100,8 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
       context(`from ${manager ? 'the manager' : 'any'} account`, function () {
         it('removes role from an already assigned account', async function () {
           await this.contract[`remove${rolename}`](authorized, { from });
-          (await this.contract[`is${rolename}`](authorized)).should.equal(false);
-          (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
+          expect(await this.contract[`is${rolename}`](authorized)).to.equal(false);
+          expect(await this.contract[`is${rolename}`](otherAuthorized)).to.equal(true);
         });
 
         it(`emits a ${rolename}Removed event`, async function () {
@@ -125,7 +126,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
     describe('renouncing roles', function () {
       it('renounces an assigned role', async function () {
         await this.contract[`renounce${rolename}`]({ from: authorized });
-        (await this.contract[`is${rolename}`](authorized)).should.equal(false);
+        expect(await this.contract[`is${rolename}`](authorized)).to.equal(false);
       });
 
       it(`emits a ${rolename}Removed event`, async function () {

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { balance, BN, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const AllowanceCrowdsaleImpl = artifacts.require('AllowanceCrowdsaleImpl');
@@ -18,7 +19,7 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
 
   describe('accepting payments', function () {
     it('should have token wallet', async function () {
-      (await this.crowdsale.tokenWallet()).should.be.equal(tokenWallet);
+      expect(await this.crowdsale.tokenWallet()).to.be.equal(tokenWallet);
     });
 
     it('should accept sends', async function () {
@@ -43,13 +44,13 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
 
     it('should assign tokens to sender', async function () {
       await this.crowdsale.sendTransaction({ value: value, from: investor });
-      (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
+      expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(expectedTokenAmount);
     });
 
     it('should forward funds to wallet', async function () {
       const balanceTracker = await balance.tracker(wallet);
       await this.crowdsale.sendTransaction({ value, from: investor });
-      (await balanceTracker.delta()).should.be.bignumber.equal(value);
+      expect(await balanceTracker.delta()).to.be.bignumber.equal(value);
     });
   });
 
@@ -57,7 +58,7 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
     it('should report correct allowance left', async function () {
       const remainingAllowance = tokenAllowance.sub(expectedTokenAmount);
       await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
-      (await this.crowdsale.remainingTokens()).should.be.bignumber.equal(remainingAllowance);
+      expect(await this.crowdsale.remainingTokens()).to.be.bignumber.equal(remainingAllowance);
     });
 
     context('when the allowance is larger than the token amount', function () {
@@ -67,7 +68,7 @@ contract('AllowanceCrowdsale', function ([_, investor, wallet, purchaser, tokenW
       });
 
       it('should report the amount instead of the allowance', async function () {
-        (await this.crowdsale.remainingTokens()).should.be.bignumber.equal(await this.token.balanceOf(tokenWallet));
+        expect(await this.crowdsale.remainingTokens()).to.be.bignumber.equal(await this.token.balanceOf(tokenWallet));
       });
     });
   });

--- a/test/crowdsale/CappedCrowdsale.test.js
+++ b/test/crowdsale/CappedCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const CappedCrowdsaleImpl = artifacts.require('CappedCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -44,17 +45,17 @@ contract('CappedCrowdsale', function ([_, wallet]) {
     describe('ending', function () {
       it('should not reach cap if sent under cap', async function () {
         await this.crowdsale.send(lessThanCap);
-        (await this.crowdsale.capReached()).should.equal(false);
+        expect(await this.crowdsale.capReached()).to.equal(false);
       });
 
       it('should not reach cap if sent just under cap', async function () {
         await this.crowdsale.send(cap.subn(1));
-        (await this.crowdsale.capReached()).should.equal(false);
+        expect(await this.crowdsale.capReached()).to.equal(false);
       });
 
       it('should reach cap if cap sent', async function () {
         await this.crowdsale.send(cap);
-        (await this.crowdsale.capReached()).should.equal(true);
+        expect(await this.crowdsale.capReached()).to.equal(true);
       });
     });
   });

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -1,4 +1,5 @@
 const { balance, BN, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const Crowdsale = artifacts.require('CrowdsaleMock');
@@ -86,13 +87,13 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
 
         it('should assign tokens to sender', async function () {
           await this.crowdsale.sendTransaction({ value: value, from: investor });
-          (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
+          expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(expectedTokenAmount);
         });
 
         it('should forward funds to wallet', async function () {
           const balanceTracker = await balance.tracker(wallet);
           await this.crowdsale.sendTransaction({ value, from: investor });
-          (await balanceTracker.delta()).should.be.bignumber.equal(value);
+          expect(await balanceTracker.delta()).to.be.bignumber.equal(value);
         });
       });
 
@@ -109,13 +110,13 @@ contract('Crowdsale', function ([_, investor, wallet, purchaser]) {
 
         it('should assign tokens to beneficiary', async function () {
           await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-          (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
+          expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(expectedTokenAmount);
         });
 
         it('should forward funds to wallet', async function () {
           const balanceTracker = await balance.tracker(wallet);
           await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-          (await balanceTracker.delta()).should.be.bignumber.equal(value);
+          expect(await balanceTracker.delta()).to.be.bignumber.equal(value);
         });
       });
     });

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const IncreasingPriceCrowdsaleImpl = artifacts.require('IncreasingPriceCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -52,8 +53,8 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
       });
 
       it('should have initial and final rate', async function () {
-        (await this.crowdsale.initialRate()).should.be.bignumber.equal(initialRate);
-        (await this.crowdsale.finalRate()).should.be.bignumber.equal(finalRate);
+        expect(await this.crowdsale.initialRate()).to.be.bignumber.equal(initialRate);
+        expect(await this.crowdsale.finalRate()).to.be.bignumber.equal(finalRate);
       });
 
       it('reverts when the base Crowdsale\'s rate function is called', async function () {
@@ -63,54 +64,54 @@ contract('IncreasingPriceCrowdsale', function ([_, investor, wallet, purchaser])
       });
 
       it('returns a rate of 0 before the crowdsale starts', async function () {
-        (await this.crowdsale.getCurrentRate()).should.be.bignumber.equal('0');
+        expect(await this.crowdsale.getCurrentRate()).to.be.bignumber.equal('0');
       });
 
       it('returns a rate of 0 after the crowdsale ends', async function () {
         await time.increaseTo(this.afterClosingTime);
-        (await this.crowdsale.getCurrentRate()).should.be.bignumber.equal('0');
+        expect(await this.crowdsale.getCurrentRate()).to.be.bignumber.equal('0');
       });
 
       it('at start', async function () {
         await time.increaseTo(this.startTime);
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(initialRate));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(initialRate));
       });
 
       it('at time 150', async function () {
         await time.increaseTo(this.startTime.addn(150));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime150));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime150));
       });
 
       it('at time 300', async function () {
         await time.increaseTo(this.startTime.addn(300));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime300));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime300));
       });
 
       it('at time 1500', async function () {
         await time.increaseTo(this.startTime.addn(1500));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime1500));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime1500));
       });
 
       it('at time 30', async function () {
         await time.increaseTo(this.startTime.addn(30));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime30));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime30));
       });
 
       it('at time 150000', async function () {
         await time.increaseTo(this.startTime.addn(150000));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime150000));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime150000));
       });
 
       it('at time 450000', async function () {
         await time.increaseTo(this.startTime.addn(450000));
         await this.crowdsale.buyTokens(investor, { value, from: purchaser });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(value.mul(rateAtTime450000));
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value.mul(rateAtTime450000));
       });
     });
   });

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const IndividuallyCappedCrowdsaleImpl = artifacts.require('IndividuallyCappedCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -30,7 +31,7 @@ contract('IndividuallyCappedCrowdsale', function (
   describe('individual caps', function () {
     it('sets a cap when the sender is a capper', async function () {
       await this.crowdsale.setCap(alice, capAlice, { from: capper });
-      (await this.crowdsale.getCap(alice)).should.be.bignumber.equal(capAlice);
+      expect(await this.crowdsale.getCap(alice)).to.be.bignumber.equal(capAlice);
     });
 
     it('reverts when a non-capper sets a cap', async function () {
@@ -84,12 +85,12 @@ contract('IndividuallyCappedCrowdsale', function (
 
       describe('reporting state', function () {
         it('should report correct cap', async function () {
-          (await this.crowdsale.getCap(alice)).should.be.bignumber.equal(capAlice);
+          expect(await this.crowdsale.getCap(alice)).to.be.bignumber.equal(capAlice);
         });
 
         it('should report actual contribution', async function () {
           await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
-          (await this.crowdsale.getContribution(alice)).should.be.bignumber.equal(lessThanCapAlice);
+          expect(await this.crowdsale.getContribution(alice)).to.be.bignumber.equal(lessThanCapAlice);
         });
       });
     });

--- a/test/crowdsale/MintedCrowdsale.behavior.js
+++ b/test/crowdsale/MintedCrowdsale.behavior.js
@@ -1,4 +1,5 @@
 const { balance, expectEvent } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 function shouldBehaveLikeMintedCrowdsale ([_, investor, wallet, purchaser], rate, value) {
   const expectedTokenAmount = rate.mul(value);
@@ -24,13 +25,13 @@ function shouldBehaveLikeMintedCrowdsale ([_, investor, wallet, purchaser], rate
 
       it('should assign tokens to sender', async function () {
         await this.crowdsale.sendTransaction({ value: value, from: investor });
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(expectedTokenAmount);
       });
 
       it('should forward funds to wallet', async function () {
         const balanceTracker = await balance.tracker(wallet);
         await this.crowdsale.sendTransaction({ value, from: investor });
-        (await balanceTracker.delta()).should.be.bignumber.equal(value);
+        expect(await balanceTracker.delta()).to.be.bignumber.equal(value);
       });
     });
   });

--- a/test/crowdsale/MintedCrowdsale.test.js
+++ b/test/crowdsale/MintedCrowdsale.test.js
@@ -1,5 +1,6 @@
 const { BN, ether, expectRevert } = require('openzeppelin-test-helpers');
 const { shouldBehaveLikeMintedCrowdsale } = require('./MintedCrowdsale.behavior');
+const { expect } = require('chai');
 
 const MintedCrowdsaleImpl = artifacts.require('MintedCrowdsaleImpl');
 const ERC20Mintable = artifacts.require('ERC20Mintable');
@@ -19,7 +20,7 @@ contract('MintedCrowdsale', function ([_, deployer, investor, wallet, purchaser]
     });
 
     it('crowdsale should be minter', async function () {
-      (await this.token.isMinter(this.crowdsale.address)).should.equal(true);
+      expect(await this.token.isMinter(this.crowdsale.address)).to.equal(true);
     });
 
     shouldBehaveLikeMintedCrowdsale([_, investor, wallet, purchaser], rate, value);

--- a/test/crowdsale/PostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/PostDeliveryCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const PostDeliveryCrowdsaleImpl = artifacts.require('PostDeliveryCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -36,8 +37,8 @@ contract('PostDeliveryCrowdsale', function ([_, investor, wallet, purchaser]) {
       });
 
       it('does not immediately assign tokens to beneficiaries', async function () {
-        (await this.crowdsale.balanceOf(investor)).should.be.bignumber.equal(value);
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal('0');
+        expect(await this.crowdsale.balanceOf(investor)).to.be.bignumber.equal(value);
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal('0');
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
@@ -53,8 +54,8 @@ contract('PostDeliveryCrowdsale', function ([_, investor, wallet, purchaser]) {
 
         it('allows beneficiaries to withdraw tokens', async function () {
           await this.crowdsale.withdrawTokens(investor);
-          (await this.crowdsale.balanceOf(investor)).should.be.bignumber.equal('0');
-          (await this.token.balanceOf(investor)).should.be.bignumber.equal(value);
+          expect(await this.crowdsale.balanceOf(investor)).to.be.bignumber.equal('0');
+          expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value);
         });
 
         it('rejects multiple withdrawals', async function () {

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { balance, BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const RefundableCrowdsaleImpl = artifacts.require('RefundableCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -72,7 +73,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
           it('refunds', async function () {
             const balanceTracker = await balance.tracker(investor);
             await this.crowdsale.claimRefund(investor, { gasPrice: 0 });
-            (await balanceTracker.delta()).should.be.bignumber.equal(lessThanGoal);
+            expect(await balanceTracker.delta()).to.be.bignumber.equal(lessThanGoal);
           });
         });
       });
@@ -96,7 +97,7 @@ contract('RefundableCrowdsale', function ([_, wallet, investor, purchaser, other
 
           it('forwards funds to wallet', async function () {
             const postWalletBalance = await balance.current(wallet);
-            postWalletBalance.sub(this.preWalletBalance).should.be.bignumber.equal(goal);
+            expect(postWalletBalance.sub(this.preWalletBalance)).to.be.bignumber.equal(goal);
           });
         });
       });

--- a/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const RefundablePostDeliveryCrowdsaleImpl = artifacts.require('RefundablePostDeliveryCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -37,8 +38,8 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
       });
 
       it('does not immediately deliver tokens to beneficiaries', async function () {
-        (await this.crowdsale.balanceOf(investor)).should.be.bignumber.equal(value);
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal('0');
+        expect(await this.crowdsale.balanceOf(investor)).to.be.bignumber.equal(value);
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal('0');
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
@@ -69,8 +70,8 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
       });
 
       it('does not immediately deliver tokens to beneficiaries', async function () {
-        (await this.crowdsale.balanceOf(investor)).should.be.bignumber.equal(value);
-        (await this.token.balanceOf(investor)).should.be.bignumber.equal('0');
+        expect(await this.crowdsale.balanceOf(investor)).to.be.bignumber.equal(value);
+        expect(await this.token.balanceOf(investor)).to.be.bignumber.equal('0');
       });
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
@@ -87,8 +88,8 @@ contract('RefundablePostDeliveryCrowdsale', function ([_, investor, wallet, purc
 
         it('allows beneficiaries to withdraw tokens', async function () {
           await this.crowdsale.withdrawTokens(investor);
-          (await this.crowdsale.balanceOf(investor)).should.be.bignumber.equal('0');
-          (await this.token.balanceOf(investor)).should.be.bignumber.equal(value);
+          expect(await this.crowdsale.balanceOf(investor)).to.be.bignumber.equal('0');
+          expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(value);
         });
 
         it('rejects multiple withdrawals', async function () {

--- a/test/crowdsale/TimedCrowdsale.test.js
+++ b/test/crowdsale/TimedCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, ether, expectEvent, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const TimedCrowdsaleImpl = artifacts.require('TimedCrowdsaleImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -47,15 +48,15 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
     });
 
     it('should be ended only after end', async function () {
-      (await this.crowdsale.hasClosed()).should.equal(false);
+      expect(await this.crowdsale.hasClosed()).to.equal(false);
       await time.increaseTo(this.afterClosingTime);
-      (await this.crowdsale.isOpen()).should.equal(false);
-      (await this.crowdsale.hasClosed()).should.equal(true);
+      expect(await this.crowdsale.isOpen()).to.equal(false);
+      expect(await this.crowdsale.hasClosed()).to.equal(true);
     });
 
     describe('accepting payments', function () {
       it('should reject payments before start', async function () {
-        (await this.crowdsale.isOpen()).should.equal(false);
+        expect(await this.crowdsale.isOpen()).to.equal(false);
         await expectRevert(this.crowdsale.send(value), 'TimedCrowdsale: not open');
         await expectRevert(this.crowdsale.buyTokens(investor, { from: purchaser, value: value }),
           'TimedCrowdsale: not open'
@@ -64,7 +65,7 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
 
       it('should accept payments after start', async function () {
         await time.increaseTo(this.openingTime);
-        (await this.crowdsale.isOpen()).should.equal(true);
+        expect(await this.crowdsale.isOpen()).to.equal(true);
         await this.crowdsale.send(value);
         await this.crowdsale.buyTokens(investor, { value: value, from: purchaser });
       });
@@ -94,7 +95,7 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
 
       context('before crowdsale start', function () {
         beforeEach(async function () {
-          (await this.crowdsale.isOpen()).should.equal(false);
+          expect(await this.crowdsale.isOpen()).to.equal(false);
           await expectRevert(this.crowdsale.send(value), 'TimedCrowdsale: not open');
         });
 
@@ -105,14 +106,14 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
             prevClosingTime: this.closingTime,
             newClosingTime: newClosingTime,
           });
-          (await this.crowdsale.closingTime()).should.be.bignumber.equal(newClosingTime);
+          expect(await this.crowdsale.closingTime()).to.be.bignumber.equal(newClosingTime);
         });
       });
 
       context('after crowdsale start', function () {
         beforeEach(async function () {
           await time.increaseTo(this.openingTime);
-          (await this.crowdsale.isOpen()).should.equal(true);
+          expect(await this.crowdsale.isOpen()).to.equal(true);
           await this.crowdsale.send(value);
         });
 
@@ -123,7 +124,7 @@ contract('TimedCrowdsale', function ([_, investor, wallet, purchaser]) {
             prevClosingTime: this.closingTime,
             newClosingTime: newClosingTime,
           });
-          (await this.crowdsale.closingTime()).should.be.bignumber.equal(newClosingTime);
+          expect(await this.crowdsale.closingTime()).to.be.bignumber.equal(newClosingTime);
         });
       });
 

--- a/test/cryptography/ECDSA.test.js
+++ b/test/cryptography/ECDSA.test.js
@@ -1,4 +1,5 @@
 const { constants, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 const { toEthSignedMessageHash, fixSignature } = require('../helpers/sign');
 
@@ -23,7 +24,7 @@ contract('ECDSA', function ([_, other]) {
         it('returns 0', async function () {
           const version = '00';
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(ZERO_ADDRESS);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(ZERO_ADDRESS);
         });
       });
 
@@ -31,7 +32,7 @@ contract('ECDSA', function ([_, other]) {
         it('works', async function () {
           const version = '1b'; // 27 = 1b.
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(signer);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(signer);
         });
       });
 
@@ -41,7 +42,7 @@ contract('ECDSA', function ([_, other]) {
           // The only valid values are 0, 1, 27 and 28.
           const version = '02';
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(ZERO_ADDRESS);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(ZERO_ADDRESS);
         });
       });
     });
@@ -55,7 +56,7 @@ contract('ECDSA', function ([_, other]) {
         it('returns 0', async function () {
           const version = '01';
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(ZERO_ADDRESS);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(ZERO_ADDRESS);
         });
       });
 
@@ -63,7 +64,7 @@ contract('ECDSA', function ([_, other]) {
         it('works', async function () {
           const version = '1c'; // 28 = 1c.
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(signer);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(signer);
         });
       });
 
@@ -73,7 +74,7 @@ contract('ECDSA', function ([_, other]) {
           // The only valid values are 0, 1, 27 and 28.
           const version = '02';
           const signature = signatureWithoutVersion + version;
-          (await this.ecdsa.recover(TEST_MESSAGE, signature)).should.equal(ZERO_ADDRESS);
+          expect(await this.ecdsa.recover(TEST_MESSAGE, signature)).to.equal(ZERO_ADDRESS);
         });
       });
     });
@@ -84,7 +85,7 @@ contract('ECDSA', function ([_, other]) {
         // eslint-disable-next-line max-len
         const highSSignature = '0xe742ff452d41413616a5bf43fe15dd88294e983d3d36206c2712f39083d638bde0a0fc89be718fbc1033e1d30d78be1c68081562ed2e97af876f286f3453231d1b';
 
-        (await this.ecdsa.recover(message, highSSignature)).should.equal(ZERO_ADDRESS);
+        expect(await this.ecdsa.recover(message, highSSignature)).to.equal(ZERO_ADDRESS);
       });
     });
 
@@ -95,10 +96,10 @@ contract('ECDSA', function ([_, other]) {
           const signature = fixSignature(await web3.eth.sign(TEST_MESSAGE, other));
 
           // Recover the signer address from the generated message and signature.
-          (await this.ecdsa.recover(
+          expect(await this.ecdsa.recover(
             toEthSignedMessageHash(TEST_MESSAGE),
             signature
-          )).should.equal(other);
+          )).to.equal(other);
         });
       });
 
@@ -108,7 +109,7 @@ contract('ECDSA', function ([_, other]) {
           const signature = await web3.eth.sign(TEST_MESSAGE, other);
 
           // Recover the signer address from the generated message and wrong signature.
-          (await this.ecdsa.recover(WRONG_MESSAGE, signature)).should.not.equal(other);
+          expect(await this.ecdsa.recover(WRONG_MESSAGE, signature)).to.not.equal(other);
         });
       });
     });
@@ -128,7 +129,7 @@ contract('ECDSA', function ([_, other]) {
 
   context('toEthSignedMessage', function () {
     it('should prefix hashes correctly', async function () {
-      (await this.ecdsa.toEthSignedMessageHash(TEST_MESSAGE)).should.equal(toEthSignedMessageHash(TEST_MESSAGE));
+      expect(await this.ecdsa.toEthSignedMessageHash(TEST_MESSAGE)).to.equal(toEthSignedMessageHash(TEST_MESSAGE));
     });
   });
 });

--- a/test/cryptography/MerkleProof.test.js
+++ b/test/cryptography/MerkleProof.test.js
@@ -1,4 +1,5 @@
 require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const { MerkleTree } = require('../helpers/merkleTree.js');
 const { keccak256, bufferToHex } = require('ethereumjs-util');
@@ -21,7 +22,7 @@ contract('MerkleProof', function () {
 
       const leaf = bufferToHex(keccak256(elements[0]));
 
-      (await this.merkleProof.verify(proof, root, leaf)).should.equal(true);
+      expect(await this.merkleProof.verify(proof, root, leaf)).to.equal(true);
     });
 
     it('should return false for an invalid Merkle proof', async function () {
@@ -37,7 +38,7 @@ contract('MerkleProof', function () {
 
       const badProof = badMerkleTree.getHexProof(badElements[0]);
 
-      (await this.merkleProof.verify(badProof, correctRoot, correctLeaf)).should.equal(false);
+      expect(await this.merkleProof.verify(badProof, correctRoot, correctLeaf)).to.equal(false);
     });
 
     it('should return false for a Merkle proof of invalid length', async function () {
@@ -51,7 +52,7 @@ contract('MerkleProof', function () {
 
       const leaf = bufferToHex(keccak256(elements[0]));
 
-      (await this.merkleProof.verify(badProof, root, leaf)).should.equal(false);
+      expect(await this.merkleProof.verify(badProof, root, leaf)).to.equal(false);
     });
   });
 });

--- a/test/drafts/Counters.test.js
+++ b/test/drafts/Counters.test.js
@@ -1,4 +1,5 @@
 const { expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const CountersImpl = artifacts.require('CountersImpl');
 
@@ -8,13 +9,13 @@ contract('Counters', function () {
   });
 
   it('starts at zero', async function () {
-    (await this.counter.current()).should.be.bignumber.equal('0');
+    expect(await this.counter.current()).to.be.bignumber.equal('0');
   });
 
   describe('increment', function () {
     it('increments the current value by one', async function () {
       await this.counter.increment();
-      (await this.counter.current()).should.be.bignumber.equal('1');
+      expect(await this.counter.current()).to.be.bignumber.equal('1');
     });
 
     it('can be called multiple times', async function () {
@@ -22,19 +23,19 @@ contract('Counters', function () {
       await this.counter.increment();
       await this.counter.increment();
 
-      (await this.counter.current()).should.be.bignumber.equal('3');
+      expect(await this.counter.current()).to.be.bignumber.equal('3');
     });
   });
 
   describe('decrement', function () {
     beforeEach(async function () {
       await this.counter.increment();
-      (await this.counter.current()).should.be.bignumber.equal('1');
+      expect(await this.counter.current()).to.be.bignumber.equal('1');
     });
 
     it('decrements the current value by one', async function () {
       await this.counter.decrement();
-      (await this.counter.current()).should.be.bignumber.equal('0');
+      expect(await this.counter.current()).to.be.bignumber.equal('0');
     });
 
     it('reverts if the current value is 0', async function () {
@@ -46,13 +47,13 @@ contract('Counters', function () {
       await this.counter.increment();
       await this.counter.increment();
 
-      (await this.counter.current()).should.be.bignumber.equal('3');
+      expect(await this.counter.current()).to.be.bignumber.equal('3');
 
       await this.counter.decrement();
       await this.counter.decrement();
       await this.counter.decrement();
 
-      (await this.counter.current()).should.be.bignumber.equal('0');
+      expect(await this.counter.current()).to.be.bignumber.equal('0');
     });
   });
 });

--- a/test/drafts/ERC1046/ERC20Metadata.test.js
+++ b/test/drafts/ERC1046/ERC20Metadata.test.js
@@ -1,6 +1,7 @@
 require('openzeppelin-test-helpers');
 
 const ERC20MetadataMock = artifacts.require('ERC20MetadataMock');
+const { expect } = require('chai');
 
 const metadataURI = 'https://example.com';
 
@@ -10,14 +11,14 @@ describe('ERC20Metadata', function () {
   });
 
   it('responds with the metadata', async function () {
-    (await this.token.tokenURI()).should.equal(metadataURI);
+    expect(await this.token.tokenURI()).to.equal(metadataURI);
   });
 
   describe('setTokenURI', function () {
     it('changes the original URI', async function () {
       const newMetadataURI = 'https://betterexample.com';
       await this.token.setTokenURI(newMetadataURI);
-      (await this.token.tokenURI()).should.equal(newMetadataURI);
+      expect(await this.token.tokenURI()).to.equal(newMetadataURI);
     });
   });
 });

--- a/test/drafts/ERC20Migrator.test.js
+++ b/test/drafts/ERC20Migrator.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const ERC20Mock = artifacts.require('ERC20Mock');
@@ -22,7 +23,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
     });
 
     it('returns legacy token', async function () {
-      (await this.migrator.legacyToken()).should.be.equal(this.legacyToken.address);
+      expect(await this.migrator.legacyToken()).to.be.equal(this.legacyToken.address);
     });
 
     describe('beginMigration', function () {
@@ -54,7 +55,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
 
     context('before starting the migration', function () {
       it('returns the zero address for the new token', async function () {
-        (await this.migrator.newToken()).should.be.equal(ZERO_ADDRESS);
+        expect(await this.migrator.newToken()).to.be.equal(ZERO_ADDRESS);
       });
 
       describe('migrateAll', function () {
@@ -97,7 +98,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
       });
 
       it('returns new token', async function () {
-        (await this.migrator.newToken()).should.be.equal(this.newToken.address);
+        expect(await this.migrator.newToken()).to.be.equal(this.newToken.address);
       });
 
       describe('migrateAll', function () {
@@ -117,20 +118,20 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
 
           it('mints the same balance of the new token', async function () {
             const currentBalance = await this.newToken.balanceOf(owner);
-            currentBalance.should.be.bignumber.equal(amount);
+            expect(currentBalance).to.be.bignumber.equal(amount);
           });
 
           it('burns a given amount of old tokens', async function () {
             const currentBurnedBalance = await this.legacyToken.balanceOf(this.migrator.address);
-            currentBurnedBalance.should.be.bignumber.equal(amount);
+            expect(currentBurnedBalance).to.be.bignumber.equal(amount);
 
             const currentLegacyTokenBalance = await this.legacyToken.balanceOf(owner);
-            currentLegacyTokenBalance.should.be.bignumber.equal('0');
+            expect(currentLegacyTokenBalance).to.be.bignumber.equal('0');
           });
 
           it('updates the total supply', async function () {
             const currentSupply = await this.newToken.totalSupply();
-            currentSupply.should.be.bignumber.equal(amount);
+            expect(currentSupply).to.be.bignumber.equal(amount);
           });
         });
 
@@ -144,7 +145,7 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
 
           it('migrates only approved amount', async function () {
             const currentBalance = await this.newToken.balanceOf(owner);
-            currentBalance.should.be.bignumber.equal(amount);
+            expect(currentBalance).to.be.bignumber.equal(amount);
           });
         });
       });
@@ -165,20 +166,20 @@ contract('ERC20Migrator', function ([_, owner, recipient, anotherAccount]) {
 
           it('mints that amount of the new token', async function () {
             const currentBalance = await this.newToken.balanceOf(owner);
-            currentBalance.should.be.bignumber.equal(amount);
+            expect(currentBalance).to.be.bignumber.equal(amount);
           });
 
           it('burns a given amount of old tokens', async function () {
             const currentBurnedBalance = await this.legacyToken.balanceOf(this.migrator.address);
-            currentBurnedBalance.should.be.bignumber.equal(amount);
+            expect(currentBurnedBalance).to.be.bignumber.equal(amount);
 
             const currentLegacyTokenBalance = await this.legacyToken.balanceOf(owner);
-            currentLegacyTokenBalance.should.be.bignumber.equal(totalSupply.sub(amount));
+            expect(currentLegacyTokenBalance).to.be.bignumber.equal(totalSupply.sub(amount));
           });
 
           it('updates the total supply', async function () {
             const currentSupply = await this.newToken.totalSupply();
-            currentSupply.should.be.bignumber.equal(amount);
+            expect(currentSupply).to.be.bignumber.equal(amount);
           });
         });
 

--- a/test/drafts/ERC20Snapshot.test.js
+++ b/test/drafts/ERC20Snapshot.test.js
@@ -1,4 +1,5 @@
 const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const ERC20SnapshotMock = artifacts.require('ERC20SnapshotMock');
 
 contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
@@ -41,7 +42,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
 
       context('with no supply changes after the snapshot', function () {
         it('returns the current total supply', async function () {
-          (await this.token.totalSupplyAt(this.initialSnapshotId)).should.be.bignumber.equal(initialSupply);
+          expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
         });
       });
 
@@ -52,7 +53,7 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
         });
 
         it('returns the total supply before the changes', async function () {
-          (await this.token.totalSupplyAt(this.initialSnapshotId)).should.be.bignumber.equal(initialSupply);
+          expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
         });
 
         context('with a second snapshot after supply changes', function () {
@@ -64,9 +65,9 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
           });
 
           it('snapshots return the supply before and after the changes', async function () {
-            (await this.token.totalSupplyAt(this.initialSnapshotId)).should.be.bignumber.equal(initialSupply);
+            expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
 
-            (await this.token.totalSupplyAt(this.secondSnapshotId)).should.be.bignumber.equal(
+            expect(await this.token.totalSupplyAt(this.secondSnapshotId)).to.be.bignumber.equal(
               await this.token.totalSupply()
             );
           });
@@ -83,12 +84,12 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
           });
 
           it('all posterior snapshots return the supply after the changes', async function () {
-            (await this.token.totalSupplyAt(this.initialSnapshotId)).should.be.bignumber.equal(initialSupply);
+            expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
 
             const currentSupply = await this.token.totalSupply();
 
             for (const id of this.secondSnapshotIds) {
-              (await this.token.totalSupplyAt(id)).should.be.bignumber.equal(currentSupply);
+              expect(await this.token.totalSupplyAt(id)).to.be.bignumber.equal(currentSupply);
             }
           });
         });
@@ -115,10 +116,10 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
 
       context('with no balance changes after the snapshot', function () {
         it('returns the current balance for all accounts', async function () {
-          (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
-            .should.be.bignumber.equal(initialSupply);
-          (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-          (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
+          expect(await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
+            .to.be.bignumber.equal(initialSupply);
+          expect(await this.token.balanceOfAt(recipient, this.initialSnapshotId)).to.be.bignumber.equal('0');
+          expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
         });
       });
 
@@ -130,10 +131,10 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
         });
 
         it('returns the balances before the changes', async function () {
-          (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
-            .should.be.bignumber.equal(initialSupply);
-          (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-          (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
+          expect(await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
+            .to.be.bignumber.equal(initialSupply);
+          expect(await this.token.balanceOfAt(recipient, this.initialSnapshotId)).to.be.bignumber.equal('0');
+          expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
         });
 
         context('with a second snapshot after supply changes', function () {
@@ -145,18 +146,18 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
           });
 
           it('snapshots return the balances before and after the changes', async function () {
-            (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
-              .should.be.bignumber.equal(initialSupply);
-            (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-            (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
+            expect(await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
+              .to.be.bignumber.equal(initialSupply);
+            expect(await this.token.balanceOfAt(recipient, this.initialSnapshotId)).to.be.bignumber.equal('0');
+            expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
 
-            (await this.token.balanceOfAt(initialHolder, this.secondSnapshotId)).should.be.bignumber.equal(
+            expect(await this.token.balanceOfAt(initialHolder, this.secondSnapshotId)).to.be.bignumber.equal(
               await this.token.balanceOf(initialHolder)
             );
-            (await this.token.balanceOfAt(recipient, this.secondSnapshotId)).should.be.bignumber.equal(
+            expect(await this.token.balanceOfAt(recipient, this.secondSnapshotId)).to.be.bignumber.equal(
               await this.token.balanceOf(recipient)
             );
-            (await this.token.balanceOfAt(other, this.secondSnapshotId)).should.be.bignumber.equal(
+            expect(await this.token.balanceOfAt(other, this.secondSnapshotId)).to.be.bignumber.equal(
               await this.token.balanceOf(other)
             );
           });
@@ -173,19 +174,19 @@ contract('ERC20Snapshot', function ([_, initialHolder, recipient, other]) {
           });
 
           it('all posterior snapshots return the supply after the changes', async function () {
-            (await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
-              .should.be.bignumber.equal(initialSupply);
-            (await this.token.balanceOfAt(recipient, this.initialSnapshotId)).should.be.bignumber.equal('0');
-            (await this.token.balanceOfAt(other, this.initialSnapshotId)).should.be.bignumber.equal('0');
+            expect(await this.token.balanceOfAt(initialHolder, this.initialSnapshotId))
+              .to.be.bignumber.equal(initialSupply);
+            expect(await this.token.balanceOfAt(recipient, this.initialSnapshotId)).to.be.bignumber.equal('0');
+            expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
 
             for (const id of this.secondSnapshotIds) {
-              (await this.token.balanceOfAt(initialHolder, id)).should.be.bignumber.equal(
+              expect(await this.token.balanceOfAt(initialHolder, id)).to.be.bignumber.equal(
                 await this.token.balanceOf(initialHolder)
               );
-              (await this.token.balanceOfAt(recipient, id)).should.be.bignumber.equal(
+              expect(await this.token.balanceOfAt(recipient, id)).to.be.bignumber.equal(
                 await this.token.balanceOf(recipient)
               );
-              (await this.token.balanceOfAt(other, id)).should.be.bignumber.equal(
+              expect(await this.token.balanceOfAt(other, id)).to.be.bignumber.equal(
                 await this.token.balanceOf(other)
               );
             }

--- a/test/drafts/SignatureBouncer.test.js
+++ b/test/drafts/SignatureBouncer.test.js
@@ -1,4 +1,5 @@
 const { expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { getSignFor } = require('../helpers/sign');
 const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
 
@@ -140,79 +141,80 @@ contract('SignatureBouncer', function ([_, signer, otherSigner, other, authorize
   context('signature validation', function () {
     context('plain signature', function () {
       it('validates valid signature for valid user', async function () {
-        (await this.sigBouncer.checkValidSignature(authorizedUser, await this.signFor(authorizedUser)))
-          .should.equal(true);
+        expect(await this.sigBouncer.checkValidSignature(authorizedUser, await this.signFor(authorizedUser)))
+          .to.equal(true);
       });
 
       it('does not validate invalid signature for valid user', async function () {
-        (await this.sigBouncer.checkValidSignature(authorizedUser, INVALID_SIGNATURE)).should.equal(false);
+        expect(await this.sigBouncer.checkValidSignature(authorizedUser, INVALID_SIGNATURE)).to.equal(false);
       });
 
       it('does not validate valid signature for anyone', async function () {
-        (await this.sigBouncer.checkValidSignature(other, await this.signFor(authorizedUser))).should.equal(false);
+        expect(await this.sigBouncer.checkValidSignature(other, await this.signFor(authorizedUser))).to.equal(false);
       });
 
       it('does not validate valid signature for method for valid user', async function () {
-        (await this.sigBouncer.checkValidSignature(
+        expect(await this.sigBouncer.checkValidSignature(
           authorizedUser, await this.signFor(authorizedUser, 'checkValidSignature'))
-        ).should.equal(false);
+        ).to.equal(false);
       });
     });
 
     context('method signature', function () {
       it('validates valid signature with correct method for valid user', async function () {
-        (await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser,
+        expect(await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser,
           await this.signFor(authorizedUser, 'checkValidSignatureAndMethod'))
-        ).should.equal(true);
+        ).to.equal(true);
       });
 
       it('does not validate invalid signature with correct method for valid user', async function () {
-        (await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser, INVALID_SIGNATURE)).should.equal(false);
+        expect(await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser, INVALID_SIGNATURE)).to.equal(false);
       });
 
       it('does not validate valid signature with correct method for anyone', async function () {
-        (await this.sigBouncer.checkValidSignatureAndMethod(other,
+        expect(await this.sigBouncer.checkValidSignatureAndMethod(other,
           await this.signFor(authorizedUser, 'checkValidSignatureAndMethod'))
-        ).should.equal(false);
+        ).to.equal(false);
       });
 
       it('does not validate valid non-method signature with correct method for valid user', async function () {
-        (await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser, await this.signFor(authorizedUser))
-        ).should.equal(false);
+        expect(await this.sigBouncer.checkValidSignatureAndMethod(authorizedUser, await this.signFor(authorizedUser))
+        ).to.equal(false);
       });
     });
 
     context('method and data signature', function () {
       it('validates valid signature with correct method and data for valid user', async function () {
-        (await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
+        expect(await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
           await this.signFor(authorizedUser, 'checkValidSignatureAndData', [authorizedUser, BYTES_VALUE, UINT_VALUE]))
-        ).should.equal(true);
+        ).to.equal(true);
       });
 
       it('does not validate invalid signature with correct method and data for valid user', async function () {
-        (await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE, INVALID_SIGNATURE)
-        ).should.equal(false);
+        expect(await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
+          INVALID_SIGNATURE)
+        ).to.equal(false);
       });
 
       it('does not validate valid signature with correct method and incorrect data for valid user',
         async function () {
-          (await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE + 10,
+          expect(await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE + 10,
             await this.signFor(authorizedUser, 'checkValidSignatureAndData', [authorizedUser, BYTES_VALUE, UINT_VALUE]))
-          ).should.equal(false);
+          ).to.equal(false);
         }
       );
 
       it('does not validate valid signature with correct method and data for anyone', async function () {
-        (await this.sigBouncer.checkValidSignatureAndData(other, BYTES_VALUE, UINT_VALUE,
+        expect(await this.sigBouncer.checkValidSignatureAndData(other, BYTES_VALUE, UINT_VALUE,
           await this.signFor(authorizedUser, 'checkValidSignatureAndData', [authorizedUser, BYTES_VALUE, UINT_VALUE]))
-        ).should.equal(false);
+        ).to.equal(false);
       });
 
       it('does not validate valid non-method-data signature with correct method and data for valid user',
         async function () {
-          (await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
+          expect(await this.sigBouncer.checkValidSignatureAndData(authorizedUser, BYTES_VALUE, UINT_VALUE,
             await this.signFor(authorizedUser, 'checkValidSignatureAndData'))
-          ).should.equal(false);
+          ).to.equal(false);
         }
       );
     });

--- a/test/drafts/SignedSafeMath.test.js
+++ b/test/drafts/SignedSafeMath.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { MAX_INT256, MIN_INT256 } = constants;
 
 const SignedSafeMathMock = artifacts.require('SignedSafeMathMock');
@@ -9,8 +10,8 @@ contract('SignedSafeMath', function () {
   });
 
   async function testCommutative (fn, lhs, rhs, expected) {
-    (await fn(lhs, rhs)).should.be.bignumber.equal(expected);
-    (await fn(rhs, lhs)).should.be.bignumber.equal(expected);
+    expect(await fn(lhs, rhs)).to.be.bignumber.equal(expected);
+    expect(await fn(rhs, lhs)).to.be.bignumber.equal(expected);
   }
 
   async function testFailsCommutative (fn, lhs, rhs, reason) {
@@ -54,7 +55,7 @@ contract('SignedSafeMath', function () {
       const b = new BN('1234');
 
       const result = await this.safeMath.sub(a, b);
-      result.should.be.bignumber.equal(a.sub(b));
+      expect(result).to.be.bignumber.equal(a.sub(b));
     });
 
     it('subtracts correctly if it does not overflow and the result is negative', async function () {
@@ -62,7 +63,7 @@ contract('SignedSafeMath', function () {
       const b = new BN('5678');
 
       const result = await this.safeMath.sub(a, b);
-      result.should.be.bignumber.equal(a.sub(b));
+      expect(result).to.be.bignumber.equal(a.sub(b));
     });
 
     it('reverts on positive subtraction overflow', async function () {
@@ -116,21 +117,21 @@ contract('SignedSafeMath', function () {
       const b = new BN('5678');
 
       const result = await this.safeMath.div(a, b);
-      result.should.be.bignumber.equal(a.div(b));
+      expect(result).to.be.bignumber.equal(a.div(b));
     });
 
     it('divides zero correctly', async function () {
       const a = new BN('0');
       const b = new BN('5678');
 
-      (await this.safeMath.div(a, b)).should.be.bignumber.equal('0');
+      expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('0');
     });
 
     it('returns complete number result on non-even division', async function () {
       const a = new BN('7000');
       const b = new BN('5678');
 
-      (await this.safeMath.div(a, b)).should.be.bignumber.equal('1');
+      expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('1');
     });
 
     it('reverts on division by zero', async function () {

--- a/test/drafts/Strings.test.js
+++ b/test/drafts/Strings.test.js
@@ -1,4 +1,5 @@
 const { constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const StringsMock = artifacts.require('StringsMock');
 
@@ -9,15 +10,15 @@ contract('Strings', function () {
 
   describe('from uint256', function () {
     it('converts 0', async function () {
-      (await this.strings.fromUint256(0)).should.equal('0');
+      expect(await this.strings.fromUint256(0)).to.equal('0');
     });
 
     it('converts a positive number', async function () {
-      (await this.strings.fromUint256(4132)).should.equal('4132');
+      expect(await this.strings.fromUint256(4132)).to.equal('4132');
     });
 
     it('converts MAX_UINT256', async function () {
-      (await this.strings.fromUint256(constants.MAX_UINT256)).should.equal(constants.MAX_UINT256.toString());
+      expect(await this.strings.fromUint256(constants.MAX_UINT256)).to.equal(constants.MAX_UINT256.toString());
     });
   });
 });

--- a/test/drafts/TokenVesting.test.js
+++ b/test/drafts/TokenVesting.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const ERC20Mintable = artifacts.require('ERC20Mintable');
@@ -18,7 +19,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
     const cliffDuration = this.duration;
     const duration = this.cliffDuration;
 
-    cliffDuration.should.be.bignumber.that.is.at.least(duration);
+    expect(cliffDuration).to.be.bignumber.that.is.at.least(duration);
 
     await expectRevert(
       TokenVesting.new(beneficiary, this.start, cliffDuration, duration, true, { from: owner }),
@@ -60,11 +61,11 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
     });
 
     it('can get state', async function () {
-      (await this.vesting.beneficiary()).should.be.equal(beneficiary);
-      (await this.vesting.cliff()).should.be.bignumber.equal(this.start.add(this.cliffDuration));
-      (await this.vesting.start()).should.be.bignumber.equal(this.start);
-      (await this.vesting.duration()).should.be.bignumber.equal(this.duration);
-      (await this.vesting.revocable()).should.be.equal(true);
+      expect(await this.vesting.beneficiary()).to.be.equal(beneficiary);
+      expect(await this.vesting.cliff()).to.be.bignumber.equal(this.start.add(this.cliffDuration));
+      expect(await this.vesting.start()).to.be.bignumber.equal(this.start);
+      expect(await this.vesting.duration()).to.be.bignumber.equal(this.duration);
+      expect(await this.vesting.revocable()).to.be.equal(true);
     });
 
     it('cannot be released before cliff', async function () {
@@ -89,8 +90,8 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
       const releaseTime = await time.latest();
 
       const releasedAmount = amount.mul(releaseTime.sub(this.start)).div(this.duration);
-      (await this.token.balanceOf(beneficiary)).should.bignumber.equal(releasedAmount);
-      (await this.vesting.released(this.token.address)).should.bignumber.equal(releasedAmount);
+      expect(await this.token.balanceOf(beneficiary)).to.bignumber.equal(releasedAmount);
+      expect(await this.vesting.released(this.token.address)).to.bignumber.equal(releasedAmount);
     });
 
     it('should linearly release tokens during vesting period', async function () {
@@ -103,22 +104,22 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
         await this.vesting.release(this.token.address);
         const expectedVesting = amount.mul(now.sub(this.start)).div(this.duration);
-        (await this.token.balanceOf(beneficiary)).should.bignumber.equal(expectedVesting);
-        (await this.vesting.released(this.token.address)).should.bignumber.equal(expectedVesting);
+        expect(await this.token.balanceOf(beneficiary)).to.bignumber.equal(expectedVesting);
+        expect(await this.vesting.released(this.token.address)).to.bignumber.equal(expectedVesting);
       }
     });
 
     it('should have released all after end', async function () {
       await time.increaseTo(this.start.add(this.duration));
       await this.vesting.release(this.token.address);
-      (await this.token.balanceOf(beneficiary)).should.bignumber.equal(amount);
-      (await this.vesting.released(this.token.address)).should.bignumber.equal(amount);
+      expect(await this.token.balanceOf(beneficiary)).to.bignumber.equal(amount);
+      expect(await this.vesting.released(this.token.address)).to.bignumber.equal(amount);
     });
 
     it('should be revoked by owner if revocable is set', async function () {
       const { logs } = await this.vesting.revoke(this.token.address, { from: owner });
       expectEvent.inLogs(logs, 'TokenVestingRevoked', { token: this.token.address });
-      (await this.vesting.revoked(this.token.address)).should.equal(true);
+      expect(await this.vesting.revoked(this.token.address)).to.equal(true);
     });
 
     it('should fail to be revoked by owner if revocable not set', async function () {
@@ -138,7 +139,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
       await this.vesting.revoke(this.token.address, { from: owner });
 
-      (await this.token.balanceOf(owner)).should.bignumber.equal(amount.sub(vested));
+      expect(await this.token.balanceOf(owner)).to.bignumber.equal(amount.sub(vested));
     });
 
     it('should keep the vested tokens when revoked by owner', async function () {
@@ -150,7 +151,7 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
 
       const vestedPost = vestedAmount(amount, await time.latest(), this.start, this.cliffDuration, this.duration);
 
-      vestedPre.should.bignumber.equal(vestedPost);
+      expect(vestedPre).to.bignumber.equal(vestedPost);
     });
 
     it('should fail to be revoked a second time', async function () {

--- a/test/examples/SampleCrowdsale.test.js
+++ b/test/examples/SampleCrowdsale.test.js
@@ -1,4 +1,5 @@
 const { BN, balance, ether, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const SampleCrowdsale = artifacts.require('SampleCrowdsale');
 const SampleCrowdsaleToken = artifacts.require('SampleCrowdsaleToken');
@@ -29,12 +30,12 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
   });
 
   it('should create crowdsale with correct parameters', async function () {
-    (await this.crowdsale.openingTime()).should.be.bignumber.equal(this.openingTime);
-    (await this.crowdsale.closingTime()).should.be.bignumber.equal(this.closingTime);
-    (await this.crowdsale.rate()).should.be.bignumber.equal(RATE);
-    (await this.crowdsale.wallet()).should.be.equal(wallet);
-    (await this.crowdsale.goal()).should.be.bignumber.equal(GOAL);
-    (await this.crowdsale.cap()).should.be.bignumber.equal(CAP);
+    expect(await this.crowdsale.openingTime()).to.be.bignumber.equal(this.openingTime);
+    expect(await this.crowdsale.closingTime()).to.be.bignumber.equal(this.closingTime);
+    expect(await this.crowdsale.rate()).to.be.bignumber.equal(RATE);
+    expect(await this.crowdsale.wallet()).to.be.equal(wallet);
+    expect(await this.crowdsale.goal()).to.be.bignumber.equal(GOAL);
+    expect(await this.crowdsale.cap()).to.be.bignumber.equal(CAP);
   });
 
   it('should not accept payments before start', async function () {
@@ -51,8 +52,8 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
     await time.increaseTo(this.openingTime);
     await this.crowdsale.buyTokens(investor, { value: investmentAmount, from: investor });
 
-    (await this.token.balanceOf(investor)).should.be.bignumber.equal(expectedTokenAmount);
-    (await this.token.totalSupply()).should.be.bignumber.equal(expectedTokenAmount);
+    expect(await this.token.balanceOf(investor)).to.be.bignumber.equal(expectedTokenAmount);
+    expect(await this.token.totalSupply()).to.be.bignumber.equal(expectedTokenAmount);
   });
 
   it('should reject payments after end', async function () {
@@ -76,7 +77,7 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
     const balanceTracker = await balance.tracker(wallet);
     await time.increaseTo(this.afterClosingTime);
     await this.crowdsale.finalize({ from: owner });
-    (await balanceTracker.delta()).should.be.bignumber.equal(GOAL);
+    expect(await balanceTracker.delta()).to.be.bignumber.equal(GOAL);
   });
 
   it('should allow refunds if the goal is not reached', async function () {
@@ -89,7 +90,7 @@ contract('SampleCrowdsale', function ([_, deployer, owner, wallet, investor]) {
     await this.crowdsale.finalize({ from: owner });
     await this.crowdsale.claimRefund(investor, { gasPrice: 0 });
 
-    (await balanceTracker.delta()).should.be.bignumber.equal('0');
+    expect(await balanceTracker.delta()).to.be.bignumber.equal('0');
   });
 
   describe('when goal > cap', function () {

--- a/test/examples/SimpleToken.test.js
+++ b/test/examples/SimpleToken.test.js
@@ -1,4 +1,5 @@
 const { constants, expectEvent } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const SimpleToken = artifacts.require('SimpleToken');
@@ -9,22 +10,22 @@ contract('SimpleToken', function ([_, creator]) {
   });
 
   it('has a name', async function () {
-    (await this.token.name()).should.equal('SimpleToken');
+    expect(await this.token.name()).to.equal('SimpleToken');
   });
 
   it('has a symbol', async function () {
-    (await this.token.symbol()).should.equal('SIM');
+    expect(await this.token.symbol()).to.equal('SIM');
   });
 
   it('has 18 decimals', async function () {
-    (await this.token.decimals()).should.be.bignumber.equal('18');
+    expect(await this.token.decimals()).to.be.bignumber.equal('18');
   });
 
   it('assigns the initial total supply to the creator', async function () {
     const totalSupply = await this.token.totalSupply();
     const creatorBalance = await this.token.balanceOf(creator);
 
-    creatorBalance.should.be.bignumber.equal(totalSupply);
+    expect(creatorBalance).to.be.bignumber.equal(totalSupply);
 
     await expectEvent.inConstruction(this.token, 'Transfer', {
       from: ZERO_ADDRESS,

--- a/test/introspection/ERC165Checker.test.js
+++ b/test/introspection/ERC165Checker.test.js
@@ -1,4 +1,5 @@
 require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ERC165CheckerMock = artifacts.require('ERC165CheckerMock');
 const ERC165NotSupported = artifacts.require('ERC165NotSupported');
@@ -23,17 +24,17 @@ contract('ERC165Checker', function () {
 
     it('does not support ERC165', async function () {
       const supported = await this.mock.supportsERC165(this.target.address);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('does not support mock interface via supportsInterface', async function () {
       const supported = await this.mock.supportsInterface(this.target.address, DUMMY_ID);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('does not support mock interface via supportsAllInterfaces', async function () {
       const supported = await this.mock.supportsAllInterfaces(this.target.address, [DUMMY_ID]);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
   });
 
@@ -44,17 +45,17 @@ contract('ERC165Checker', function () {
 
     it('supports ERC165', async function () {
       const supported = await this.mock.supportsERC165(this.target.address);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
 
     it('does not support mock interface via supportsInterface', async function () {
       const supported = await this.mock.supportsInterface(this.target.address, DUMMY_ID);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('does not support mock interface via supportsAllInterfaces', async function () {
       const supported = await this.mock.supportsAllInterfaces(this.target.address, [DUMMY_ID]);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
   });
 
@@ -65,17 +66,17 @@ contract('ERC165Checker', function () {
 
     it('supports ERC165', async function () {
       const supported = await this.mock.supportsERC165(this.target.address);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
 
     it('supports mock interface via supportsInterface', async function () {
       const supported = await this.mock.supportsInterface(this.target.address, DUMMY_ID);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
 
     it('supports mock interface via supportsAllInterfaces', async function () {
       const supported = await this.mock.supportsAllInterfaces(this.target.address, [DUMMY_ID]);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
   });
 
@@ -87,50 +88,50 @@ contract('ERC165Checker', function () {
 
     it('supports ERC165', async function () {
       const supported = await this.mock.supportsERC165(this.target.address);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
 
     it('supports each interfaceId via supportsInterface', async function () {
       for (const interfaceId of this.supportedInterfaces) {
         const supported = await this.mock.supportsInterface(this.target.address, interfaceId);
-        supported.should.equal(true);
+        expect(supported).to.equal(true);
       };
     });
 
     it('supports all interfaceIds via supportsAllInterfaces', async function () {
       const supported = await this.mock.supportsAllInterfaces(this.target.address, this.supportedInterfaces);
-      supported.should.equal(true);
+      expect(supported).to.equal(true);
     });
 
     it('supports none of the interfaces queried via supportsAllInterfaces', async function () {
       const interfaceIdsToTest = [DUMMY_UNSUPPORTED_ID, DUMMY_UNSUPPORTED_ID_2];
 
       const supported = await this.mock.supportsAllInterfaces(this.target.address, interfaceIdsToTest);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('supports not all of the interfaces queried via supportsAllInterfaces', async function () {
       const interfaceIdsToTest = [...this.supportedInterfaces, DUMMY_UNSUPPORTED_ID];
 
       const supported = await this.mock.supportsAllInterfaces(this.target.address, interfaceIdsToTest);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
   });
 
   context('account address does not support ERC165', function () {
     it('does not support ERC165', async function () {
       const supported = await this.mock.supportsERC165(DUMMY_ACCOUNT);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('does not support mock interface via supportsInterface', async function () {
       const supported = await this.mock.supportsInterface(DUMMY_ACCOUNT, DUMMY_ID);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
 
     it('does not support mock interface via supportsAllInterfaces', async function () {
       const supported = await this.mock.supportsAllInterfaces(DUMMY_ACCOUNT, [DUMMY_ID]);
-      supported.should.equal(false);
+      expect(supported).to.equal(false);
     });
   });
 });

--- a/test/introspection/ERC1820Implementer.test.js
+++ b/test/introspection/ERC1820Implementer.test.js
@@ -1,4 +1,5 @@
 const { expectRevert, singletons } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { bufferToHex, keccak256 } = require('ethereumjs-util');
 
 const ERC1820ImplementerMock = artifacts.require('ERC1820ImplementerMock');
@@ -16,8 +17,8 @@ contract('ERC1820Implementer', function ([_, registryFunder, implementee, other]
 
   context('with no registered interfaces', function () {
     it('returns false when interface implementation is queried', async function () {
-      (await this.implementer.canImplementInterfaceForAddress(this.interfaceA, implementee))
-        .should.not.equal(ERC1820_ACCEPT_MAGIC);
+      expect(await this.implementer.canImplementInterfaceForAddress(this.interfaceA, implementee))
+        .to.not.equal(ERC1820_ACCEPT_MAGIC);
     });
 
     it('reverts when attempting to set as implementer in the registry', async function () {
@@ -36,18 +37,18 @@ contract('ERC1820Implementer', function ([_, registryFunder, implementee, other]
     });
 
     it('returns true when interface implementation is queried', async function () {
-      (await this.implementer.canImplementInterfaceForAddress(this.interfaceA, implementee))
-        .should.equal(ERC1820_ACCEPT_MAGIC);
+      expect(await this.implementer.canImplementInterfaceForAddress(this.interfaceA, implementee))
+        .to.equal(ERC1820_ACCEPT_MAGIC);
     });
 
     it('returns false when interface implementation for non-supported interfaces is queried', async function () {
-      (await this.implementer.canImplementInterfaceForAddress(this.interfaceB, implementee))
-        .should.not.equal(ERC1820_ACCEPT_MAGIC);
+      expect(await this.implementer.canImplementInterfaceForAddress(this.interfaceB, implementee))
+        .to.not.equal(ERC1820_ACCEPT_MAGIC);
     });
 
     it('returns false when interface implementation for non-supported addresses is queried', async function () {
-      (await this.implementer.canImplementInterfaceForAddress(this.interfaceA, other))
-        .should.not.equal(ERC1820_ACCEPT_MAGIC);
+      expect(await this.implementer.canImplementInterfaceForAddress(this.interfaceA, other))
+        .to.not.equal(ERC1820_ACCEPT_MAGIC);
     });
 
     it('can be set as an implementer for supported interfaces in the registry', async function () {
@@ -55,8 +56,8 @@ contract('ERC1820Implementer', function ([_, registryFunder, implementee, other]
         implementee, this.interfaceA, this.implementer.address, { from: implementee }
       );
 
-      (await this.registry.getInterfaceImplementer(implementee, this.interfaceA))
-        .should.equal(this.implementer.address);
+      expect(await this.registry.getInterfaceImplementer(implementee, this.interfaceA))
+        .to.equal(this.implementer.address);
     });
   });
 });

--- a/test/introspection/SupportsInterface.behavior.js
+++ b/test/introspection/SupportsInterface.behavior.js
@@ -1,4 +1,5 @@
 const { makeInterfaceId } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const INTERFACES = {
   ERC165: [
@@ -48,11 +49,11 @@ function shouldSupportInterfaces (interfaces = []) {
       describe(k, function () {
         describe('ERC165\'s supportsInterface(bytes4)', function () {
           it('should use less than 30k gas', async function () {
-            (await this.contractUnderTest.supportsInterface.estimateGas(interfaceId)).should.be.lte(30000);
+            expect(await this.contractUnderTest.supportsInterface.estimateGas(interfaceId)).to.be.lte(30000);
           });
 
           it('should claim support', async function () {
-            (await this.contractUnderTest.supportsInterface(interfaceId)).should.equal(true);
+            expect(await this.contractUnderTest.supportsInterface(interfaceId)).to.equal(true);
           });
         });
 
@@ -60,7 +61,7 @@ function shouldSupportInterfaces (interfaces = []) {
           const fnSig = FN_SIGNATURES[fnName];
           describe(fnName, function () {
             it('should be implemented', function () {
-              this.contractUnderTest.abi.filter(fn => fn.signature === fnSig).length.should.equal(1);
+              expect(this.contractUnderTest.abi.filter(fn => fn.signature === fnSig).length).to.equal(1);
             });
           });
         }

--- a/test/lifecycle/Pausable.test.js
+++ b/test/lifecycle/Pausable.test.js
@@ -1,4 +1,5 @@
 const { expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { shouldBehaveLikePublicRole } = require('../behaviors/access/roles/PublicRole.behavior');
 
 const PausableMock = artifacts.require('PausableMock');
@@ -19,27 +20,27 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
 
   context('when unpaused', function () {
     beforeEach(async function () {
-      (await this.pausable.paused()).should.equal(false);
+      expect(await this.pausable.paused()).to.equal(false);
     });
 
     it('can perform normal process in non-pause', async function () {
-      (await this.pausable.count()).should.be.bignumber.equal('0');
+      expect(await this.pausable.count()).to.be.bignumber.equal('0');
 
       await this.pausable.normalProcess({ from: other });
-      (await this.pausable.count()).should.be.bignumber.equal('1');
+      expect(await this.pausable.count()).to.be.bignumber.equal('1');
     });
 
     it('cannot take drastic measure in non-pause', async function () {
       await expectRevert(this.pausable.drasticMeasure({ from: other }),
         'Pausable: not paused'
       );
-      (await this.pausable.drasticMeasureTaken()).should.equal(false);
+      expect(await this.pausable.drasticMeasureTaken()).to.equal(false);
     });
 
     describe('pausing', function () {
       it('is pausable by the pauser', async function () {
         await this.pausable.pause({ from: pauser });
-        (await this.pausable.paused()).should.equal(true);
+        expect(await this.pausable.paused()).to.equal(true);
       });
 
       it('reverts when pausing from non-pauser', async function () {
@@ -63,7 +64,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
 
         it('can take a drastic measure in a pause', async function () {
           await this.pausable.drasticMeasure({ from: other });
-          (await this.pausable.drasticMeasureTaken()).should.equal(true);
+          expect(await this.pausable.drasticMeasureTaken()).to.equal(true);
         });
 
         it('reverts when re-pausing', async function () {
@@ -73,7 +74,7 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
         describe('unpausing', function () {
           it('is unpausable by the pauser', async function () {
             await this.pausable.unpause({ from: pauser });
-            (await this.pausable.paused()).should.equal(false);
+            expect(await this.pausable.paused()).to.equal(false);
           });
 
           it('reverts when unpausing from non-pauser', async function () {
@@ -92,9 +93,9 @@ contract('Pausable', function ([_, pauser, otherPauser, other, ...otherAccounts]
             });
 
             it('should resume allowing normal process', async function () {
-              (await this.pausable.count()).should.be.bignumber.equal('0');
+              expect(await this.pausable.count()).to.be.bignumber.equal('0');
               await this.pausable.normalProcess({ from: other });
-              (await this.pausable.count()).should.be.bignumber.equal('1');
+              expect(await this.pausable.count()).to.be.bignumber.equal('1');
             });
 
             it('should prevent drastic measure', async function () {

--- a/test/math/Math.test.js
+++ b/test/math/Math.test.js
@@ -1,4 +1,5 @@
 const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const MathMock = artifacts.require('MathMock');
 
@@ -12,21 +13,21 @@ contract('Math', function () {
 
   describe('max', function () {
     it('is correctly detected in first argument position', async function () {
-      (await this.math.max(max, min)).should.be.bignumber.equal(max);
+      expect(await this.math.max(max, min)).to.be.bignumber.equal(max);
     });
 
     it('is correctly detected in second argument position', async function () {
-      (await this.math.max(min, max)).should.be.bignumber.equal(max);
+      expect(await this.math.max(min, max)).to.be.bignumber.equal(max);
     });
   });
 
   describe('min', function () {
     it('is correctly detected in first argument position', async function () {
-      (await this.math.min(min, max)).should.be.bignumber.equal(min);
+      expect(await this.math.min(min, max)).to.be.bignumber.equal(min);
     });
 
     it('is correctly detected in second argument position', async function () {
-      (await this.math.min(max, min)).should.be.bignumber.equal(min);
+      expect(await this.math.min(max, min)).to.be.bignumber.equal(min);
     });
   });
 
@@ -38,19 +39,19 @@ contract('Math', function () {
     it('is correctly calculated with two odd numbers', async function () {
       const a = new BN('57417');
       const b = new BN('95431');
-      (await this.math.average(a, b)).should.be.bignumber.equal(bnAverage(a, b));
+      expect(await this.math.average(a, b)).to.be.bignumber.equal(bnAverage(a, b));
     });
 
     it('is correctly calculated with two even numbers', async function () {
       const a = new BN('42304');
       const b = new BN('84346');
-      (await this.math.average(a, b)).should.be.bignumber.equal(bnAverage(a, b));
+      expect(await this.math.average(a, b)).to.be.bignumber.equal(bnAverage(a, b));
     });
 
     it('is correctly calculated with one even and one odd number', async function () {
       const a = new BN('57417');
       const b = new BN('84346');
-      (await this.math.average(a, b)).should.be.bignumber.equal(bnAverage(a, b));
+      expect(await this.math.average(a, b)).to.be.bignumber.equal(bnAverage(a, b));
     });
   });
 });

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { MAX_UINT256 } = constants;
 
 const SafeMathMock = artifacts.require('SafeMathMock');
@@ -9,8 +10,8 @@ contract('SafeMath', function () {
   });
 
   async function testCommutative (fn, lhs, rhs, expected) {
-    (await fn(lhs, rhs)).should.be.bignumber.equal(expected);
-    (await fn(rhs, lhs)).should.be.bignumber.equal(expected);
+    expect(await fn(lhs, rhs)).to.be.bignumber.equal(expected);
+    expect(await fn(rhs, lhs)).to.be.bignumber.equal(expected);
   }
 
   async function testFailsCommutative (fn, lhs, rhs, reason) {
@@ -39,7 +40,7 @@ contract('SafeMath', function () {
       const a = new BN('5678');
       const b = new BN('1234');
 
-      (await this.safeMath.sub(a, b)).should.be.bignumber.equal(a.sub(b));
+      expect(await this.safeMath.sub(a, b)).to.be.bignumber.equal(a.sub(b));
     });
 
     it('reverts if subtraction result would be negative', async function () {
@@ -78,21 +79,21 @@ contract('SafeMath', function () {
       const a = new BN('5678');
       const b = new BN('5678');
 
-      (await this.safeMath.div(a, b)).should.be.bignumber.equal(a.div(b));
+      expect(await this.safeMath.div(a, b)).to.be.bignumber.equal(a.div(b));
     });
 
     it('divides zero correctly', async function () {
       const a = new BN('0');
       const b = new BN('5678');
 
-      (await this.safeMath.div(a, b)).should.be.bignumber.equal('0');
+      expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('0');
     });
 
     it('returns complete number result on non-even division', async function () {
       const a = new BN('7000');
       const b = new BN('5678');
 
-      (await this.safeMath.div(a, b)).should.be.bignumber.equal('1');
+      expect(await this.safeMath.div(a, b)).to.be.bignumber.equal('1');
     });
 
     it('reverts on divison by zero', async function () {
@@ -109,28 +110,28 @@ contract('SafeMath', function () {
         const a = new BN('284');
         const b = new BN('5678');
 
-        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+        expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
       });
 
       it('when the dividend is equal to the divisor', async function () {
         const a = new BN('5678');
         const b = new BN('5678');
 
-        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+        expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
       });
 
       it('when the dividend is larger than the divisor', async function () {
         const a = new BN('7000');
         const b = new BN('5678');
 
-        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+        expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
       });
 
       it('when the dividend is a multiple of the divisor', async function () {
         const a = new BN('17034'); // 17034 == 5678 * 3
         const b = new BN('5678');
 
-        (await this.safeMath.mod(a, b)).should.be.bignumber.equal(a.mod(b));
+        expect(await this.safeMath.mod(a, b)).to.be.bignumber.equal(a.mod(b));
       });
     });
 

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -1,19 +1,20 @@
 const { constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeOwnable (owner, [other]) {
   describe('as an ownable', function () {
     it('should have an owner', async function () {
-      (await this.ownable.owner()).should.equal(owner);
+      expect(await this.ownable.owner()).to.equal(owner);
     });
 
     it('changes owner after transfer', async function () {
-      (await this.ownable.isOwner({ from: other })).should.be.equal(false);
+      expect(await this.ownable.isOwner({ from: other })).to.be.equal(false);
       const { logs } = await this.ownable.transferOwnership(other, { from: owner });
       expectEvent.inLogs(logs, 'OwnershipTransferred');
 
-      (await this.ownable.owner()).should.equal(other);
-      (await this.ownable.isOwner({ from: other })).should.be.equal(true);
+      expect(await this.ownable.owner()).to.equal(other);
+      expect(await this.ownable.isOwner({ from: other })).to.be.equal(true);
     });
 
     it('should prevent non-owners from transferring', async function () {
@@ -34,7 +35,7 @@ function shouldBehaveLikeOwnable (owner, [other]) {
       const { logs } = await this.ownable.renounceOwnership({ from: owner });
       expectEvent.inLogs(logs, 'OwnershipTransferred');
 
-      (await this.ownable.owner()).should.equal(ZERO_ADDRESS);
+      expect(await this.ownable.owner()).to.equal(ZERO_ADDRESS);
     });
 
     it('should prevent non-owners from renouncement', async function () {

--- a/test/ownership/Secondary.test.js
+++ b/test/ownership/Secondary.test.js
@@ -1,4 +1,5 @@
 const { constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const SecondaryMock = artifacts.require('SecondaryMock');
@@ -9,7 +10,7 @@ contract('Secondary', function ([_, primary, newPrimary, other]) {
   });
 
   it('stores the primary\'s address', async function () {
-    (await this.secondary.primary()).should.equal(primary);
+    expect(await this.secondary.primary()).to.equal(primary);
   });
 
   describe('onlyPrimary', function () {
@@ -28,7 +29,7 @@ contract('Secondary', function ([_, primary, newPrimary, other]) {
     it('makes the recipient the new primary', async function () {
       const { logs } = await this.secondary.transferPrimary(newPrimary, { from: primary });
       expectEvent.inLogs(logs, 'PrimaryTransferred', { recipient: newPrimary });
-      (await this.secondary.primary()).should.equal(newPrimary);
+      expect(await this.secondary.primary()).to.equal(newPrimary);
     });
 
     it('reverts when transferring to the null address', async function () {

--- a/test/payment/PaymentSplitter.test.js
+++ b/test/payment/PaymentSplitter.test.js
@@ -1,4 +1,5 @@
 const { balance, constants, ether, expectEvent, send, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const PaymentSplitter = artifacts.require('PaymentSplitter');
@@ -49,28 +50,28 @@ contract('PaymentSplitter', function ([_, owner, payee1, payee2, payee3, nonpaye
     });
 
     it('should have total shares', async function () {
-      (await this.contract.totalShares()).should.be.bignumber.equal('100');
+      expect(await this.contract.totalShares()).to.be.bignumber.equal('100');
     });
 
     it('should have payees', async function () {
       await Promise.all(this.payees.map(async (payee, index) => {
-        (await this.contract.payee(index)).should.be.equal(payee);
-        (await this.contract.released(payee)).should.be.bignumber.equal('0');
+        expect(await this.contract.payee(index)).to.be.equal(payee);
+        expect(await this.contract.released(payee)).to.be.bignumber.equal('0');
       }));
     });
 
     it('should accept payments', async function () {
       await send.ether(owner, this.contract.address, amount);
 
-      (await balance.current(this.contract.address)).should.be.bignumber.equal(amount);
+      expect(await balance.current(this.contract.address)).to.be.bignumber.equal(amount);
     });
 
     it('should store shares if address is payee', async function () {
-      (await this.contract.shares(payee1)).should.be.bignumber.not.equal('0');
+      expect(await this.contract.shares(payee1)).to.be.bignumber.not.equal('0');
     });
 
     it('should not store shares if address is not payee', async function () {
-      (await this.contract.shares(nonpayee1)).should.be.bignumber.equal('0');
+      expect(await this.contract.shares(nonpayee1)).to.be.bignumber.equal('0');
     });
 
     it('should throw if no funds to claim', async function () {
@@ -91,33 +92,33 @@ contract('PaymentSplitter', function ([_, owner, payee1, payee2, payee3, nonpaye
 
       // receive funds
       const initBalance = await balance.current(this.contract.address);
-      initBalance.should.be.bignumber.equal(amount);
+      expect(initBalance).to.be.bignumber.equal(amount);
 
       // distribute to payees
 
       const initAmount1 = await balance.current(payee1);
       const { logs: logs1 } = await this.contract.release(payee1, { gasPrice: 0 });
       const profit1 = (await balance.current(payee1)).sub(initAmount1);
-      profit1.should.be.bignumber.equal(ether('0.20'));
+      expect(profit1).to.be.bignumber.equal(ether('0.20'));
       expectEvent.inLogs(logs1, 'PaymentReleased', { to: payee1, amount: profit1 });
 
       const initAmount2 = await balance.current(payee2);
       const { logs: logs2 } = await this.contract.release(payee2, { gasPrice: 0 });
       const profit2 = (await balance.current(payee2)).sub(initAmount2);
-      profit2.should.be.bignumber.equal(ether('0.10'));
+      expect(profit2).to.be.bignumber.equal(ether('0.10'));
       expectEvent.inLogs(logs2, 'PaymentReleased', { to: payee2, amount: profit2 });
 
       const initAmount3 = await balance.current(payee3);
       const { logs: logs3 } = await this.contract.release(payee3, { gasPrice: 0 });
       const profit3 = (await balance.current(payee3)).sub(initAmount3);
-      profit3.should.be.bignumber.equal(ether('0.70'));
+      expect(profit3).to.be.bignumber.equal(ether('0.70'));
       expectEvent.inLogs(logs3, 'PaymentReleased', { to: payee3, amount: profit3 });
 
       // end balance should be zero
-      (await balance.current(this.contract.address)).should.be.bignumber.equal('0');
+      expect(await balance.current(this.contract.address)).to.be.bignumber.equal('0');
 
       // check correct funds released accounting
-      (await this.contract.totalReleased()).should.be.bignumber.equal(initBalance);
+      expect(await this.contract.totalReleased()).to.be.bignumber.equal(initBalance);
     });
   });
 });

--- a/test/payment/PullPayment.test.js
+++ b/test/payment/PullPayment.test.js
@@ -1,4 +1,5 @@
 const { balance, ether } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const PullPaymentMock = artifacts.require('PullPaymentMock');
 
@@ -11,33 +12,33 @@ contract('PullPayment', function ([_, payer, payee1, payee2]) {
 
   it('can record an async payment correctly', async function () {
     await this.contract.callTransfer(payee1, 100, { from: payer });
-    (await this.contract.payments(payee1)).should.be.bignumber.equal('100');
+    expect(await this.contract.payments(payee1)).to.be.bignumber.equal('100');
   });
 
   it('can add multiple balances on one account', async function () {
     await this.contract.callTransfer(payee1, 200, { from: payer });
     await this.contract.callTransfer(payee1, 300, { from: payer });
-    (await this.contract.payments(payee1)).should.be.bignumber.equal('500');
+    expect(await this.contract.payments(payee1)).to.be.bignumber.equal('500');
   });
 
   it('can add balances on multiple accounts', async function () {
     await this.contract.callTransfer(payee1, 200, { from: payer });
     await this.contract.callTransfer(payee2, 300, { from: payer });
 
-    (await this.contract.payments(payee1)).should.be.bignumber.equal('200');
+    expect(await this.contract.payments(payee1)).to.be.bignumber.equal('200');
 
-    (await this.contract.payments(payee2)).should.be.bignumber.equal('300');
+    expect(await this.contract.payments(payee2)).to.be.bignumber.equal('300');
   });
 
   it('can withdraw payment', async function () {
     const balanceTracker = await balance.tracker(payee1);
 
     await this.contract.callTransfer(payee1, amount, { from: payer });
-    (await this.contract.payments(payee1)).should.be.bignumber.equal(amount);
+    expect(await this.contract.payments(payee1)).to.be.bignumber.equal(amount);
 
     await this.contract.withdrawPayments(payee1);
 
-    (await balanceTracker.delta()).should.be.bignumber.equal(amount);
-    (await this.contract.payments(payee1)).should.be.bignumber.equal('0');
+    expect(await balanceTracker.delta()).to.be.bignumber.equal(amount);
+    expect(await this.contract.payments(payee1)).to.be.bignumber.equal('0');
   });
 });

--- a/test/payment/escrow/Escrow.behavior.js
+++ b/test/payment/escrow/Escrow.behavior.js
@@ -1,4 +1,5 @@
 const { balance, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
   const amount = ether('42');
@@ -8,9 +9,9 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
       it('can accept a single deposit', async function () {
         await this.escrow.deposit(payee1, { from: primary, value: amount });
 
-        (await balance.current(this.escrow.address)).should.be.bignumber.equal(amount);
+        expect(await balance.current(this.escrow.address)).to.be.bignumber.equal(amount);
 
-        (await this.escrow.depositsOf(payee1)).should.be.bignumber.equal(amount);
+        expect(await this.escrow.depositsOf(payee1)).to.be.bignumber.equal(amount);
       });
 
       it('can accept an empty deposit', async function () {
@@ -35,20 +36,20 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
         await this.escrow.deposit(payee1, { from: primary, value: amount });
         await this.escrow.deposit(payee1, { from: primary, value: amount.muln(2) });
 
-        (await balance.current(this.escrow.address)).should.be.bignumber.equal(amount.muln(3));
+        expect(await balance.current(this.escrow.address)).to.be.bignumber.equal(amount.muln(3));
 
-        (await this.escrow.depositsOf(payee1)).should.be.bignumber.equal(amount.muln(3));
+        expect(await this.escrow.depositsOf(payee1)).to.be.bignumber.equal(amount.muln(3));
       });
 
       it('can track deposits to multiple accounts', async function () {
         await this.escrow.deposit(payee1, { from: primary, value: amount });
         await this.escrow.deposit(payee2, { from: primary, value: amount.muln(2) });
 
-        (await balance.current(this.escrow.address)).should.be.bignumber.equal(amount.muln(3));
+        expect(await balance.current(this.escrow.address)).to.be.bignumber.equal(amount.muln(3));
 
-        (await this.escrow.depositsOf(payee1)).should.be.bignumber.equal(amount);
+        expect(await this.escrow.depositsOf(payee1)).to.be.bignumber.equal(amount);
 
-        (await this.escrow.depositsOf(payee2)).should.be.bignumber.equal(amount.muln(2));
+        expect(await this.escrow.depositsOf(payee2)).to.be.bignumber.equal(amount.muln(2));
       });
     });
 
@@ -59,10 +60,10 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
         await this.escrow.deposit(payee1, { from: primary, value: amount });
         await this.escrow.withdraw(payee1, { from: primary });
 
-        (await balanceTracker.delta()).should.be.bignumber.equal(amount);
+        expect(await balanceTracker.delta()).to.be.bignumber.equal(amount);
 
-        (await balance.current(this.escrow.address)).should.be.bignumber.equal('0');
-        (await this.escrow.depositsOf(payee1)).should.be.bignumber.equal('0');
+        expect(await balance.current(this.escrow.address)).to.be.bignumber.equal('0');
+        expect(await this.escrow.depositsOf(payee1)).to.be.bignumber.equal('0');
       });
 
       it('can do an empty withdrawal', async function () {

--- a/test/payment/escrow/RefundEscrow.test.js
+++ b/test/payment/escrow/RefundEscrow.test.js
@@ -1,4 +1,5 @@
 const { balance, constants, ether, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const RefundEscrow = artifacts.require('RefundEscrow');
@@ -20,14 +21,14 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
 
     context('active state', function () {
       it('has beneficiary and state', async function () {
-        (await this.escrow.beneficiary()).should.be.equal(beneficiary);
-        (await this.escrow.state()).should.be.bignumber.equal('0');
+        expect(await this.escrow.beneficiary()).to.be.equal(beneficiary);
+        expect(await this.escrow.state()).to.be.bignumber.equal('0');
       });
 
       it('accepts deposits', async function () {
         await this.escrow.deposit(refundee1, { from: primary, value: amount });
 
-        (await this.escrow.depositsOf(refundee1)).should.be.bignumber.equal(amount);
+        expect(await this.escrow.depositsOf(refundee1)).to.be.bignumber.equal(amount);
       });
 
       it('does not refund refundees', async function () {
@@ -76,7 +77,7 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
       it('allows beneficiary withdrawal', async function () {
         const balanceTracker = await balance.tracker(beneficiary);
         await this.escrow.beneficiaryWithdraw();
-        (await balanceTracker.delta()).should.be.bignumber.equal(amount.muln(refundees.length));
+        expect(await balanceTracker.delta()).to.be.bignumber.equal(amount.muln(refundees.length));
       });
 
       it('prevents entering the refund state', async function () {
@@ -118,7 +119,7 @@ contract('RefundEscrow', function ([_, primary, beneficiary, refundee1, refundee
         for (const refundee of [refundee1, refundee2]) {
           const balanceTracker = await balance.tracker(refundee);
           await this.escrow.withdraw(refundee, { from: primary });
-          (await balanceTracker.delta()).should.be.bignumber.equal(amount);
+          expect(await balanceTracker.delta()).to.be.bignumber.equal(amount);
         }
       });
 

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -1,23 +1,24 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recipient, anotherAccount) {
   describe('total supply', function () {
     it('returns the total amount of tokens', async function () {
-      (await this.token.totalSupply()).should.be.bignumber.equal(initialSupply);
+      expect(await this.token.totalSupply()).to.be.bignumber.equal(initialSupply);
     });
   });
 
   describe('balanceOf', function () {
     describe('when the requested account has no tokens', function () {
       it('returns zero', async function () {
-        (await this.token.balanceOf(anotherAccount)).should.be.bignumber.equal('0');
+        expect(await this.token.balanceOf(anotherAccount)).to.be.bignumber.equal('0');
       });
     });
 
     describe('when the requested account has some tokens', function () {
       it('returns the total amount of tokens', async function () {
-        (await this.token.balanceOf(initialHolder)).should.be.bignumber.equal(initialSupply);
+        expect(await this.token.balanceOf(initialHolder)).to.be.bignumber.equal(initialSupply);
       });
     });
   });
@@ -50,15 +51,15 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
             it('transfers the requested amount', async function () {
               await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
 
-              (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
+              expect(await this.token.balanceOf(tokenOwner)).to.be.bignumber.equal('0');
 
-              (await this.token.balanceOf(to)).should.be.bignumber.equal(amount);
+              expect(await this.token.balanceOf(to)).to.be.bignumber.equal(amount);
             });
 
             it('decreases the spender allowance', async function () {
               await this.token.transferFrom(tokenOwner, to, amount, { from: spender });
 
-              (await this.token.allowance(tokenOwner, spender)).should.be.bignumber.equal('0');
+              expect(await this.token.allowance(tokenOwner, spender)).to.be.bignumber.equal('0');
             });
 
             it('emits a transfer event', async function () {
@@ -176,9 +177,9 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
       it('transfers the requested amount', async function () {
         await transfer.call(this, from, to, amount);
 
-        (await this.token.balanceOf(from)).should.be.bignumber.equal('0');
+        expect(await this.token.balanceOf(from)).to.be.bignumber.equal('0');
 
-        (await this.token.balanceOf(to)).should.be.bignumber.equal(amount);
+        expect(await this.token.balanceOf(to)).to.be.bignumber.equal(amount);
       });
 
       it('emits a transfer event', async function () {
@@ -198,9 +199,9 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
       it('transfers the requested amount', async function () {
         await transfer.call(this, from, to, amount);
 
-        (await this.token.balanceOf(from)).should.be.bignumber.equal(balance);
+        expect(await this.token.balanceOf(from)).to.be.bignumber.equal(balance);
 
-        (await this.token.balanceOf(to)).should.be.bignumber.equal('0');
+        expect(await this.token.balanceOf(to)).to.be.bignumber.equal('0');
       });
 
       it('emits a transfer event', async function () {
@@ -243,7 +244,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
         it('approves the requested amount', async function () {
           await approve.call(this, owner, spender, amount);
 
-          (await this.token.allowance(owner, spender)).should.be.bignumber.equal(amount);
+          expect(await this.token.allowance(owner, spender)).to.be.bignumber.equal(amount);
         });
       });
 
@@ -255,7 +256,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
         it('approves the requested amount and replaces the previous one', async function () {
           await approve.call(this, owner, spender, amount);
 
-          (await this.token.allowance(owner, spender)).should.be.bignumber.equal(amount);
+          expect(await this.token.allowance(owner, spender)).to.be.bignumber.equal(amount);
         });
       });
     });
@@ -277,7 +278,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
         it('approves the requested amount', async function () {
           await approve.call(this, owner, spender, amount);
 
-          (await this.token.allowance(owner, spender)).should.be.bignumber.equal(amount);
+          expect(await this.token.allowance(owner, spender)).to.be.bignumber.equal(amount);
         });
       });
 
@@ -289,7 +290,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
         it('approves the requested amount and replaces the previous one', async function () {
           await approve.call(this, owner, spender, amount);
 
-          (await this.token.allowance(owner, spender)).should.be.bignumber.equal(amount);
+          expect(await this.token.allowance(owner, spender)).to.be.bignumber.equal(amount);
         });
       });
     });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const {
@@ -51,12 +52,12 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           it('decreases the spender allowance subtracting the requested amount', async function () {
             await this.token.decreaseAllowance(spender, approvedAmount.subn(1), { from: initialHolder });
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal('1');
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal('1');
           });
 
           it('sets the allowance to zero when all allowance is removed', async function () {
             await this.token.decreaseAllowance(spender, approvedAmount, { from: initialHolder });
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal('0');
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal('0');
           });
 
           it('reverts when more than the full allowance is removed', async function () {
@@ -114,7 +115,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           it('approves the requested amount', async function () {
             await this.token.increaseAllowance(spender, amount, { from: initialHolder });
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal(amount);
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal(amount);
           });
         });
 
@@ -126,7 +127,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           it('increases the spender allowance adding the requested amount', async function () {
             await this.token.increaseAllowance(spender, amount, { from: initialHolder });
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal(amount.addn(1));
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal(amount.addn(1));
           });
         });
       });
@@ -148,7 +149,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           it('approves the requested amount', async function () {
             await this.token.increaseAllowance(spender, amount, { from: initialHolder });
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal(amount);
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal(amount);
           });
         });
 
@@ -160,7 +161,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           it('increases the spender allowance adding the requested amount', async function () {
             await this.token.increaseAllowance(spender, amount, { from: initialHolder });
 
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal(amount.addn(1));
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal(amount.addn(1));
           });
         });
       });
@@ -193,11 +194,11 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
       it('increments totalSupply', async function () {
         const expectedSupply = initialSupply.add(amount);
-        (await this.token.totalSupply()).should.be.bignumber.equal(expectedSupply);
+        expect(await this.token.totalSupply()).to.be.bignumber.equal(expectedSupply);
       });
 
       it('increments recipient balance', async function () {
-        (await this.token.balanceOf(recipient)).should.be.bignumber.equal(amount);
+        expect(await this.token.balanceOf(recipient)).to.be.bignumber.equal(amount);
       });
 
       it('emits Transfer event', async function () {
@@ -206,7 +207,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
           to: recipient,
         });
 
-        event.args.value.should.be.bignumber.equal(amount);
+        expect(event.args.value).to.be.bignumber.equal(amount);
       });
     });
   });
@@ -233,12 +234,12 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
           it('decrements totalSupply', async function () {
             const expectedSupply = initialSupply.sub(amount);
-            (await this.token.totalSupply()).should.be.bignumber.equal(expectedSupply);
+            expect(await this.token.totalSupply()).to.be.bignumber.equal(expectedSupply);
           });
 
           it('decrements initialHolder balance', async function () {
             const expectedBalance = initialSupply.sub(amount);
-            (await this.token.balanceOf(initialHolder)).should.be.bignumber.equal(expectedBalance);
+            expect(await this.token.balanceOf(initialHolder)).to.be.bignumber.equal(expectedBalance);
           });
 
           it('emits Transfer event', async function () {
@@ -247,7 +248,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
               to: ZERO_ADDRESS,
             });
 
-            event.args.value.should.be.bignumber.equal(amount);
+            expect(event.args.value).to.be.bignumber.equal(amount);
           });
         });
       };
@@ -294,17 +295,17 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
 
           it('decrements totalSupply', async function () {
             const expectedSupply = initialSupply.sub(amount);
-            (await this.token.totalSupply()).should.be.bignumber.equal(expectedSupply);
+            expect(await this.token.totalSupply()).to.be.bignumber.equal(expectedSupply);
           });
 
           it('decrements initialHolder balance', async function () {
             const expectedBalance = initialSupply.sub(amount);
-            (await this.token.balanceOf(initialHolder)).should.be.bignumber.equal(expectedBalance);
+            expect(await this.token.balanceOf(initialHolder)).to.be.bignumber.equal(expectedBalance);
           });
 
           it('decrements spender allowance', async function () {
             const expectedAllowance = allowance.sub(amount);
-            (await this.token.allowance(initialHolder, spender)).should.be.bignumber.equal(expectedAllowance);
+            expect(await this.token.allowance(initialHolder, spender)).to.be.bignumber.equal(expectedAllowance);
           });
 
           it('emits a Transfer event', async function () {
@@ -313,7 +314,7 @@ contract('ERC20', function ([_, initialHolder, recipient, anotherAccount]) {
               to: ZERO_ADDRESS,
             });
 
-            event.args.value.should.be.bignumber.equal(amount);
+            expect(event.args.value).to.be.bignumber.equal(amount);
           });
 
           it('emits an Approval event', async function () {

--- a/test/token/ERC20/ERC20Detailed.test.js
+++ b/test/token/ERC20/ERC20Detailed.test.js
@@ -1,4 +1,5 @@
 const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ERC20DetailedMock = artifacts.require('ERC20DetailedMock');
 
@@ -12,14 +13,14 @@ contract('ERC20Detailed', function () {
   });
 
   it('has a name', async function () {
-    (await this.detailedERC20.name()).should.be.equal(_name);
+    expect(await this.detailedERC20.name()).to.be.equal(_name);
   });
 
   it('has a symbol', async function () {
-    (await this.detailedERC20.symbol()).should.be.equal(_symbol);
+    expect(await this.detailedERC20.symbol()).to.be.equal(_symbol);
   });
 
   it('has an amount of decimals', async function () {
-    (await this.detailedERC20.decimals()).should.be.bignumber.equal(_decimals);
+    expect(await this.detailedERC20.decimals()).to.be.bignumber.equal(_decimals);
   });
 });

--- a/test/token/ERC20/ERC20Pausable.test.js
+++ b/test/token/ERC20/ERC20Pausable.test.js
@@ -1,4 +1,5 @@
 const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ERC20PausableMock = artifacts.require('ERC20PausableMock');
 const { shouldBehaveLikePublicRole } = require('../../behaviors/access/roles/PublicRole.behavior');
@@ -26,7 +27,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       describe('when the token is unpaused', function () {
         it('pauses the token', async function () {
           await this.token.pause({ from });
-          (await this.token.paused()).should.equal(true);
+          expect(await this.token.paused()).to.equal(true);
         });
 
         it('emits a Pause event', async function () {
@@ -69,7 +70,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         it('unpauses the token', async function () {
           await this.token.unpause({ from });
-          (await this.token.paused()).should.equal(false);
+          expect(await this.token.paused()).to.equal(false);
         });
 
         it('emits an Unpause event', async function () {
@@ -102,18 +103,18 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
     describe('paused', function () {
       it('is not paused by default', async function () {
-        (await this.token.paused({ from })).should.equal(false);
+        expect(await this.token.paused({ from })).to.equal(false);
       });
 
       it('is paused after being paused', async function () {
         await this.token.pause({ from });
-        (await this.token.paused({ from })).should.equal(true);
+        expect(await this.token.paused({ from })).to.equal(true);
       });
 
       it('is not paused after being paused and then unpaused', async function () {
         await this.token.pause({ from });
         await this.token.unpause({ from });
-        (await this.token.paused()).should.equal(false);
+        expect(await this.token.paused()).to.equal(false);
       });
     });
 
@@ -121,8 +122,8 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('allows to transfer when unpaused', async function () {
         await this.token.transfer(recipient, initialSupply, { from: pauser });
 
-        (await this.token.balanceOf(pauser)).should.be.bignumber.equal('0');
-        (await this.token.balanceOf(recipient)).should.be.bignumber.equal(initialSupply);
+        expect(await this.token.balanceOf(pauser)).to.be.bignumber.equal('0');
+        expect(await this.token.balanceOf(recipient)).to.be.bignumber.equal(initialSupply);
       });
 
       it('allows to transfer when paused and then unpaused', async function () {
@@ -131,8 +132,8 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         await this.token.transfer(recipient, initialSupply, { from: pauser });
 
-        (await this.token.balanceOf(pauser)).should.be.bignumber.equal('0');
-        (await this.token.balanceOf(recipient)).should.be.bignumber.equal(initialSupply);
+        expect(await this.token.balanceOf(pauser)).to.be.bignumber.equal('0');
+        expect(await this.token.balanceOf(recipient)).to.be.bignumber.equal(initialSupply);
       });
 
       it('reverts when trying to transfer when paused', async function () {
@@ -150,7 +151,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('allows to approve when unpaused', async function () {
         await this.token.approve(anotherAccount, allowance, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance);
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance);
       });
 
       it('allows to approve when paused and then unpaused', async function () {
@@ -159,7 +160,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         await this.token.approve(anotherAccount, allowance, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance);
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance);
       });
 
       it('reverts when trying to approve when paused', async function () {
@@ -181,8 +182,8 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('allows to transfer from when unpaused', async function () {
         await this.token.transferFrom(pauser, recipient, allowance, { from: anotherAccount });
 
-        (await this.token.balanceOf(recipient)).should.be.bignumber.equal(allowance);
-        (await this.token.balanceOf(pauser)).should.be.bignumber.equal(initialSupply.sub(allowance));
+        expect(await this.token.balanceOf(recipient)).to.be.bignumber.equal(allowance);
+        expect(await this.token.balanceOf(pauser)).to.be.bignumber.equal(initialSupply.sub(allowance));
       });
 
       it('allows to transfer when paused and then unpaused', async function () {
@@ -191,8 +192,8 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         await this.token.transferFrom(pauser, recipient, allowance, { from: anotherAccount });
 
-        (await this.token.balanceOf(recipient)).should.be.bignumber.equal(allowance);
-        (await this.token.balanceOf(pauser)).should.be.bignumber.equal(initialSupply.sub(allowance));
+        expect(await this.token.balanceOf(recipient)).to.be.bignumber.equal(allowance);
+        expect(await this.token.balanceOf(pauser)).to.be.bignumber.equal(initialSupply.sub(allowance));
       });
 
       it('reverts when trying to transfer from when paused', async function () {
@@ -215,7 +216,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('allows to decrease approval when unpaused', async function () {
         await this.token.decreaseAllowance(anotherAccount, decrement, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance.sub(decrement));
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance.sub(decrement));
       });
 
       it('allows to decrease approval when paused and then unpaused', async function () {
@@ -224,7 +225,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         await this.token.decreaseAllowance(anotherAccount, decrement, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance.sub(decrement));
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance.sub(decrement));
       });
 
       it('reverts when trying to transfer when paused', async function () {
@@ -247,7 +248,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
       it('allows to increase approval when unpaused', async function () {
         await this.token.increaseAllowance(anotherAccount, increment, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance.add(increment));
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance.add(increment));
       });
 
       it('allows to increase approval when paused and then unpaused', async function () {
@@ -256,7 +257,7 @@ contract('ERC20Pausable', function ([_, pauser, otherPauser, recipient, anotherA
 
         await this.token.increaseAllowance(anotherAccount, increment, { from: pauser });
 
-        (await this.token.allowance(pauser, anotherAccount)).should.be.bignumber.equal(allowance.add(increment));
+        expect(await this.token.allowance(pauser, anotherAccount)).to.be.bignumber.equal(allowance.add(increment));
       });
 
       it('reverts when trying to increase approval when paused', async function () {

--- a/test/token/ERC20/TokenTimelock.test.js
+++ b/test/token/ERC20/TokenTimelock.test.js
@@ -1,4 +1,5 @@
 const { BN, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ERC20Mintable = artifacts.require('ERC20Mintable');
 const TokenTimelock = artifacts.require('TokenTimelock');
@@ -27,9 +28,9 @@ contract('TokenTimelock', function ([_, minter, beneficiary]) {
       });
 
       it('can get state', async function () {
-        (await this.timelock.token()).should.be.equal(this.token.address);
-        (await this.timelock.beneficiary()).should.be.equal(beneficiary);
-        (await this.timelock.releaseTime()).should.be.bignumber.equal(this.releaseTime);
+        expect(await this.timelock.token()).to.be.equal(this.token.address);
+        expect(await this.timelock.beneficiary()).to.be.equal(beneficiary);
+        expect(await this.timelock.releaseTime()).to.be.bignumber.equal(this.releaseTime);
       });
 
       it('cannot be released before time limit', async function () {
@@ -44,20 +45,20 @@ contract('TokenTimelock', function ([_, minter, beneficiary]) {
       it('can be released just after limit', async function () {
         await time.increaseTo(this.releaseTime.add(time.duration.seconds(1)));
         await this.timelock.release();
-        (await this.token.balanceOf(beneficiary)).should.be.bignumber.equal(amount);
+        expect(await this.token.balanceOf(beneficiary)).to.be.bignumber.equal(amount);
       });
 
       it('can be released after time limit', async function () {
         await time.increaseTo(this.releaseTime.add(time.duration.years(1)));
         await this.timelock.release();
-        (await this.token.balanceOf(beneficiary)).should.be.bignumber.equal(amount);
+        expect(await this.token.balanceOf(beneficiary)).to.be.bignumber.equal(amount);
       });
 
       it('cannot be released twice', async function () {
         await time.increaseTo(this.releaseTime.add(time.duration.years(1)));
         await this.timelock.release();
         await expectRevert(this.timelock.release(), 'TokenTimelock: no tokens to release');
-        (await this.token.balanceOf(beneficiary)).should.be.bignumber.equal(amount);
+        expect(await this.token.balanceOf(beneficiary)).to.be.bignumber.equal(amount);
       });
     });
   });

--- a/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
@@ -18,7 +19,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
         });
 
         it('burns the requested amount', async function () {
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal(initialBalance.sub(amount));
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal(initialBalance.sub(amount));
         });
 
         it('emits a transfer event', async function () {
@@ -62,11 +63,11 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
         });
 
         it('burns the requested amount', async function () {
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal(initialBalance.sub(amount));
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal(initialBalance.sub(amount));
         });
 
         it('decrements allowance', async function () {
-          (await this.token.allowance(owner, burner)).should.be.bignumber.equal(originalAllowance.sub(amount));
+          expect(await this.token.allowance(owner, burner)).to.be.bignumber.equal(originalAllowance.sub(amount));
         });
 
         it('emits a transfer event', async function () {

--- a/test/token/ERC20/behaviors/ERC20Capped.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Capped.behavior.js
@@ -1,16 +1,17 @@
 const { expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 function shouldBehaveLikeERC20Capped (minter, [other], cap) {
   describe('capped token', function () {
     const from = minter;
 
     it('should start with the correct cap', async function () {
-      (await this.token.cap()).should.be.bignumber.equal(cap);
+      expect(await this.token.cap()).to.be.bignumber.equal(cap);
     });
 
     it('should mint when amount is less than cap', async function () {
       await this.token.mint(other, cap.subn(1), { from });
-      (await this.token.totalSupply()).should.be.bignumber.equal(cap.subn(1));
+      expect(await this.token.totalSupply()).to.be.bignumber.equal(cap.subn(1));
     });
 
     it('should fail to mint if the amount exceeds the cap', async function () {

--- a/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC20Mintable (minter, [other]) {
@@ -23,7 +24,7 @@ function shouldBehaveLikeERC20Mintable (minter, [other]) {
           });
 
           it('mints the requested amount', async function () {
-            (await this.token.balanceOf(other)).should.be.bignumber.equal(amount);
+            expect(await this.token.balanceOf(other)).to.be.bignumber.equal(amount);
           });
 
           it('emits a mint and a transfer event', async function () {

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
 
@@ -24,13 +25,13 @@ function shouldBehaveLikeERC721 (
     describe('balanceOf', function () {
       context('when the given address owns some tokens', function () {
         it('returns the amount of tokens owned by the given address', async function () {
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal('2');
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('2');
         });
       });
 
       context('when the given address does not own any tokens', function () {
         it('returns 0', async function () {
-          (await this.token.balanceOf(other)).should.be.bignumber.equal('0');
+          expect(await this.token.balanceOf(other)).to.be.bignumber.equal('0');
         });
       });
 
@@ -48,7 +49,7 @@ function shouldBehaveLikeERC721 (
         const tokenId = firstTokenId;
 
         it('returns the owner of the given token ID', async function () {
-          (await this.token.ownerOf(tokenId)).should.be.equal(owner);
+          expect(await this.token.ownerOf(tokenId)).to.be.equal(owner);
         });
       });
 
@@ -76,11 +77,11 @@ function shouldBehaveLikeERC721 (
 
       const transferWasSuccessful = function ({ owner, tokenId, approved }) {
         it('transfers the ownership of the given token ID to the given address', async function () {
-          (await this.token.ownerOf(tokenId)).should.be.equal(this.toWhom);
+          expect(await this.token.ownerOf(tokenId)).to.be.equal(this.toWhom);
         });
 
         it('clears the approval for the token ID', async function () {
-          (await this.token.getApproved(tokenId)).should.be.equal(ZERO_ADDRESS);
+          expect(await this.token.getApproved(tokenId)).to.be.equal(ZERO_ADDRESS);
         });
 
         if (approved) {
@@ -102,15 +103,15 @@ function shouldBehaveLikeERC721 (
         }
 
         it('adjusts owners balances', async function () {
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal('1');
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
         });
 
         it('adjusts owners tokens by index', async function () {
           if (!this.token.tokenOfOwnerByIndex) return;
 
-          (await this.token.tokenOfOwnerByIndex(this.toWhom, 0)).should.be.bignumber.equal(tokenId);
+          expect(await this.token.tokenOfOwnerByIndex(this.toWhom, 0)).to.be.bignumber.equal(tokenId);
 
-          (await this.token.tokenOfOwnerByIndex(owner, 0)).should.be.bignumber.not.equal(tokenId);
+          expect(await this.token.tokenOfOwnerByIndex(owner, 0)).to.be.bignumber.not.equal(tokenId);
         });
       };
 
@@ -150,11 +151,11 @@ function shouldBehaveLikeERC721 (
           });
 
           it('keeps ownership of the token', async function () {
-            (await this.token.ownerOf(tokenId)).should.be.equal(owner);
+            expect(await this.token.ownerOf(tokenId)).to.be.equal(owner);
           });
 
           it('clears the approval for the token ID', async function () {
-            (await this.token.getApproved(tokenId)).should.be.equal(ZERO_ADDRESS);
+            expect(await this.token.getApproved(tokenId)).to.be.equal(ZERO_ADDRESS);
           });
 
           it('emits only a transfer event', async function () {
@@ -166,7 +167,7 @@ function shouldBehaveLikeERC721 (
           });
 
           it('keeps the owner balance', async function () {
-            (await this.token.balanceOf(owner)).should.be.bignumber.equal('2');
+            expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('2');
           });
 
           it('keeps same tokens by index', async function () {
@@ -174,7 +175,7 @@ function shouldBehaveLikeERC721 (
             const tokensListed = await Promise.all(
               [0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i))
             );
-            tokensListed.map(t => t.toNumber()).should.have.members(
+            expect(tokensListed.map(t => t.toNumber())).to.have.members(
               [firstTokenId.toNumber(), secondTokenId.toNumber()]
             );
           });
@@ -330,13 +331,13 @@ function shouldBehaveLikeERC721 (
 
       const itClearsApproval = function () {
         it('clears approval for the token', async function () {
-          (await this.token.getApproved(tokenId)).should.be.equal(ZERO_ADDRESS);
+          expect(await this.token.getApproved(tokenId)).to.be.equal(ZERO_ADDRESS);
         });
       };
 
       const itApproves = function (address) {
         it('sets the approval for the target address', async function () {
-          (await this.token.getApproved(tokenId)).should.be.equal(address);
+          expect(await this.token.getApproved(tokenId)).to.be.equal(address);
         });
       };
 
@@ -449,7 +450,7 @@ function shouldBehaveLikeERC721 (
           it('approves the operator', async function () {
             await this.token.setApprovalForAll(operator, true, { from: owner });
 
-            (await this.token.isApprovedForAll(owner, operator)).should.equal(true);
+            expect(await this.token.isApprovedForAll(owner, operator)).to.equal(true);
           });
 
           it('emits an approval event', async function () {
@@ -471,7 +472,7 @@ function shouldBehaveLikeERC721 (
           it('approves the operator', async function () {
             await this.token.setApprovalForAll(operator, true, { from: owner });
 
-            (await this.token.isApprovedForAll(owner, operator)).should.equal(true);
+            expect(await this.token.isApprovedForAll(owner, operator)).to.equal(true);
           });
 
           it('emits an approval event', async function () {
@@ -487,7 +488,7 @@ function shouldBehaveLikeERC721 (
           it('can unset the operator approval', async function () {
             await this.token.setApprovalForAll(operator, false, { from: owner });
 
-            (await this.token.isApprovedForAll(owner, operator)).should.equal(false);
+            expect(await this.token.isApprovedForAll(owner, operator)).to.equal(false);
           });
         });
 
@@ -499,7 +500,7 @@ function shouldBehaveLikeERC721 (
           it('keeps the approval to the given address', async function () {
             await this.token.setApprovalForAll(operator, true, { from: owner });
 
-            (await this.token.isApprovedForAll(owner, operator)).should.equal(true);
+            expect(await this.token.isApprovedForAll(owner, operator)).to.equal(true);
           });
 
           it('emits an approval event', async function () {

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
@@ -31,8 +32,8 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
         });
 
         it('creates the token', async function () {
-          (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('1');
-          (await this.token.ownerOf(tokenId)).should.equal(tokenOwner);
+          expect(await this.token.balanceOf(tokenOwner)).to.be.bignumber.equal('1');
+          expect(await this.token.ownerOf(tokenId)).to.equal(tokenOwner);
         });
 
         it('reverts when adding a token id that already exists', async function () {
@@ -69,7 +70,7 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
           });
 
           it('deletes the token', async function () {
-            (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
+            expect(await this.token.balanceOf(tokenOwner)).to.be.bignumber.equal('0');
             await expectRevert(
               this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
             );
@@ -107,7 +108,7 @@ contract('ERC721', function ([_, creator, tokenOwner, other, ...accounts]) {
           });
 
           it('deletes the token', async function () {
-            (await this.token.balanceOf(tokenOwner)).should.be.bignumber.equal('0');
+            expect(await this.token.balanceOf(tokenOwner)).to.be.bignumber.equal('0');
             await expectRevert(
               this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
             );

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -1,4 +1,5 @@
 const { BN, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const { shouldBehaveLikeERC721 } = require('./ERC721.behavior');
 const { shouldSupportInterfaces } = require('../../introspection/SupportsInterface.behavior');
@@ -40,11 +41,11 @@ contract('ERC721Full', function ([
       });
 
       it('adjusts owner tokens by index', async function () {
-        (await this.token.tokenOfOwnerByIndex(newOwner, 0)).should.be.bignumber.equal(thirdTokenId);
+        expect(await this.token.tokenOfOwnerByIndex(newOwner, 0)).to.be.bignumber.equal(thirdTokenId);
       });
 
       it('adjusts all tokens list', async function () {
-        (await this.token.tokenByIndex(2)).should.be.bignumber.equal(thirdTokenId);
+        expect(await this.token.tokenByIndex(2)).to.be.bignumber.equal(thirdTokenId);
       });
     });
 
@@ -54,16 +55,16 @@ contract('ERC721Full', function ([
       });
 
       it('removes that token from the token list of the owner', async function () {
-        (await this.token.tokenOfOwnerByIndex(owner, 0)).should.be.bignumber.equal(secondTokenId);
+        expect(await this.token.tokenOfOwnerByIndex(owner, 0)).to.be.bignumber.equal(secondTokenId);
       });
 
       it('adjusts all tokens list', async function () {
-        (await this.token.tokenByIndex(0)).should.be.bignumber.equal(secondTokenId);
+        expect(await this.token.tokenByIndex(0)).to.be.bignumber.equal(secondTokenId);
       });
 
       it('burns all tokens', async function () {
         await this.token.burn(secondTokenId, { from: owner });
-        (await this.token.totalSupply()).should.be.bignumber.equal('0');
+        expect(await this.token.totalSupply()).to.be.bignumber.equal('0');
         await expectRevert(
           this.token.tokenByIndex(0), 'ERC721Enumerable: global index out of bounds'
         );
@@ -74,16 +75,16 @@ contract('ERC721Full', function ([
       const sampleUri = 'mock://mytoken';
 
       it('has a name', async function () {
-        (await this.token.name()).should.be.equal(name);
+        expect(await this.token.name()).to.be.equal(name);
       });
 
       it('has a symbol', async function () {
-        (await this.token.symbol()).should.be.equal(symbol);
+        expect(await this.token.symbol()).to.be.equal(symbol);
       });
 
       it('sets and returns metadata for a token id', async function () {
         await this.token.setTokenURI(firstTokenId, sampleUri);
-        (await this.token.tokenURI(firstTokenId)).should.be.equal(sampleUri);
+        expect(await this.token.tokenURI(firstTokenId)).to.be.equal(sampleUri);
       });
 
       it('reverts when setting metadata for non existent token id', async function () {
@@ -95,11 +96,11 @@ contract('ERC721Full', function ([
       it('can burn token with metadata', async function () {
         await this.token.setTokenURI(firstTokenId, sampleUri);
         await this.token.burn(firstTokenId, { from: owner });
-        (await this.token.exists(firstTokenId)).should.equal(false);
+        expect(await this.token.exists(firstTokenId)).to.equal(false);
       });
 
       it('returns empty metadata for token', async function () {
-        (await this.token.tokenURI(firstTokenId)).should.be.equal('');
+        expect(await this.token.tokenURI(firstTokenId)).to.be.equal('');
       });
 
       it('reverts when querying metadata for non existent token id', async function () {
@@ -112,22 +113,22 @@ contract('ERC721Full', function ([
     describe('tokensOfOwner', function () {
       it('returns total tokens of owner', async function () {
         const tokenIds = await this.token.tokensOfOwner(owner);
-        tokenIds.length.should.equal(2);
-        tokenIds[0].should.be.bignumber.equal(firstTokenId);
-        tokenIds[1].should.be.bignumber.equal(secondTokenId);
+        expect(tokenIds.length).to.equal(2);
+        expect(tokenIds[0]).to.be.bignumber.equal(firstTokenId);
+        expect(tokenIds[1]).to.be.bignumber.equal(secondTokenId);
       });
     });
 
     describe('totalSupply', function () {
       it('returns total token supply', async function () {
-        (await this.token.totalSupply()).should.be.bignumber.equal('2');
+        expect(await this.token.totalSupply()).to.be.bignumber.equal('2');
       });
     });
 
     describe('tokenOfOwnerByIndex', function () {
       describe('when the given index is lower than the amount of tokens owned by the given address', function () {
         it('returns the token ID placed at the given index', async function () {
-          (await this.token.tokenOfOwnerByIndex(owner, 0)).should.be.bignumber.equal(firstTokenId);
+          expect(await this.token.tokenOfOwnerByIndex(owner, 0)).to.be.bignumber.equal(firstTokenId);
         });
       });
 
@@ -154,15 +155,16 @@ contract('ERC721Full', function ([
         });
 
         it('returns correct token IDs for target', async function () {
-          (await this.token.balanceOf(another)).should.be.bignumber.equal('2');
+          expect(await this.token.balanceOf(another)).to.be.bignumber.equal('2');
           const tokensListed = await Promise.all(
             [0, 1].map(i => this.token.tokenOfOwnerByIndex(another, i))
           );
-          tokensListed.map(t => t.toNumber()).should.have.members([firstTokenId.toNumber(), secondTokenId.toNumber()]);
+          expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
+            secondTokenId.toNumber()]);
         });
 
         it('returns empty collection for original owner', async function () {
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal('0');
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('0');
           await expectRevert(
             this.token.tokenOfOwnerByIndex(owner, 0), 'ERC721Enumerable: owner index out of bounds'
           );
@@ -175,7 +177,8 @@ contract('ERC721Full', function ([
         const tokensListed = await Promise.all(
           [0, 1].map(i => this.token.tokenByIndex(i))
         );
-        tokensListed.map(t => t.toNumber()).should.have.members([firstTokenId.toNumber(), secondTokenId.toNumber()]);
+        expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
+          secondTokenId.toNumber()]);
       });
 
       it('should revert if index is greater than supply', async function () {
@@ -193,7 +196,7 @@ contract('ERC721Full', function ([
           await this.token.mint(newOwner, newTokenId, { from: minter });
           await this.token.mint(newOwner, anotherNewTokenId, { from: minter });
 
-          (await this.token.totalSupply()).should.be.bignumber.equal('3');
+          expect(await this.token.totalSupply()).to.be.bignumber.equal('3');
 
           const tokensListed = await Promise.all(
             [0, 1, 2].map(i => this.token.tokenByIndex(i))
@@ -201,7 +204,7 @@ contract('ERC721Full', function ([
           const expectedTokens = [firstTokenId, secondTokenId, newTokenId, anotherNewTokenId].filter(
             x => (x !== tokenId)
           );
-          tokensListed.map(t => t.toNumber()).should.have.members(expectedTokens.map(t => t.toNumber()));
+          expect(tokensListed.map(t => t.toNumber())).to.have.members(expectedTokens.map(t => t.toNumber()));
         });
       });
     });

--- a/test/token/ERC721/ERC721Holder.test.js
+++ b/test/token/ERC721/ERC721Holder.test.js
@@ -1,4 +1,5 @@
 const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ERC721Holder = artifacts.require('ERC721Holder.sol');
 const ERC721Mintable = artifacts.require('ERC721MintableBurnableImpl.sol');
@@ -13,6 +14,6 @@ contract('ERC721Holder', function ([creator]) {
     await token.approve(receiver.address, tokenId, { from: creator });
     await token.safeTransferFrom(creator, receiver.address, tokenId);
 
-    (await token.ownerOf(tokenId)).should.be.equal(receiver.address);
+    expect(await token.ownerOf(tokenId)).to.be.equal(receiver.address);
   });
 });

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeMintAndBurnERC721 (
@@ -28,11 +29,11 @@ function shouldBehaveLikeMintAndBurnERC721 (
         });
 
         it('assigns the token to the new owner', async function () {
-          (await this.token.ownerOf(thirdTokenId)).should.be.equal(newOwner);
+          expect(await this.token.ownerOf(thirdTokenId)).to.be.equal(newOwner);
         });
 
         it('increases the balance of its owner', async function () {
-          (await this.token.balanceOf(newOwner)).should.be.bignumber.equal('1');
+          expect(await this.token.balanceOf(newOwner)).to.be.bignumber.equal('1');
         });
 
         it('emits a transfer and minted event', async function () {
@@ -85,7 +86,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
             this.token.ownerOf(tokenId),
             'ERC721: owner query for nonexistent token'
           );
-          (await this.token.balanceOf(owner)).should.be.bignumber.equal('1');
+          expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
         });
 
         it('emits a burn event', async function () {

--- a/test/token/ERC721/ERC721PausedToken.behavior.js
+++ b/test/token/ERC721/ERC721PausedToken.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 function shouldBehaveLikeERC721PausedToken (owner, [recipient, operator]) {
@@ -46,33 +47,33 @@ function shouldBehaveLikeERC721PausedToken (owner, [recipient, operator]) {
     describe('getApproved', function () {
       it('returns approved address', async function () {
         const approvedAccount = await this.token.getApproved(firstTokenId);
-        approvedAccount.should.be.equal(ZERO_ADDRESS);
+        expect(approvedAccount).to.be.equal(ZERO_ADDRESS);
       });
     });
 
     describe('balanceOf', function () {
       it('returns the amount of tokens owned by the given address', async function () {
         const balance = await this.token.balanceOf(owner);
-        balance.should.be.bignumber.equal(mintedTokens);
+        expect(balance).to.be.bignumber.equal(mintedTokens);
       });
     });
 
     describe('ownerOf', function () {
       it('returns the amount of tokens owned by the given address', async function () {
         const ownerOfToken = await this.token.ownerOf(firstTokenId);
-        ownerOfToken.should.be.equal(owner);
+        expect(ownerOfToken).to.be.equal(owner);
       });
     });
 
     describe('exists', function () {
       it('should return token existence', async function () {
-        (await this.token.exists(firstTokenId)).should.equal(true);
+        expect(await this.token.exists(firstTokenId)).to.equal(true);
       });
     });
 
     describe('isApprovedForAll', function () {
       it('returns the approval of the operator', async function () {
-        (await this.token.isApprovedForAll(owner, operator)).should.equal(false);
+        expect(await this.token.isApprovedForAll(owner, operator)).to.equal(false);
       });
     });
   });

--- a/test/token/ERC777/ERC777.behavior.js
+++ b/test/token/ERC777/ERC777.behavior.js
@@ -1,4 +1,5 @@
 const { BN, constants, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 const { ZERO_ADDRESS } = constants;
 
 const ERC777SenderRecipientMock = artifacts.require('ERC777SenderRecipientMock');
@@ -217,9 +218,9 @@ function shouldSendTokens (from, operator, to, amount, data, operatorData) {
     const finalFromBalance = await this.token.balanceOf(from);
     const finalToBalance = await this.token.balanceOf(to);
 
-    finalTotalSupply.should.be.bignumber.equal(initialTotalSupply);
-    finalToBalance.sub(initialToBalance).should.be.bignumber.equal(amount);
-    finalFromBalance.sub(initialFromBalance).should.be.bignumber.equal(amount.neg());
+    expect(finalTotalSupply).to.be.bignumber.equal(initialTotalSupply);
+    expect(finalToBalance.sub(initialToBalance)).to.be.bignumber.equal(amount);
+    expect(finalFromBalance.sub(initialFromBalance)).to.be.bignumber.equal(amount.neg());
   });
 }
 
@@ -268,8 +269,8 @@ function shouldBurnTokens (from, operator, amount, data, operatorData) {
     const finalTotalSupply = await this.token.totalSupply();
     const finalFromBalance = await this.token.balanceOf(from);
 
-    finalTotalSupply.sub(initialTotalSupply).should.be.bignumber.equal(amount.neg());
-    finalFromBalance.sub(initialFromBalance).should.be.bignumber.equal(amount.neg());
+    expect(finalTotalSupply.sub(initialTotalSupply)).to.be.bignumber.equal(amount.neg());
+    expect(finalFromBalance.sub(initialFromBalance)).to.be.bignumber.equal(amount.neg());
   });
 }
 
@@ -306,8 +307,8 @@ function shouldInternalMintTokens (operator, to, amount, data, operatorData) {
     const finalTotalSupply = await this.token.totalSupply();
     const finalToBalance = await this.token.balanceOf(to);
 
-    finalTotalSupply.sub(initialTotalSupply).should.be.bignumber.equal(amount);
-    finalToBalance.sub(initialToBalance).should.be.bignumber.equal(amount);
+    expect(finalTotalSupply.sub(initialTotalSupply)).to.be.bignumber.equal(amount);
+    expect(finalToBalance.sub(initialToBalance)).to.be.bignumber.equal(amount);
   });
 }
 
@@ -505,7 +506,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
 function removeBalance (holder) {
   beforeEach(async function () {
     await this.token.burn(await this.token.balanceOf(holder), '0x', { from: holder });
-    (await this.token.balanceOf(holder)).should.be.bignumber.equal('0');
+    expect(await this.token.balanceOf(holder)).to.be.bignumber.equal('0');
   });
 }
 

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -1,4 +1,5 @@
 const { BN, expectEvent, expectRevert, singletons } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const {
   shouldBehaveLikeERC777DirectSendBurn,
@@ -44,56 +45,56 @@ contract('ERC777', function ([
 
     describe('basic information', function () {
       it('returns the name', async function () {
-        (await this.token.name()).should.equal(name);
+        expect(await this.token.name()).to.equal(name);
       });
 
       it('returns the symbol', async function () {
-        (await this.token.symbol()).should.equal(symbol);
+        expect(await this.token.symbol()).to.equal(symbol);
       });
 
       it('returns a granularity of 1', async function () {
-        (await this.token.granularity()).should.be.bignumber.equal('1');
+        expect(await this.token.granularity()).to.be.bignumber.equal('1');
       });
 
       it('returns the default operators', async function () {
-        (await this.token.defaultOperators()).should.deep.equal(defaultOperators);
+        expect(await this.token.defaultOperators()).to.deep.equal(defaultOperators);
       });
 
       it('default operators are operators for all accounts', async function () {
         for (const operator of defaultOperators) {
-          (await this.token.isOperatorFor(operator, anyone)).should.equal(true);
+          expect(await this.token.isOperatorFor(operator, anyone)).to.equal(true);
         }
       });
 
       it('returns the total supply', async function () {
-        (await this.token.totalSupply()).should.be.bignumber.equal(initialSupply);
+        expect(await this.token.totalSupply()).to.be.bignumber.equal(initialSupply);
       });
 
       it('returns 18 when decimals is called', async function () {
-        (await this.token.decimals()).should.be.bignumber.equal('18');
+        expect(await this.token.decimals()).to.be.bignumber.equal('18');
       });
 
       it('the ERC777Token interface is registered in the registry', async function () {
-        (await this.erc1820.getInterfaceImplementer(this.token.address, web3.utils.soliditySha3('ERC777Token')))
-          .should.equal(this.token.address);
+        expect(await this.erc1820.getInterfaceImplementer(this.token.address, web3.utils.soliditySha3('ERC777Token')))
+          .to.equal(this.token.address);
       });
 
       it('the ERC20Token interface is registered in the registry', async function () {
-        (await this.erc1820.getInterfaceImplementer(this.token.address, web3.utils.soliditySha3('ERC20Token')))
-          .should.equal(this.token.address);
+        expect(await this.erc1820.getInterfaceImplementer(this.token.address, web3.utils.soliditySha3('ERC20Token')))
+          .to.equal(this.token.address);
       });
     });
 
     describe('balanceOf', function () {
       context('for an account with no tokens', function () {
         it('returns zero', async function () {
-          (await this.token.balanceOf(anyone)).should.be.bignumber.equal('0');
+          expect(await this.token.balanceOf(anyone)).to.be.bignumber.equal('0');
         });
       });
 
       context('for an account with tokens', function () {
         it('returns their balance', async function () {
-          (await this.token.balanceOf(holder)).should.be.bignumber.equal(initialSupply);
+          expect(await this.token.balanceOf(holder)).to.be.bignumber.equal(initialSupply);
         });
       });
     });
@@ -155,7 +156,7 @@ contract('ERC777', function ([
 
     describe('operator management', function () {
       it('accounts are their own operator', async function () {
-        (await this.token.isOperatorFor(holder, holder)).should.equal(true);
+        expect(await this.token.isOperatorFor(holder, holder)).to.equal(true);
       });
 
       it('reverts when self-authorizing', async function () {
@@ -171,21 +172,21 @@ contract('ERC777', function ([
       });
 
       it('non-operators can be revoked', async function () {
-        (await this.token.isOperatorFor(newOperator, holder)).should.equal(false);
+        expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(false);
 
         const { logs } = await this.token.revokeOperator(newOperator, { from: holder });
         expectEvent.inLogs(logs, 'RevokedOperator', { operator: newOperator, tokenHolder: holder });
 
-        (await this.token.isOperatorFor(newOperator, holder)).should.equal(false);
+        expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(false);
       });
 
       it('non-operators can be authorized', async function () {
-        (await this.token.isOperatorFor(newOperator, holder)).should.equal(false);
+        expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(false);
 
         const { logs } = await this.token.authorizeOperator(newOperator, { from: holder });
         expectEvent.inLogs(logs, 'AuthorizedOperator', { operator: newOperator, tokenHolder: holder });
 
-        (await this.token.isOperatorFor(newOperator, holder)).should.equal(true);
+        expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(true);
       });
 
       describe('new operators', function () {
@@ -194,21 +195,21 @@ contract('ERC777', function ([
         });
 
         it('are not added to the default operators list', async function () {
-          (await this.token.defaultOperators()).should.deep.equal(defaultOperators);
+          expect(await this.token.defaultOperators()).to.deep.equal(defaultOperators);
         });
 
         it('can be re-authorized', async function () {
           const { logs } = await this.token.authorizeOperator(newOperator, { from: holder });
           expectEvent.inLogs(logs, 'AuthorizedOperator', { operator: newOperator, tokenHolder: holder });
 
-          (await this.token.isOperatorFor(newOperator, holder)).should.equal(true);
+          expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(true);
         });
 
         it('can be revoked', async function () {
           const { logs } = await this.token.revokeOperator(newOperator, { from: holder });
           expectEvent.inLogs(logs, 'RevokedOperator', { operator: newOperator, tokenHolder: holder });
 
-          (await this.token.isOperatorFor(newOperator, holder)).should.equal(false);
+          expect(await this.token.isOperatorFor(newOperator, holder)).to.equal(false);
         });
       });
 
@@ -217,14 +218,14 @@ contract('ERC777', function ([
           const { logs } = await this.token.authorizeOperator(defaultOperatorA, { from: holder });
           expectEvent.inLogs(logs, 'AuthorizedOperator', { operator: defaultOperatorA, tokenHolder: holder });
 
-          (await this.token.isOperatorFor(defaultOperatorA, holder)).should.equal(true);
+          expect(await this.token.isOperatorFor(defaultOperatorA, holder)).to.equal(true);
         });
 
         it('can be revoked', async function () {
           const { logs } = await this.token.revokeOperator(defaultOperatorA, { from: holder });
           expectEvent.inLogs(logs, 'RevokedOperator', { operator: defaultOperatorA, tokenHolder: holder });
 
-          (await this.token.isOperatorFor(defaultOperatorA, holder)).should.equal(false);
+          expect(await this.token.isOperatorFor(defaultOperatorA, holder)).to.equal(false);
         });
 
         it('cannot be revoked for themselves', async function () {
@@ -240,22 +241,22 @@ contract('ERC777', function ([
           });
 
           it('default operator is not revoked for other holders', async function () {
-            (await this.token.isOperatorFor(defaultOperatorA, anyone)).should.equal(true);
+            expect(await this.token.isOperatorFor(defaultOperatorA, anyone)).to.equal(true);
           });
 
           it('other default operators are not revoked', async function () {
-            (await this.token.isOperatorFor(defaultOperatorB, holder)).should.equal(true);
+            expect(await this.token.isOperatorFor(defaultOperatorB, holder)).to.equal(true);
           });
 
           it('default operators list is not modified', async function () {
-            (await this.token.defaultOperators()).should.deep.equal(defaultOperators);
+            expect(await this.token.defaultOperators()).to.deep.equal(defaultOperators);
           });
 
           it('revoked default operator can be re-authorized', async function () {
             const { logs } = await this.token.authorizeOperator(defaultOperatorA, { from: holder });
             expectEvent.inLogs(logs, 'AuthorizedOperator', { operator: defaultOperatorA, tokenHolder: holder });
 
-            (await this.token.isOperatorFor(defaultOperatorA, holder)).should.equal(true);
+            expect(await this.token.isOperatorFor(defaultOperatorA, holder)).to.equal(true);
           });
         });
       });
@@ -424,7 +425,7 @@ contract('ERC777', function ([
     });
 
     it('default operators list is empty', async function () {
-      (await this.token.defaultOperators()).should.deep.equal([]);
+      expect(await this.token.defaultOperators()).to.deep.equal([]);
     });
   });
 });

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -1,4 +1,5 @@
 const { constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const AddressImpl = artifacts.require('AddressImpl');
 const SimpleToken = artifacts.require('SimpleToken');
@@ -12,26 +13,26 @@ contract('Address', function ([_, other]) {
 
   describe('isContract', function () {
     it('should return false for account address', async function () {
-      (await this.mock.isContract(other)).should.equal(false);
+      expect(await this.mock.isContract(other)).to.equal(false);
     });
 
     it('should return true for contract address', async function () {
       const contract = await SimpleToken.new();
-      (await this.mock.isContract(contract.address)).should.equal(true);
+      expect(await this.mock.isContract(contract.address)).to.equal(true);
     });
   });
 
   describe('toPayable', function () {
     it('should return a payable address when the account is the zero address', async function () {
-      (await this.mock.toPayable(constants.ZERO_ADDRESS)).should.equal(constants.ZERO_ADDRESS);
+      expect(await this.mock.toPayable(constants.ZERO_ADDRESS)).to.equal(constants.ZERO_ADDRESS);
     });
 
     it('should return a payable address when the account is an arbitrary address', async function () {
-      (await this.mock.toPayable(other)).should.equal(other);
+      expect(await this.mock.toPayable(other)).to.equal(other);
     });
 
     it('should return a payable address when the account is the all ones address', async function () {
-      (await this.mock.toPayable(ALL_ONES_ADDRESS)).should.equal(ALL_ONES_ADDRESS);
+      expect(await this.mock.toPayable(ALL_ONES_ADDRESS)).to.equal(ALL_ONES_ADDRESS);
     });
   });
 });

--- a/test/utils/Arrays.test.js
+++ b/test/utils/Arrays.test.js
@@ -1,4 +1,5 @@
 require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ArraysImpl = artifacts.require('ArraysImpl');
 
@@ -11,23 +12,23 @@ contract('Arrays', function () {
     });
 
     it('should return correct index for the basic case', async function () {
-      (await this.arrays.findUpperBound(16)).should.be.bignumber.equal('5');
+      expect(await this.arrays.findUpperBound(16)).to.be.bignumber.equal('5');
     });
 
     it('should return 0 for the first element', async function () {
-      (await this.arrays.findUpperBound(11)).should.be.bignumber.equal('0');
+      expect(await this.arrays.findUpperBound(11)).to.be.bignumber.equal('0');
     });
 
     it('should return index of the last element', async function () {
-      (await this.arrays.findUpperBound(20)).should.be.bignumber.equal('9');
+      expect(await this.arrays.findUpperBound(20)).to.be.bignumber.equal('9');
     });
 
     it('should return first index after last element if searched value is over the upper boundary', async function () {
-      (await this.arrays.findUpperBound(32)).should.be.bignumber.equal('10');
+      expect(await this.arrays.findUpperBound(32)).to.be.bignumber.equal('10');
     });
 
     it('should return 0 for the element under the lower boundary', async function () {
-      (await this.arrays.findUpperBound(2)).should.be.bignumber.equal('0');
+      expect(await this.arrays.findUpperBound(2)).to.be.bignumber.equal('0');
     });
   });
 
@@ -39,23 +40,23 @@ contract('Arrays', function () {
     });
 
     it('should return correct index for the basic case', async function () {
-      (await this.arrays.findUpperBound(16)).should.be.bignumber.equal('5');
+      expect(await this.arrays.findUpperBound(16)).to.be.bignumber.equal('5');
     });
 
     it('should return 0 for the first element', async function () {
-      (await this.arrays.findUpperBound(11)).should.be.bignumber.equal('0');
+      expect(await this.arrays.findUpperBound(11)).to.be.bignumber.equal('0');
     });
 
     it('should return index of the last element', async function () {
-      (await this.arrays.findUpperBound(21)).should.be.bignumber.equal('10');
+      expect(await this.arrays.findUpperBound(21)).to.be.bignumber.equal('10');
     });
 
     it('should return first index after last element if searched value is over the upper boundary', async function () {
-      (await this.arrays.findUpperBound(32)).should.be.bignumber.equal('11');
+      expect(await this.arrays.findUpperBound(32)).to.be.bignumber.equal('11');
     });
 
     it('should return 0 for the element under the lower boundary', async function () {
-      (await this.arrays.findUpperBound(2)).should.be.bignumber.equal('0');
+      expect(await this.arrays.findUpperBound(2)).to.be.bignumber.equal('0');
     });
   });
 
@@ -67,7 +68,7 @@ contract('Arrays', function () {
     });
 
     it('should return index of first element in next filled range', async function () {
-      (await this.arrays.findUpperBound(17)).should.be.bignumber.equal('5');
+      expect(await this.arrays.findUpperBound(17)).to.be.bignumber.equal('5');
     });
   });
 
@@ -77,7 +78,7 @@ contract('Arrays', function () {
     });
 
     it('should always return 0 for empty array', async function () {
-      (await this.arrays.findUpperBound(10)).should.be.bignumber.equal('0');
+      expect(await this.arrays.findUpperBound(10)).to.be.bignumber.equal('0');
     });
   });
 });

--- a/test/utils/ReentrancyGuard.test.js
+++ b/test/utils/ReentrancyGuard.test.js
@@ -1,4 +1,5 @@
 const { expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
 
 const ReentrancyMock = artifacts.require('ReentrancyMock');
 const ReentrancyAttack = artifacts.require('ReentrancyAttack');
@@ -6,7 +7,7 @@ const ReentrancyAttack = artifacts.require('ReentrancyAttack');
 contract('ReentrancyGuard', function () {
   beforeEach(async function () {
     this.reentrancyMock = await ReentrancyMock.new();
-    (await this.reentrancyMock.counter()).should.be.bignumber.equal('0');
+    expect(await this.reentrancyMock.counter()).to.be.bignumber.equal('0');
   });
 
   it('should not allow remote callback', async function () {


### PR DESCRIPTION
This PR addresses Issue Fixes [#1687](https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1687) which explains why chai.expect is preferred over chai.should.

Added `const { expect } = require('chai');` to each file that used chai.should (~56 files) and then replaced instances of `obj.should.equal()` for `expect(obj).to.equal()`. 

Only modified test files. 