### PR TITLE
Fix Part 1 : added tests for getApproved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Improvements:
  * `Address.isContract`: switched from `extcodesize` to `extcodehash` for less gas usage. ([#1802](https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1802))
+ * `ERC721`:  ERC721 test suite was missing getApproved function test. Added that.([#1148](https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1148))
 
 ### Bugfixes
 

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -523,6 +523,41 @@ function shouldBehaveLikeERC721 (
       });
     });
 
+    describe("getApproved", async function() {
+      context("when ERC721 token is not even minted", async function() {
+        it("should revert error for non-existent token Id", async function() {
+          await expectRevert(
+            this.token.getApproved(unknownTokenId, { from: minter }),
+            "ERC721: approved query for nonexistent token"
+          );
+        });
+      });
+
+      context("when ERC721 token has been minted ", async function() {
+        it("should return Zero address for newly minted ERC721 token", async function() {
+          expect(await this.token.getApproved(firstTokenId)).to.be.equal(
+            ZERO_ADDRESS
+          );
+        });
+
+        context("when ERC721 token has been approved", async function() {
+          beforeEach(async function() {
+            await this.token.approve(approved, firstTokenId, { from: owner });
+          });
+
+          it("should return correct approved address after approvals are done", async function() {
+            expect(await this.token.getApproved(firstTokenId)).to.be.equal(approved);
+          });
+
+          it("owner should not be approved", async function() {
+            expect(
+              await this.token.getApproved(firstTokenId)
+            ).to.not.equal(owner);
+          });
+        });
+      });
+    });
+
     shouldSupportInterfaces([
       'ERC165',
       'ERC721',


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->
No open issues as of now. This pull request changes 1 test file. It just adds a new test for getApproved function which was not there before.

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #1148 

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->
This Pull request fixes issue 1148 partly.  I have added tests for  function getApproved in ERC721.sol and those tests are passing/failing appropriately. 

There is a change in only 1 file : test/token/ERC721/ERC721.behaviour.js

Please let me know if I have missed any use case for the same.

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
--> 
### Checklist
- [x] reviewed the OpenZeppelin Contributor Guidelines    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
- [x] added tests where applicable to test new functionality,
- [x] made sure that your contracts are well-documented,
- [x] run the Solidity linter (`npm run lint:sol`) and fixed any issues,
- [x] run the JS linter and fixed any issues (`npm run lint:fix`), and
- [x] updated the changelog, if applicable.